### PR TITLE
Add contact photos with initials fallback

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02D950C10327393FB2B5BB7E /* ImageProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76507F3A1E2222FB64D7F31 /* ImageProcessing.swift */; };
 		14C13B18A26BC44F834915C1 /* ContactModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75D02267D3BC6C014143329 /* ContactModelTests.swift */; };
 		14E0C9EBEF8212F3F9B2777D /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51E6728EF90B1D2BF8EA5AE /* Contact.swift */; };
 		15AD8E34CC4EF4BC81F8A159 /* ContactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */; };
@@ -16,6 +17,7 @@
 		6BF479700A4101F1353CBF78 /* ContactQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B27567532AC1A51FF4CC13A /* ContactQuery.swift */; };
 		6DDC44CAA558E1DB276460CF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833F1AF82CACF7B9E89BADCA /* ContentView.swift */; };
 		7F3D3F509379FD171AEC3606 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DEAB729518FA2A6600E3570B /* Images.xcassets */; };
+		9506DFC07D9490AEDFB096EC /* ImageProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */; };
 		C2A11D686722C70868435ACE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303A7F66E428BF3662142C0 /* SidebarView.swift */; };
 		DED8178E13A452A900EC3234 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DED8178D13A452A900EC3234 /* Cocoa.framework */; };
 		DED817AB13A452AA00EC3234 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DED8178D13A452A900EC3234 /* Cocoa.framework */; };
@@ -38,6 +40,7 @@
 		0B27567532AC1A51FF4CC13A /* ContactQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactQuery.swift; sourceTree = "<group>"; };
 		0F82C8A388E97CC4F1106176 /* SampleData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SampleData.swift; sourceTree = "<group>"; };
 		2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
+		5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingTests.swift; sourceTree = "<group>"; };
 		6303A7F66E428BF3662142C0 /* SidebarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactDetailView.swift; sourceTree = "<group>"; };
 		833F1AF82CACF7B9E89BADCA /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -53,6 +56,7 @@
 		DEFCA6D1259AAB9C00DB0749 /* SharedSettings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SharedSettings.xcconfig; sourceTree = "<group>"; };
 		EBDDA2A3FA3C7375D63CFC55 /* ContactManagerApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactManagerApp.swift; sourceTree = "<group>"; };
 		F51E6728EF90B1D2BF8EA5AE /* Contact.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Contact.swift; sourceTree = "<group>"; };
+		F76507F3A1E2222FB64D7F31 /* ImageProcessing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessing.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +98,15 @@
 			);
 			name = Models;
 			path = Models;
+			sourceTree = "<group>";
+		};
+		A34742F5CC5340B2EE610BF4 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				F76507F3A1E2222FB64D7F31 /* ImageProcessing.swift */,
+			);
+			name = Support;
+			path = Support;
 			sourceTree = "<group>";
 		};
 		C876089F42640D0818FE333F /* Views */ = {
@@ -219,6 +232,7 @@
 				05B7EB62632E82EC1D048F88 /* App */,
 				1A7FF215BB060EF1483FD33C /* Models */,
 				C876089F42640D0818FE333F /* Views */,
+				A34742F5CC5340B2EE610BF4 /* Support */,
 			);
 			path = ContactManager;
 			sourceTree = "<group>";
@@ -237,6 +251,7 @@
 				DE27DD9413B7C68900EF7A92 /* Model Tests */,
 				DED817AF13A452AA00EC3234 /* Supporting Files */,
 				B75D02267D3BC6C014143329 /* ContactModelTests.swift */,
+				5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -362,6 +377,7 @@
 				465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */,
 				15AD8E34CC4EF4BC81F8A159 /* ContactDetailView.swift in Sources */,
 				23BF1F338E4C813308B5DEE2 /* ContactField.swift in Sources */,
