### PR TITLE
Add search, alphabetical sections, and sort order

### DIFF
--- a/ContactManager/Models/Contact.swift
+++ b/ContactManager/Models/Contact.swift
@@ -108,6 +108,18 @@ extension Contact {
         Int(truncatingIfNeeded: createdAt.timeIntervalSinceReferenceDate.bitPattern)
     }
 
+    /// Primary/secondary keys for a given sort order. The primary key also
+    /// drives alphabetical section grouping.
+    func sortKeys(for order: ContactSortOrder) -> (primary: String, secondary: String) {
+        switch order {
+        case .lastName:
+            return (sortKey, firstNameSortKey)
+        case .firstName:
+            let first = firstNameSortKey
+            return (first.isEmpty ? sortKey : first, sortKey)
+        }
+    }
+
     // MARK: - Field helpers
 
     var emails: [ContactField] { fields(of: .email) }

--- a/ContactManager/Models/Contact.swift
+++ b/ContactManager/Models/Contact.swift
@@ -87,11 +87,15 @@ extension Contact {
         return combined.isEmpty ? "#" : combined
     }
 
-    /// Lowercased key used to sort contacts by last name, then first name.
+    /// Lowercased key used to sort contacts: last name, then first name, then
+    /// company. Falling back to company keeps sorting/sectioning aligned with
+    /// the displayed `fullName` for company-only contacts.
     var sortKey: String {
-        let last = lastName.trimmingCharacters(in: .whitespaces)
-        let primary = last.isEmpty ? firstName : last
-        return primary.trimmingCharacters(in: .whitespaces).lowercased()
+        for candidate in [lastName, firstName, company] {
+            let trimmed = candidate.trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty { return trimmed.lowercased() }
+        }
+        return ""
     }
 
     /// Lowercased first name, trimmed — used as the secondary sort key so it

--- a/ContactManager/Models/ContactQuery.swift
+++ b/ContactManager/Models/ContactQuery.swift
@@ -2,20 +2,44 @@
 //  ContactQuery.swift
 //  ContactManager
 //
-//  Pure, testable helpers for filtering and sorting contacts. Keeping this
-//  logic out of the views makes it straightforward to unit test.
+//  Pure, testable helpers for filtering, sorting, and sectioning contacts.
+//  Keeping this logic out of the views makes it straightforward to unit test.
 //
 
 import Foundation
 
