### PR TITLE
Add richer contact fields

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		14C13B18A26BC44F834915C1 /* ContactModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75D02267D3BC6C014143329 /* ContactModelTests.swift */; };
 		14E0C9EBEF8212F3F9B2777D /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51E6728EF90B1D2BF8EA5AE /* Contact.swift */; };
 		15AD8E34CC4EF4BC81F8A159 /* ContactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */; };
+		23BF1F338E4C813308B5DEE2 /* ContactField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25751DDEC1515E341AF67F5 /* ContactField.swift */; };
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
 		4EC36757044377406665E53B /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */; };
 		6BF479700A4101F1353CBF78 /* ContactQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B27567532AC1A51FF4CC13A /* ContactQuery.swift */; };
@@ -40,6 +41,7 @@
 		6303A7F66E428BF3662142C0 /* SidebarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactDetailView.swift; sourceTree = "<group>"; };
 		833F1AF82CACF7B9E89BADCA /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		B25751DDEC1515E341AF67F5 /* ContactField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactField.swift; sourceTree = "<group>"; };
 		B75D02267D3BC6C014143329 /* ContactModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactModelTests.swift; sourceTree = "<group>"; };
 		DEAB729518FA2A6600E3570B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		DED8178913A452A900EC3234 /* ContactManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ContactManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -88,6 +90,7 @@
 				F51E6728EF90B1D2BF8EA5AE /* Contact.swift */,
 				0B27567532AC1A51FF4CC13A /* ContactQuery.swift */,
 				0F82C8A388E97CC4F1106176 /* SampleData.swift */,
+				B25751DDEC1515E341AF67F5 /* ContactField.swift */,
 			);
 			name = Models;
 			path = Models;
@@ -358,6 +361,7 @@
 				4EC36757044377406665E53B /* ContactListView.swift in Sources */,
 				465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */,
 				15AD8E34CC4EF4BC81F8A159 /* ContactDetailView.swift in Sources */,
