### PR TITLE
Polish: Liquid Glass actions and smooth animations

### DIFF
--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -112,7 +112,7 @@ private struct StoreErrorView: View {
             Text(message)
         } actions: {
             Button("Reset Data", role: .destructive, action: onReset)
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.glassProminent)
         }
         .frame(minWidth: 360, minHeight: 240)
     }

--- a/ContactManager/Views/AvatarView.swift
+++ b/ContactManager/Views/AvatarView.swift
@@ -36,6 +36,7 @@ struct AvatarView: View {
         }
         .frame(width: size, height: size)
         .clipShape(Circle())
+        .animation(.smooth, value: contact.photoData)
         .task(id: contact.photoData) {
             photo = contact.photoData.flatMap { NSImage(data: $0) }
         }

--- a/ContactManager/Views/AvatarView.swift
+++ b/ContactManager/Views/AvatarView.swift
@@ -23,6 +23,7 @@ struct AvatarView: View {
                 Image(nsImage: photo)
                     .resizable()
                     .scaledToFill()
+                    .transition(.opacity)
             } else {
                 Circle()
                     .fill(gradient)
@@ -32,13 +33,15 @@ struct AvatarView: View {
                             .foregroundStyle(.white)
                             .minimumScaleFactor(0.5)
                     }
+                    .transition(.opacity)
             }
         }
         .frame(width: size, height: size)
         .clipShape(Circle())
-        .animation(.smooth, value: contact.photoData)
         .task(id: contact.photoData) {
-            photo = contact.photoData.flatMap { NSImage(data: $0) }
+            let decoded = contact.photoData.flatMap { NSImage(data: $0) }
+            // Animate the actual swap, which happens when `photo` updates.
+            withAnimation(.smooth) { photo = decoded }
         }
     }
 

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -30,6 +30,7 @@ struct ContactListView: View {
         }
         .navigationTitle("Contacts")
         .navigationSplitViewColumnWidth(min: 240, ideal: 280, max: 420)
+        .animation(.smooth, value: sortOrder)
         .searchable(text: $searchText, prompt: "Search Contacts")
         .overlay { emptyState }
         .onDeleteCommand {
@@ -72,11 +73,14 @@ struct ContactListView: View {
         if sections.isEmpty {
             if totalCount == 0 {
                 // An empty store always reads as "No Contacts", even mid-search.
-                ContentUnavailableView(
-                    "No Contacts",
-                    systemImage: "person.crop.circle.badge.plus",
-                    description: Text("Add a contact to get started.")
-                )
+                ContentUnavailableView {
+                    Label("No Contacts", systemImage: "person.crop.circle.badge.plus")
+                } description: {
+                    Text("Add a contact to get started.")
+                } actions: {
+                    Button("New Contact", action: addContact)
+                        .buttonStyle(.glassProminent)
+                }
             } else if !searchText.isEmpty {
                 ContentUnavailableView.search(text: searchText)
             }

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -74,6 +74,7 @@ struct ContentView: View {
                 ContactPlaceholderView()
             }
         }
+        .frame(minWidth: 840, minHeight: 480)
         .onReceive(NotificationCenter.default.publisher(for: .newContactRequested)) { _ in
             addContact()
         }
@@ -120,7 +121,7 @@ struct ContentView: View {
         context.insert(contact)
         do {
             try context.save()
-            selectedContact = contact
+            withAnimation(.snappy) { selectedContact = contact }
         } catch {
             context.delete(contact)
             errorMessage = error.localizedDescription
@@ -146,7 +147,7 @@ struct ContentView: View {
         context.insert(group)
         do {
             try context.save()
-            sidebarSelection = .group(group.persistentModelID)
+            withAnimation(.snappy) { sidebarSelection = .group(group.persistentModelID) }
         } catch {
             context.delete(group)
             errorMessage = error.localizedDescription

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **ContactManager** is a native macOS contact manager built with **SwiftUI** and **SwiftData**, targeting the modern macOS Tahoe (macOS 26) look and feel. It is **100% self-contained** with zero third-party dependencies.
 
-The app was originally an Objective-C / AppKit / Core Data demo and is being rebuilt, in focused increments, into a polished native Tahoe application.
+The app was originally an Objective-C / AppKit / Core Data demo and was rebuilt, in focused increments, into a polished native Tahoe application.
 
 ---
 
@@ -47,6 +47,7 @@ ContactManager/
 - Contact photos (downscaled on import) with an initials avatar fallback.
 - User-defined groups (sidebar create/rename/delete) with per-contact membership.
 - vCard 3.0 import and export (File ▸ Import/Export vCard…).
+- Liquid Glass styling, glass-prominent actions, and smooth list/selection animations.
 - Sample contacts seeded on first launch.
 
 ### Roadmap
@@ -58,7 +59,7 @@ Shipped as small, single-purpose PRs:
 3. ✅ **Search & sections** — live search and alphabetical sectioning.
 4. ✅ **Contact photos** — photo import with initials fallback.
 5. ✅ **Groups & vCard** — user groups/tags and `.vcf` import/export.
-6. **Tahoe polish** — Liquid Glass refinements, animations, and richer empty states.
+6. ✅ **Tahoe polish** — Liquid Glass refinements, animations, and richer empty states.
 
 ---
 


### PR DESCRIPTION
## Summary

**PR F** — the final roadmap item. Tahoe polish on top of the automatic Liquid Glass that toolbars and `NavigationSplitView` already adopt from the macOS 26 SDK.

## Changes
- **Glass actions**: the empty-state *New Contact* button and the store-recovery *Reset Data* button use `.buttonStyle(.glassProminent)`.
- **Animations**: section regrouping on sort-order change, creating/selecting a contact, switching groups, and an avatar photo crossfade.
- A sensible **minimum window size** for the three-column layout.

## Notes
- `glassEffect` / `GlassEffectContainer` aren't present in the macOS 26.5 SwiftUI interface, so explicit glass is applied via the supported glass **button styles**; the broader Liquid Glass look comes from automatic SDK adoption.

## Test plan
- [x] Clean build, zero code warnings
- [x] 21 tests pass across 3 suites
- [x] App launches and runs headless
- [ ] Visual check of glass buttons + animations via `⌘R` (no screenshot capability in the build environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)