+/// The order contacts are sorted and grouped by.
+enum ContactSortOrder: String, CaseIterable, Identifiable {
+    case lastName
+    case firstName
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .lastName: return "Last Name"
+        case .firstName: return "First Name"
+        }
+    }
+}
+
+/// An alphabetical group of contacts, titled by initial ("A"…"Z" or "#").
+struct ContactSection: Identifiable {
+    let title: String
+    let contacts: [Contact]
+    var id: String { title }
+}
+
 enum ContactQuery {
-    /// Sorts contacts by last name, then first name, case-insensitively.
-    static func sorted(_ contacts: [Contact]) -> [Contact] {
+    /// Sorts contacts by the given order's primary key, then its secondary key.
+    static func sorted(_ contacts: [Contact], by order: ContactSortOrder = .lastName) -> [Contact] {
         contacts.sorted { lhs, rhs in
-            if lhs.sortKey != rhs.sortKey {
-                return lhs.sortKey < rhs.sortKey
+            let l = lhs.sortKeys(for: order)
+            let r = rhs.sortKeys(for: order)
+            if l.primary != r.primary {
+                return l.primary < r.primary
             }
-            return lhs.firstNameSortKey < rhs.firstNameSortKey
+            return l.secondary < r.secondary
         }
     }
 
@@ -36,5 +60,28 @@ enum ContactQuery {
 
             return haystacks.contains { $0.lowercased().contains(needle) }
         }
+    }
+
+    /// Groups contacts into alphabetical sections by their initial, sorted
+    /// within each section. Names that don't start with a letter land in a
+    /// trailing "#" section.
+    static func sections(_ contacts: [Contact], by order: ContactSortOrder = .lastName) -> [ContactSection] {
+        let ordered = sorted(contacts, by: order)
+        let grouped = Dictionary(grouping: ordered) { sectionTitle(for: $0, order: order) }
+
+        let titles = grouped.keys.sorted { lhs, rhs in
+            if lhs == "#" { return false }   // "#" always sorts last
+            if rhs == "#" { return true }
+            return lhs < rhs
+        }
+
+        return titles.map { ContactSection(title: $0, contacts: grouped[$0] ?? []) }
+    }
+
+    private static func sectionTitle(for contact: Contact, order: ContactSortOrder) -> String {
+        guard let first = contact.sortKeys(for: order).primary.first, first.isLetter else {
+            return "#"
+        }
+        return String(first).uppercased()
     }
 }

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -70,14 +70,15 @@ struct ContactListView: View {
     @ViewBuilder
     private var emptyState: some View {
         if sections.isEmpty {
-            if !searchText.isEmpty {
-                ContentUnavailableView.search(text: searchText)
-            } else if totalCount == 0 {
+            if totalCount == 0 {
+                // An empty store always reads as "No Contacts", even mid-search.
                 ContentUnavailableView(
                     "No Contacts",
                     systemImage: "person.crop.circle.badge.plus",
                     description: Text("Add a contact to get started.")
                 )
+            } else if !searchText.isEmpty {
+                ContentUnavailableView.search(text: searchText)
             }
         }
     }

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -2,36 +2,36 @@
 //  ContactListView.swift
 //  ContactManager
 //
-//  Middle column: the selectable list of contacts plus the add/delete
-//  toolbar affordances.
+//  Middle column: a searchable, alphabetically sectioned list of contacts
+//  plus the sort and add/delete toolbar affordances.
 //
 
 import SwiftUI
 
 struct ContactListView: View {
-    let contacts: [Contact]
+    let sections: [ContactSection]
+    let totalCount: Int
+    @Binding var searchText: String
+    @Binding var sortOrder: ContactSortOrder
     @Binding var selection: Contact?
     var addContact: () -> Void
     var deleteContact: (Contact) -> Void
 
     var body: some View {
         List(selection: $selection) {
-            ForEach(contacts) { contact in
-                ContactRow(contact: contact)
-                    .tag(contact)
+            ForEach(sections) { section in
+                Section(section.title) {
+                    ForEach(section.contacts) { contact in
+                        ContactRow(contact: contact)
+                            .tag(contact)
+                    }
+                }
             }
         }
         .navigationTitle("Contacts")
         .navigationSplitViewColumnWidth(min: 240, ideal: 280, max: 420)
-        .overlay {
-            if contacts.isEmpty {
-                ContentUnavailableView(
-                    "No Contacts",
-                    systemImage: "person.crop.circle.badge.plus",
-                    description: Text("Add a contact to get started.")
-                )
-            }
-        }
+        .searchable(text: $searchText, prompt: "Search Contacts")
+        .overlay { emptyState }
         .onDeleteCommand {
             if let selection { deleteContact(selection) }
         }
@@ -50,6 +50,34 @@ struct ContactListView: View {
                 }
                 .help("Delete Contact")
                 .disabled(selection == nil)
+            }
+            ToolbarItem {
+                Menu {
+                    Picker("Sort By", selection: $sortOrder) {
+                        ForEach(ContactSortOrder.allCases) { order in
+                            Text(order.title).tag(order)
+                        }
+                    }
+                    .pickerStyle(.inline)
+                } label: {
+                    Label("Sort", systemImage: "arrow.up.arrow.down")
+                }
+                .help("Sort Order")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if sections.isEmpty {
+            if !searchText.isEmpty {
+                ContentUnavailableView.search(text: searchText)
+            } else if totalCount == 0 {
+                ContentUnavailableView(
+                    "No Contacts",
+                    systemImage: "person.crop.circle.badge.plus",
+                    description: Text("Add a contact to get started.")
+                )
             }
         }
     }

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -18,13 +18,25 @@ struct ContentView: View {
     @State private var sidebarSelection: SidebarItem? = .allContacts
     @State private var selectedContact: Contact?
     @State private var errorMessage: String?
+    @State private var searchText = ""
+    @AppStorage("contactSortOrder") private var sortOrder: ContactSortOrder = .lastName
+
+    private var sections: [ContactSection] {
+        ContactQuery.sections(
+            ContactQuery.filtered(contacts, matching: searchText),
+            by: sortOrder
+        )
+    }
 
     var body: some View {
         NavigationSplitView {
             SidebarView(selection: $sidebarSelection, contactCount: contacts.count)
         } content: {
             ContactListView(
-                contacts: contacts,
+                sections: sections,
+                totalCount: contacts.count,
+                searchText: $searchText,
+                sortOrder: $sortOrder,
                 selection: $selectedContact,
                 addContact: addContact,
                 deleteContact: deleteContact

--- a/ContactManagerTests/ContactModelTests.swift
+++ b/ContactManagerTests/ContactModelTests.swift
@@ -127,6 +127,13 @@ struct ContactModelTests {
         #expect(sections.first?.contacts.first?.lastName == "Hopper")
     }
 
+    @Test func companyOnlyContactGroupsUnderCompanyInitial() {
+        let acme = Contact(company: "Acme")          // letter → "A"
+        let numeric = Contact(company: "1Password")  // non-letter → "#"
+        let sections = ContactQuery.sections([acme, numeric], by: .lastName)
+        #expect(sections.map(\.title) == ["A", "#"])
+    }
+
     @Test func sortingAndSectioningByFirstNameUsesFirstNameInitial() {
         let contacts = [
             Contact(firstName: "Ada", lastName: "Lovelace"),

--- a/ContactManagerTests/ContactModelTests.swift
+++ b/ContactManagerTests/ContactModelTests.swift
@@ -115,6 +115,30 @@ struct ContactModelTests {
         #expect(sorted.map(\.lastName) == ["Hopper", "Lovelace", "Turing"])
     }
 
+    @Test func sectionsGroupByInitialWithSymbolsLast() {
+        let contacts = [
+            Contact(firstName: "Ada", lastName: "Lovelace"),
+            Contact(firstName: "Alan", lastName: "Turing"),
+            Contact(firstName: "Grace", lastName: "Hopper"),
+            Contact(company: "1Password"), // no person name → "#"
+        ]
+        let sections = ContactQuery.sections(contacts, by: .lastName)
+        #expect(sections.map(\.title) == ["H", "L", "T", "#"])
+        #expect(sections.first?.contacts.first?.lastName == "Hopper")
+    }
+
+    @Test func sortingAndSectioningByFirstNameUsesFirstNameInitial() {
+        let contacts = [
+            Contact(firstName: "Ada", lastName: "Lovelace"),
+            Contact(firstName: "Alan", lastName: "Turing"),
+            Contact(firstName: "Grace", lastName: "Hopper"),
+        ]
+        let sections = ContactQuery.sections(contacts, by: .firstName)
+        #expect(sections.map(\.title) == ["A", "G"])
+        // Within "A": Ada (Lovelace) before Alan (Turing).
+        #expect(sections.first?.contacts.map(\.firstName) == ["Ada", "Alan"])
+    }
+
     @Test func filteringMatchesName_Company_Notes_AndFieldValues() throws {
         let ada = Contact(firstName: "Ada", lastName: "Lovelace", company: "Analytical Engine")
         ada.fields = [ContactField(kind: .email, value: "ada@analytical.engine")]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ ContactManager/
 - Create, edit (inline, autosaving), and delete contacts.
 - Multiple labeled emails and phone numbers per contact (add/remove inline).
 - Company, job title, postal address, birthday, and free-form notes.
+- Live search across name, company, title, notes, and field values.
+- Alphabetical sections with a first-name / last-name sort toggle.
 - Initials-based avatars.
 - Sample contacts seeded on first launch.
 
@@ -47,7 +49,7 @@ Shipped as small, single-purpose PRs:
 
 1. ✅ **Foundation** — SwiftUI + SwiftData rewrite, CRUD, project modernized to macOS 26.
 2. ✅ **Richer fields** — multiple emails/phones, company/title, address, birthday, notes.
-3. **Search & sections** — live search and alphabetical sectioning.
+3. ✅ **Search & sections** — live search and alphabetical sectioning.
 4. **Contact photos** — photo import with initials fallback.
 5. **Groups & vCard** — user groups/tags and `.vcf` import/export.
 6. **Tahoe polish** — Liquid Glass refinements, animations, and richer empty states.


### PR DESCRIPTION
## Summary

**PR C** of the Tahoe rewrite roadmap. Makes the contact list searchable and alphabetically sectioned, with a sort toggle.

## Changes
- **Live search** (`.searchable`) filtering by name, company, job title, notes, and any email/phone value (reuses the tested `ContactQuery.filtered`).
- **Alphabetical sections** — contacts grouped by initial; names without a letter initial fall into a trailing **`#`** section.
- **Sort toggle** — a toolbar menu switches between **Last Name** and **First Name** ordering, persisted via `@AppStorage`. The chosen order drives both sorting and section grouping.
- Empty states distinguish *no search results* from *no contacts*.

## Implementation
- `ContactQuery` gains pure `sorted(by:)` and `sections(by:)`, plus `ContactSortOrder` and `ContactSection`; `Contact` gains `sortKeys(for:)`. All logic stays out of the views for testability.

## Test plan
- [x] Clean build, zero code warnings
- [x] 11/11 Swift Testing tests pass (added sectioning + first-name ordering)
- [x] App launches and runs headless

🤖 Generated with [Claude Code](https://claude.com/claude-code)