+				23BF1F338E4C813308B5DEE2 /* ContactField.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -25,7 +25,7 @@ struct ContactManagerApp: App {
         }
 
         do {
-            let built = try ModelContainer(for: Contact.self)
+            let built = try ModelContainer(for: Contact.self, ContactField.self)
             SampleData.seedIfNeeded(built.mainContext)
             container = built
         } catch {

--- a/ContactManager/Models/Contact.swift
+++ b/ContactManager/Models/Contact.swift
@@ -2,8 +2,7 @@
 //  Contact.swift
 //  ContactManager
 //
-//  The SwiftData model backing a single contact. Replaces the legacy
-//  Core Data `Contact` NSManagedObject.
+//  The SwiftData model backing a single contact.
 //
 
 import Foundation
@@ -11,42 +10,80 @@ import SwiftData
 
 @Model
 final class Contact {
-    var firstName: String
-    var lastName: String
-    var emailAddress: String
-    var phoneNumber: String
-    var createdAt: Date
+    // Identity
+    var firstName: String = ""
+    var lastName: String = ""
+
+    // Work
+    var company: String = ""
+    var jobTitle: String = ""
+
+    // Postal address
+    var street: String = ""
+    var city: String = ""
+    var state: String = ""
+    var postalCode: String = ""
+    var country: String = ""
+
+    // Misc
+    var birthday: Date?
+    var notes: String = ""
+    var createdAt: Date = Date.now
+
+    // Labeled emails and phone numbers.
+    @Relationship(deleteRule: .cascade, inverse: \ContactField.contact)
+    var fields: [ContactField]
 
     init(
         firstName: String = "",
         lastName: String = "",
-        emailAddress: String = "",
-        phoneNumber: String = "",
+        company: String = "",
+        jobTitle: String = "",
+        street: String = "",
+        city: String = "",
+        state: String = "",
+        postalCode: String = "",
+        country: String = "",
+        birthday: Date? = nil,
+        notes: String = "",
         createdAt: Date = .now
     ) {
         self.firstName = firstName
         self.lastName = lastName
-        self.emailAddress = emailAddress
-        self.phoneNumber = phoneNumber
+        self.company = company
+        self.jobTitle = jobTitle
+        self.street = street
+        self.city = city
+        self.state = state
+        self.postalCode = postalCode
+        self.country = country
+        self.birthday = birthday
+        self.notes = notes
         self.createdAt = createdAt
+        self.fields = []
     }
 }
 
 extension Contact {
-    /// Human-readable name, falling back to a placeholder for brand-new contacts.
+    /// Human-readable name, falling back to company, then a placeholder.
     var fullName: String {
         let name = [firstName, lastName]
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
             .joined(separator: " ")
-        return name.isEmpty ? "New Contact" : name
+        if !name.isEmpty { return name }
+        let trimmedCompany = company.trimmingCharacters(in: .whitespaces)
+        return trimmedCompany.isEmpty ? "New Contact" : trimmedCompany
     }
 
     /// One or two uppercase letters used for the avatar placeholder.
     var initials: String {
         let first = firstName.trimmingCharacters(in: .whitespaces).first.map(String.init) ?? ""
         let last = lastName.trimmingCharacters(in: .whitespaces).first.map(String.init) ?? ""
-        let combined = (first + last).uppercased()
+        var combined = (first + last).uppercased()
+        if combined.isEmpty {
+            combined = company.trimmingCharacters(in: .whitespaces).first.map { String($0).uppercased() } ?? ""
+        }
         return combined.isEmpty ? "#" : combined
     }
 
@@ -55,5 +92,34 @@ extension Contact {
         let last = lastName.trimmingCharacters(in: .whitespaces)
         let primary = last.isEmpty ? firstName : last
         return primary.trimmingCharacters(in: .whitespaces).lowercased()
+    }
+
+    // MARK: - Field helpers
+
+    var emails: [ContactField] { fields(of: .email) }
+    var phones: [ContactField] { fields(of: .phone) }
+
+    func fields(of kind: FieldKind) -> [ContactField] {
+        fields
+            .filter { $0.kind == kind }
+            .sorted { $0.sortIndex < $1.sortIndex }
+    }
+
+    /// The first non-empty email, used as the list subtitle.
+    var primaryEmail: String? {
+        emails.first { !$0.value.trimmingCharacters(in: .whitespaces).isEmpty }?.value
+    }
+
+    /// The first non-empty phone number.
+    var primaryPhone: String? {
+        phones.first { !$0.value.trimmingCharacters(in: .whitespaces).isEmpty }?.value
+    }
+
+    /// Best available secondary line for list rows: email, then phone, then company.
+    var subtitle: String? {
+        if let email = primaryEmail { return email }
+        if let phone = primaryPhone { return phone }
+        let trimmedCompany = company.trimmingCharacters(in: .whitespaces)
+        return trimmedCompany.isEmpty ? nil : trimmedCompany
     }
 }

--- a/ContactManager/Models/ContactField.swift
+++ b/ContactManager/Models/ContactField.swift
@@ -1,0 +1,59 @@
+//
+//  ContactField.swift
+//  ContactManager
+//
+//  A labeled, repeatable value (email or phone) belonging to a contact.
+//  Modeled as its own SwiftData entity so a contact can have any number of
+//  them, each with its own label.
+//
+
+import Foundation
+import SwiftData
+
+enum FieldKind: String, Codable, CaseIterable {
+    case email
+    case phone
+}
+
+enum FieldLabel: String, Codable, CaseIterable, Identifiable {
+    case home
+    case work
+    case mobile
+    case main
+    case other
+
+    var id: String { rawValue }
+    var title: String { rawValue.capitalized }
+}
+
+@Model
+final class ContactField {
+    var kind: FieldKind
+    var label: FieldLabel
+    var value: String
+    /// Preserves the order fields were added within their kind.
+    var sortIndex: Int
+    var contact: Contact?
+
+    init(
+        kind: FieldKind,
+        label: FieldLabel = .home,
+        value: String = "",
+        sortIndex: Int = 0
+    ) {
+        self.kind = kind
+        self.label = label
+        self.value = value
+        self.sortIndex = sortIndex
+    }
+}
+
+extension FieldKind {
+    /// Sensible default label when adding a new field of this kind.
+    var defaultLabel: FieldLabel {
+        switch self {
+        case .email: return .home
+        case .phone: return .mobile
+        }
+    }
+}

--- a/ContactManager/Models/ContactQuery.swift
+++ b/ContactManager/Models/ContactQuery.swift
@@ -26,9 +26,14 @@ enum ContactQuery {
         guard !needle.isEmpty else { return contacts }
 
         return contacts.filter { contact in
-            contact.fullName.lowercased().contains(needle)
-                || contact.emailAddress.lowercased().contains(needle)
-                || contact.phoneNumber.lowercased().contains(needle)
+            let haystacks = [
+                contact.fullName,
+                contact.company,
+                contact.jobTitle,
+                contact.notes,
+            ] + contact.fields.map(\.value)
+
+            return haystacks.contains { $0.lowercased().contains(needle) }
         }
     }
 }

--- a/ContactManager/Models/SampleData.swift
+++ b/ContactManager/Models/SampleData.swift
@@ -16,14 +16,38 @@ enum SampleData {
     /// Builds a fresh set of sample contacts. Each call returns brand-new
     /// instances so they can be safely inserted into any model context.
     static func makeContacts() -> [Contact] {
-        [
-            Contact(firstName: "Ada", lastName: "Lovelace",
-                    emailAddress: "ada@analytical.engine", phoneNumber: "+1 (555) 0100"),
-            Contact(firstName: "Alan", lastName: "Turing",
-                    emailAddress: "alan@bletchley.uk", phoneNumber: "+44 20 7555 0142"),
-            Contact(firstName: "Grace", lastName: "Hopper",
-                    emailAddress: "grace@navy.mil", phoneNumber: "+1 (555) 0199"),
+        let ada = Contact(
+            firstName: "Ada", lastName: "Lovelace",
+            company: "Analytical Engine Co.", jobTitle: "Mathematician",
+            city: "London", country: "United Kingdom",
+            notes: "First computer programmer."
+        )
+        ada.fields = [
+            ContactField(kind: .email, label: .work, value: "ada@analytical.engine", sortIndex: 0),
+            ContactField(kind: .phone, label: .mobile, value: "+1 (555) 0100", sortIndex: 0),
         ]
+
+        let alan = Contact(
+            firstName: "Alan", lastName: "Turing",
+            company: "Bletchley Park", jobTitle: "Cryptanalyst",
+            city: "Milton Keynes", country: "United Kingdom"
+        )
+        alan.fields = [
+            ContactField(kind: .email, label: .work, value: "alan@bletchley.uk", sortIndex: 0),
+            ContactField(kind: .phone, label: .work, value: "+44 20 7555 0142", sortIndex: 0),
+        ]
+
+        let grace = Contact(
+            firstName: "Grace", lastName: "Hopper",
+            company: "US Navy", jobTitle: "Rear Admiral",
+            city: "Arlington", state: "VA", country: "USA"
+        )
+        grace.fields = [
+            ContactField(kind: .email, label: .work, value: "grace@navy.mil", sortIndex: 0),
+            ContactField(kind: .phone, label: .main, value: "+1 (555) 0199", sortIndex: 0),
+        ]
+
+        return [ada, alan, grace]
     }
 
     /// Inserts the sample contacts only when the store is empty.

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -10,40 +10,152 @@ import SwiftUI
 import SwiftData
 
 struct ContactDetailView: View {
+    @Environment(\.modelContext) private var context
     @Bindable var contact: Contact
 
     var body: some View {
         Form {
-            Section {
-                HStack(spacing: 16) {
-                    AvatarView(contact: contact, size: 72)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(contact.fullName)
-                            .font(.title2.weight(.semibold))
-                        if !contact.emailAddress.isEmpty {
-                            Text(contact.emailAddress)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    Spacer()
-                }
-                .padding(.vertical, 4)
-            }
+            header
 
             Section("Name") {
                 TextField("First Name", text: $contact.firstName)
                 TextField("Last Name", text: $contact.lastName)
             }
 
-            Section("Contact") {
-                TextField("Email", text: $contact.emailAddress)
-                    .textContentType(.emailAddress)
-                TextField("Phone", text: $contact.phoneNumber)
-                    .textContentType(.telephoneNumber)
+            Section("Work") {
+                TextField("Company", text: $contact.company)
+                TextField("Job Title", text: $contact.jobTitle)
+            }
+
+            fieldSection("Email", kind: .email, fields: contact.emails)
+            fieldSection("Phone", kind: .phone, fields: contact.phones)
+
+            Section("Address") {
+                TextField("Street", text: $contact.street)
+                TextField("City", text: $contact.city)
+                TextField("State / Province", text: $contact.state)
+                TextField("Postal Code", text: $contact.postalCode)
+                TextField("Country", text: $contact.country)
+            }
+
+            Section("Birthday") {
+                Toggle("Has Birthday", isOn: birthdayEnabled)
+                if contact.birthday != nil {
+                    DatePicker("Date", selection: birthdayValue, displayedComponents: .date)
+                }
+            }
+
+            Section("Notes") {
+                TextField("Notes", text: $contact.notes, axis: .vertical)
+                    .lineLimit(3...10)
             }
         }
         .formStyle(.grouped)
         .navigationTitle(contact.fullName)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        Section {
+            HStack(spacing: 16) {
+                AvatarView(contact: contact, size: 72)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(contact.fullName)
+                        .font(.title2.weight(.semibold))
+                    let role = [contact.jobTitle, contact.company]
+                        .filter { !$0.isEmpty }
+                        .joined(separator: " · ")
+                    if !role.isEmpty {
+                        Text(role).foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - Repeatable field sections
+
+    @ViewBuilder
+    private func fieldSection(_ title: String, kind: FieldKind, fields: [ContactField]) -> some View {
+        Section(title) {
+            ForEach(fields) { field in
+                ContactFieldRow(field: field)
+            }
+            .onDelete { offsets in
+                delete(offsets, from: fields)
+            }
+
+            Button {
+                addField(kind: kind)
+            } label: {
+                Label("Add \(title)", systemImage: "plus.circle.fill")
+                    .foregroundStyle(.green)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func addField(kind: FieldKind) {
+        let field = ContactField(
+            kind: kind,
+            label: kind.defaultLabel,
+            sortIndex: contact.fields(of: kind).count
+        )
+        field.contact = contact
+        context.insert(field)
+        try? context.save()
+    }
+
+    private func delete(_ offsets: IndexSet, from fields: [ContactField]) {
+        for index in offsets {
+            context.delete(fields[index])
+        }
+        try? context.save()
+    }
+
+    // MARK: - Birthday bindings
+
+    private var birthdayEnabled: Binding<Bool> {
+        Binding(
+            get: { contact.birthday != nil },
+            set: { contact.birthday = $0 ? (contact.birthday ?? .now) : nil }
+        )
+    }
+
+    private var birthdayValue: Binding<Date> {
+        Binding(
+            get: { contact.birthday ?? .now },
+            set: { contact.birthday = $0 }
+        )
+    }
+}
+
+/// A single editable email/phone row: a label picker plus its value.
+private struct ContactFieldRow: View {
+    @Bindable var field: ContactField
+
+    var body: some View {
+        HStack {
+            Picker("", selection: $field.label) {
+                ForEach(FieldLabel.allCases) { label in
+                    Text(label.title).tag(label)
+                }
+            }
+            .labelsHidden()
+            .fixedSize()
+
+            TextField(placeholder, text: $field.value)
+                .textContentType(field.kind == .email ? .emailAddress : .telephoneNumber)
+        }
+    }
+
+    private var placeholder: String {
+        field.kind == .email ? "name@example.com" : "Phone"
     }
 }
 

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -64,8 +64,8 @@ struct ContactRow: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text(contact.fullName)
                     .lineLimit(1)
-                if !contact.emailAddress.isEmpty {
-                    Text(contact.emailAddress)
+                if let subtitle = contact.subtitle {
+                    Text(subtitle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)

--- a/ContactManagerTests/ContactModelTests.swift
+++ b/ContactManagerTests/ContactModelTests.swift
@@ -21,7 +21,7 @@ struct ContactModelTests {
 
     init() throws {
         container = try ModelContainer(
-            for: Contact.self,
+            for: Contact.self, ContactField.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
     }
@@ -45,13 +45,28 @@ struct ContactModelTests {
         context.delete(contact)
         try context.save()
 
-        let count = try context.fetchCount(FetchDescriptor<Contact>())
-        #expect(count == 0)
+        #expect(try context.fetchCount(FetchDescriptor<Contact>()) == 0)
+    }
+
+    @Test func deletingContactCascadesToItsFields() throws {
+        let contact = Contact(firstName: "Ada", lastName: "Lovelace")
+        contact.fields = [
+            ContactField(kind: .email, value: "ada@analytical.engine"),
+            ContactField(kind: .phone, value: "+1 (555) 0100"),
+        ]
+        context.insert(contact)
+        try context.save()
+        #expect(try context.fetchCount(FetchDescriptor<ContactField>()) == 2)
+
+        context.delete(contact)
+        try context.save()
+        #expect(try context.fetchCount(FetchDescriptor<ContactField>()) == 0)
     }
 
     @Test func seedingPopulatesAnEmptyStoreOnce() throws {
         SampleData.seedIfNeeded(context)
         #expect(try context.fetchCount(FetchDescriptor<Contact>()) == SampleData.count)
+        #expect(try context.fetchCount(FetchDescriptor<ContactField>()) > 0)
 
         // Seeding again should be a no-op on a non-empty store.
         SampleData.seedIfNeeded(context)
@@ -60,16 +75,32 @@ struct ContactModelTests {
 
     // MARK: - Derived values
 
-    @Test func fullNameJoinsAvailableParts() {
+    @Test func fullNameJoinsAvailablePartsThenFallsBackToCompany() {
         #expect(Contact(firstName: "Ada", lastName: "Lovelace").fullName == "Ada Lovelace")
         #expect(Contact(firstName: "Ada").fullName == "Ada")
+        #expect(Contact(company: "Acme").fullName == "Acme")
         #expect(Contact().fullName == "New Contact")
     }
 
     @Test func initialsUseFirstAndLastInitial() {
         #expect(Contact(firstName: "Ada", lastName: "Lovelace").initials == "AL")
         #expect(Contact(firstName: "grace").initials == "G")
+        #expect(Contact(company: "acme").initials == "A")
         #expect(Contact().initials == "#")
+    }
+
+    @Test func primaryValuesAndSubtitlePreferEmail() {
+        let contact = Contact(firstName: "Ada", company: "Analytical")
+        contact.fields = [
+            ContactField(kind: .phone, value: "+1 (555) 0100", sortIndex: 0),
+            ContactField(kind: .email, value: "ada@analytical.engine", sortIndex: 0),
+        ]
+        #expect(contact.primaryEmail == "ada@analytical.engine")
+        #expect(contact.primaryPhone == "+1 (555) 0100")
+        #expect(contact.subtitle == "ada@analytical.engine")
+
+        let companyOnly = Contact(firstName: "Bob", company: "Globex")
+        #expect(companyOnly.subtitle == "Globex")
     }
 
     // MARK: - Query helpers
@@ -84,15 +115,21 @@ struct ContactModelTests {
         #expect(sorted.map(\.lastName) == ["Hopper", "Lovelace", "Turing"])
     }
 
-    @Test func filteringMatchesNameEmailAndPhone() {
-        let contacts = [
-            Contact(firstName: "Ada", lastName: "Lovelace", emailAddress: "ada@analytical.engine"),
-            Contact(firstName: "Alan", lastName: "Turing", phoneNumber: "+44 20 7555 0142"),
-        ]
-        #expect(ContactQuery.filtered(contacts, matching: "love").count == 1)
-        #expect(ContactQuery.filtered(contacts, matching: "analytical").first?.firstName == "Ada")
-        #expect(ContactQuery.filtered(contacts, matching: "7555").first?.firstName == "Alan")
-        #expect(ContactQuery.filtered(contacts, matching: "").count == 2)
-        #expect(ContactQuery.filtered(contacts, matching: "nobody").isEmpty)
+    @Test func filteringMatchesName_Company_Notes_AndFieldValues() throws {
+        let ada = Contact(firstName: "Ada", lastName: "Lovelace", company: "Analytical Engine")
+        ada.fields = [ContactField(kind: .email, value: "ada@analytical.engine")]
+        let alan = Contact(firstName: "Alan", lastName: "Turing", notes: "Enigma")
+        alan.fields = [ContactField(kind: .phone, value: "+44 20 7555 0142")]
+        context.insert(ada)
+        context.insert(alan)
+        try context.save()
+
+        let all = try context.fetch(FetchDescriptor<Contact>())
+        #expect(ContactQuery.filtered(all, matching: "love").count == 1)        // name
+        #expect(ContactQuery.filtered(all, matching: "analytical").count == 1)  // company + email
+        #expect(ContactQuery.filtered(all, matching: "enigma").first?.firstName == "Alan") // notes
+        #expect(ContactQuery.filtered(all, matching: "7555").first?.firstName == "Alan")   // phone field
+        #expect(ContactQuery.filtered(all, matching: "").count == 2)
+        #expect(ContactQuery.filtered(all, matching: "nobody").isEmpty)
     }
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The app was originally an Objective-C / AppKit / Core Data demo and is being reb
 ContactManager/
 ├── App/      ContactManagerApp.swift   – @main entry point, model container, menu commands
 ├── Models/   Contact.swift             – the @Model contact entity + derived values
+│             ContactField.swift        – labeled, repeatable email/phone child entity
 │             ContactQuery.swift        – pure, testable filter/sort helpers
 │             SampleData.swift          – first-launch seed data
 └── Views/    ContentView.swift         – NavigationSplitView shell + create/delete actions
@@ -35,6 +36,8 @@ ContactManager/
 
 - Three-column native layout with a Liquid Glass toolbar.
 - Create, edit (inline, autosaving), and delete contacts.
+- Multiple labeled emails and phone numbers per contact (add/remove inline).
+- Company, job title, postal address, birthday, and free-form notes.
 - Initials-based avatars.
 - Sample contacts seeded on first launch.
 
@@ -43,7 +46,7 @@ ContactManager/
 Shipped as small, single-purpose PRs:
 
 1. ✅ **Foundation** — SwiftUI + SwiftData rewrite, CRUD, project modernized to macOS 26.
-2. **Richer fields** — multiple emails/phones, company/title, address, birthday, notes.
+2. ✅ **Richer fields** — multiple emails/phones, company/title, address, birthday, notes.
 3. **Search & sections** — live search and alphabetical sectioning.
 4. **Contact photos** — photo import with initials fallback.
 5. **Groups & vCard** — user groups/tags and `.vcf` import/export.


### PR DESCRIPTION
## Summary

**PR B** of the Tahoe rewrite roadmap. Expands the contact model and detail editor well beyond the original four fields.

> Stacked on #9 — review/merge that first. Base will retarget to `main` once #9 lands.

## Model
- New `ContactField` child `@Model`: labeled, repeatable **email/phone** values, cascade-deleted with their contact.
- `Contact` gains **company**, **job title**, **postal address** (street/city/state/postal code/country), optional **birthday**, and **notes**.
- All new scalar attributes declare inline defaults so existing SwiftData stores **migrate in place** (fixes Core Data error `134110`, "missing attribute values on mandatory destination attribute").
- Derived helpers: primary email/phone, list subtitle, company fallback for name/initials. Search now spans name, company, title, notes, and every field value.

## UI
- `ContactDetailView` rebuilt as a grouped `Form`: Name, Work, Email, Phone, Address, Birthday (toggle + `DatePicker`), and Notes.
- Email/Phone sections **add and delete rows inline**, each with a label picker.

## Test plan
- [x] `xcodebuild ... build` — clean, zero code warnings
- [x] `xcodebuild ... test` — 9/9 Swift Testing tests pass (incl. cascade delete + broadened search)
- [x] Fresh store launches and runs
- [x] **Migration verified end-to-end**: built the #9 app in a worktree, created a prior-schema store, then launched this build against it — migrated cleanly and ran
- [ ] Visual check of the new detail form via `⌘R` (no screenshot capability in the build environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)