+				02D950C10327393FB2B5BB7E /* ImageProcessing.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -370,6 +386,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				14C13B18A26BC44F834915C1 /* ContactModelTests.swift in Sources */,
+				9506DFC07D9490AEDFB096EC /* ImageProcessingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Models/Contact.swift
+++ b/ContactManager/Models/Contact.swift
@@ -30,7 +30,8 @@ final class Contact {
     var notes: String = ""
     var createdAt: Date = Date.now
 
-    /// Downscaled avatar image (JPEG). Stored outside the SQLite file.
+    /// Downscaled avatar image (JPEG). `.externalStorage` lets SwiftData keep
+    /// large blobs outside the SQLite file when appropriate.
     @Attribute(.externalStorage) var photoData: Data?
 
     // Labeled emails and phone numbers.

--- a/ContactManager/Models/Contact.swift
+++ b/ContactManager/Models/Contact.swift
@@ -30,6 +30,9 @@ final class Contact {
     var notes: String = ""
     var createdAt: Date = Date.now
 
+    /// Downscaled avatar image (JPEG). Stored outside the SQLite file.
+    @Attribute(.externalStorage) var photoData: Data?
+
     // Labeled emails and phone numbers.
     @Relationship(deleteRule: .cascade, inverse: \ContactField.contact)
     var fields: [ContactField]

--- a/ContactManager/Support/ImageProcessing.swift
+++ b/ContactManager/Support/ImageProcessing.swift
@@ -1,0 +1,56 @@
+//
+//  ImageProcessing.swift
+//  ContactManager
+//
+//  Downscales and re-encodes picked images into compact avatar JPEGs so the
+//  store stays lean. Uses ImageIO thumbnails for efficient decoding.
+//
+
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+enum ImageProcessing {
+    /// Longest edge (in pixels) of a generated avatar.
+    static let maxPixelSize: CGFloat = 512
+
+    /// JPEG compression quality for generated avatars.
+    static let compressionQuality: Double = 0.8
+
+    /// Reads an image file and returns a downscaled avatar JPEG, or `nil` if
+    /// the file isn't a decodable image.
+    static func avatarData(from url: URL) -> Data? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
+        return avatarData(from: source)
+    }
+
+    /// Returns a downscaled avatar JPEG for the given image data, or `nil` if
+    /// the data isn't a decodable image.
+    static func avatarData(from data: Data) -> Data? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        return avatarData(from: source)
+    }
+
+    private static func avatarData(from source: CGImageSource) -> Data? {
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+        ]
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return nil
+        }
+
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            output, UTType.jpeg.identifier as CFString, 1, nil
+        ) else { return nil }
+
+        CGImageDestinationAddImage(
+            destination, thumbnail,
+            [kCGImageDestinationLossyCompressionQuality: compressionQuality] as CFDictionary
+        )
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return output as Data
+    }
+}

--- a/ContactManager/Views/AvatarView.swift
+++ b/ContactManager/Views/AvatarView.swift
@@ -2,26 +2,36 @@
 //  AvatarView.swift
 //  ContactManager
 //
-//  Circular avatar showing the contact's initials over a tinted gradient.
-//  Photo support arrives in a later milestone; this is the fallback.
+//  Circular avatar: shows the contact's photo when set, otherwise their
+//  initials over a stable per-contact tinted gradient.
 //
 
 import SwiftUI
+import AppKit
 
 struct AvatarView: View {
     let contact: Contact
     var size: CGFloat = 64
 
     var body: some View {
-        Circle()
-            .fill(gradient)
-            .overlay {
-                Text(contact.initials)
-                    .font(.system(size: size * 0.4, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.white)
-                    .minimumScaleFactor(0.5)
+        Group {
+            if let data = contact.photoData, let image = NSImage(data: data) {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Circle()
+                    .fill(gradient)
+                    .overlay {
+                        Text(contact.initials)
+                            .font(.system(size: size * 0.4, weight: .semibold, design: .rounded))
+                            .foregroundStyle(.white)
+                            .minimumScaleFactor(0.5)
+                    }
             }
-            .frame(width: size, height: size)
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
     }
 
     /// A stable per-contact color so avatars stay visually distinct.

--- a/ContactManager/Views/AvatarView.swift
+++ b/ContactManager/Views/AvatarView.swift
@@ -13,10 +13,14 @@ struct AvatarView: View {
     let contact: Contact
     var size: CGFloat = 64
 
+    // Decoded once per photo change rather than on every body evaluation
+    // (important for list rows that re-render frequently).
+    @State private var photo: NSImage?
+
     var body: some View {
         Group {
-            if let data = contact.photoData, let image = NSImage(data: data) {
-                Image(nsImage: image)
+            if let photo {
+                Image(nsImage: photo)
                     .resizable()
                     .scaledToFill()
             } else {
@@ -32,6 +36,9 @@ struct AvatarView: View {
         }
         .frame(width: size, height: size)
         .clipShape(Circle())
+        .task(id: contact.photoData) {
+            photo = contact.photoData.flatMap { NSImage(data: $0) }
+        }
     }
 
     /// A stable per-contact color so avatars stay visually distinct.

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -14,6 +14,7 @@ struct ContactDetailView: View {
     @Environment(\.modelContext) private var context
     @Bindable var contact: Contact
     @State private var isImportingPhoto = false
+    @State private var photoError: String?
 
     var body: some View {
         Form {
@@ -54,6 +55,15 @@ struct ContactDetailView: View {
         }
         .formStyle(.grouped)
         .navigationTitle(contact.fullName)
+        .alert(
+            "Couldn't Add Photo",
+            isPresented: Binding(get: { photoError != nil }, set: { if !$0 { photoError = nil } }),
+            presenting: photoError
+        ) { _ in
+            Button("OK", role: .cancel) {}
+        } message: { message in
+            Text(message)
+        }
     }
 
     // MARK: - Header
@@ -97,13 +107,12 @@ struct ContactDetailView: View {
         }
         .buttonStyle(.plain)
         .help("Change Photo")
+        .accessibilityLabel("Change Photo")
         .fileImporter(
             isPresented: $isImportingPhoto,
             allowedContentTypes: [.image]
         ) { result in
-            if case .success(let url) = result {
-                importPhoto(from: url)
-            }
+            handleImport(result)
         }
     }
 
@@ -131,14 +140,35 @@ struct ContactDetailView: View {
 
     // MARK: - Actions
 
-    private func importPhoto(from url: URL) {
-        // The picked URL is security-scoped; access it while reading.
-        let didAccess = url.startAccessingSecurityScopedResource()
-        defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+    private func handleImport(_ result: Result<URL, Error>) {
+        switch result {
+        case .failure(let error):
+            photoError = error.localizedDescription
+        case .success(let url):
+            // Read the picked file while its security scope is held, then hand
+            // the bytes off; downscaling happens off the main actor below.
+            let didAccess = url.startAccessingSecurityScopedResource()
+            defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+            do {
+                let fileData = try Data(contentsOf: url)
+                processPhoto(fileData)
+            } catch {
+                photoError = error.localizedDescription
+            }
+        }
+    }
 
-        guard let data = ImageProcessing.avatarData(from: url) else { return }
-        contact.photoData = data
-        try? context.save()
+    private func processPhoto(_ fileData: Data) {
+        Task {
+            // Decode/downscale off the main actor so large images don't block UI.
+            let avatar = await Task.detached { ImageProcessing.avatarData(from: fileData) }.value
+            guard let avatar else {
+                photoError = "That file couldn't be read as an image."
+                return
+            }
+            contact.photoData = avatar
+            do { try context.save() } catch { photoError = error.localizedDescription }
+        }
     }
 
     private func removePhoto() {

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -8,10 +8,12 @@
 
 import SwiftUI
 import SwiftData
+import UniformTypeIdentifiers
 
 struct ContactDetailView: View {
     @Environment(\.modelContext) private var context
     @Bindable var contact: Contact
+    @State private var isImportingPhoto = false
 
     var body: some View {
         Form {
@@ -59,7 +61,7 @@ struct ContactDetailView: View {
     private var header: some View {
         Section {
             HStack(spacing: 16) {
-                AvatarView(contact: contact, size: 72)
+                photoWell
                 VStack(alignment: .leading, spacing: 2) {
                     Text(contact.fullName)
                         .font(.title2.weight(.semibold))
@@ -73,6 +75,35 @@ struct ContactDetailView: View {
                 Spacer()
             }
             .padding(.vertical, 4)
+        }
+    }
+
+    /// Tappable avatar that offers choosing or removing a photo.
+    private var photoWell: some View {
+        Menu {
+            Button("Choose Photo…") { isImportingPhoto = true }
+            if contact.photoData != nil {
+                Button("Remove Photo", role: .destructive, action: removePhoto)
+            }
+        } label: {
+            AvatarView(contact: contact, size: 72)
+                .overlay(alignment: .bottomTrailing) {
+                    Image(systemName: "camera.circle.fill")
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(.white, .blue)
+                        .font(.system(size: 22))
+                        .background(.white, in: Circle())
+                }
+        }
+        .buttonStyle(.plain)
+        .help("Change Photo")
+        .fileImporter(
+            isPresented: $isImportingPhoto,
+            allowedContentTypes: [.image]
+        ) { result in
+            if case .success(let url) = result {
+                importPhoto(from: url)
+            }
         }
     }
 
@@ -99,6 +130,21 @@ struct ContactDetailView: View {
     }
 
     // MARK: - Actions
+
+    private func importPhoto(from url: URL) {
+        // The picked URL is security-scoped; access it while reading.
+        let didAccess = url.startAccessingSecurityScopedResource()
+        defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+
+        guard let data = ImageProcessing.avatarData(from: url) else { return }
+        contact.photoData = data
+        try? context.save()
+    }
+
+    private func removePhoto() {
+        contact.photoData = nil
+        try? context.save()
+    }
 
     private func addField(kind: FieldKind) {
         // Use max+1 (not count) so indices stay strictly increasing even after

--- a/ContactManagerTests/ImageProcessingTests.swift
+++ b/ContactManagerTests/ImageProcessingTests.swift
@@ -1,0 +1,58 @@
+//
+//  ImageProcessingTests.swift
+//  ContactManagerTests
+//
+//  Verifies avatar generation downscales and re-encodes images.
+//
+
+import Testing
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+@testable import ContactManager
+
+struct ImageProcessingTests {
+
+    /// Encodes a solid-color image of the given size as PNG data.
+    private func makePNG(width: Int, height: Int) throws -> Data {
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        let context = try #require(CGContext(
+            data: nil, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: 0, space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        let image = try #require(context.makeImage())
+
+        let data = NSMutableData()
+        let destination = try #require(CGImageDestinationCreateWithData(
+            data, UTType.png.identifier as CFString, 1, nil
+        ))
+        CGImageDestinationAddImage(destination, image, nil)
+        #expect(CGImageDestinationFinalize(destination))
+        return data as Data
+    }
+
+    private func pixelSize(of data: Data) throws -> (width: Int, height: Int) {
+        let source = try #require(CGImageSourceCreateWithData(data as CFData, nil))
+        let image = try #require(CGImageSourceCreateImageAtIndex(source, 0, nil))
+        return (image.width, image.height)
+    }
+
+    @Test func downscalesImagesLargerThanTheMaxEdge() throws {
+        let input = try makePNG(width: 1024, height: 768)
+        let avatar = try #require(ImageProcessing.avatarData(from: input))
+
+        let size = try pixelSize(of: avatar)
+        #expect(max(size.width, size.height) <= Int(ImageProcessing.maxPixelSize))
+        // Aspect ratio is preserved: 1024x768 → 512x384.
+        #expect(size.width == 512)
+        #expect(size.height == 384)
+    }
+
+    @Test func returnsNilForNonImageData() {
+        let garbage = Data("not an image".utf8)
+        #expect(ImageProcessing.avatarData(from: garbage) == nil)
+    }
+}

--- a/ContactManagerTests/ImageProcessingTests.swift
+++ b/ContactManagerTests/ImageProcessingTests.swift
@@ -15,7 +15,7 @@ struct ImageProcessingTests {
 
     /// Encodes a solid-color image of the given size as PNG data.
     private func makePNG(width: Int, height: Int) throws -> Data {
-        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        let colorSpace = try #require(CGColorSpace(name: CGColorSpace.sRGB))
         let context = try #require(CGContext(
             data: nil, width: width, height: height,
             bitsPerComponent: 8, bytesPerRow: 0, space: colorSpace,

--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ ContactManager/
 ├── App/      ContactManagerApp.swift   – @main entry point, model container, menu commands
 ├── Models/   Contact.swift             – the @Model contact entity + derived values
 │             ContactField.swift        – labeled, repeatable email/phone child entity
-│             ContactQuery.swift        – pure, testable filter/sort helpers
+│             ContactQuery.swift        – pure, testable filter/sort/section helpers
 │             SampleData.swift          – first-launch seed data
+├── Support/  ImageProcessing.swift     – downscales picked images into avatar JPEGs
 └── Views/    ContentView.swift         – NavigationSplitView shell + create/delete actions
               SidebarView.swift         – groups sidebar (All Contacts)
-              ContactListView.swift     – selectable contact list + toolbar
-              ContactDetailView.swift   – editable detail form
-              AvatarView.swift          – initials avatar with a per-contact tint
+              ContactListView.swift     – searchable, sectioned contact list + toolbar
+              ContactDetailView.swift   – editable detail form + photo well
+              AvatarView.swift          – photo or initials avatar with a per-contact tint
 ```
 
 ---
@@ -40,7 +41,7 @@ ContactManager/
 - Company, job title, postal address, birthday, and free-form notes.
 - Live search across name, company, title, notes, and field values.
 - Alphabetical sections with a first-name / last-name sort toggle.
-- Initials-based avatars.
+- Contact photos (downscaled on import) with an initials avatar fallback.
 - Sample contacts seeded on first launch.
 
 ### Roadmap
@@ -50,7 +51,7 @@ Shipped as small, single-purpose PRs:
 1. ✅ **Foundation** — SwiftUI + SwiftData rewrite, CRUD, project modernized to macOS 26.
 2. ✅ **Richer fields** — multiple emails/phones, company/title, address, birthday, notes.
 3. ✅ **Search & sections** — live search and alphabetical sectioning.
-4. **Contact photos** — photo import with initials fallback.
+4. ✅ **Contact photos** — photo import with initials fallback.
 5. **Groups & vCard** — user groups/tags and `.vcf` import/export.
 6. **Tahoe polish** — Liquid Glass refinements, animations, and richer empty states.
 


### PR DESCRIPTION
## Summary

**PR D** of the Tahoe rewrite roadmap. Adds per-contact photos, falling back to the initials avatar.

## Changes
- `Contact` gains an `@Attribute(.externalStorage) var photoData: Data?` — optional, so existing stores migrate cleanly (large blobs are kept outside the SQLite file).
- `AvatarView` renders the photo when set and falls back to the initials gradient; used by both list rows and the detail header.
- `ContactDetailView`'s avatar becomes a **photo well**: a menu to *Choose Photo…* (via `.fileImporter`, security-scoped) or *Remove Photo*, with a camera badge overlay.
- New `ImageProcessing` helper downscales picked images to a 512px JPEG via ImageIO so the store stays lean.

## Test plan
- [x] Clean build, zero code warnings
- [x] 14 tests pass across 2 suites (added image downscale + non-image-input tests)
- [x] App launches; migrating an existing store to the photo-enabled schema works
- [ ] Visual check: pick/remove a photo via `⌘R` (no screenshot capability in the build environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)