### PR TITLE
Lint via CI; adopt recommended settings; drop the SwiftLint build phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tooling
+        run: brew bundle
+
+      - name: Check formatting (SwiftFormat)
+        run: swiftformat --lint .
+
+      - name: Lint (SwiftLint)
+        run: swiftlint lint --strict

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,9 @@ ContactManagerTests/     Swift Testing suites
 Run `make format` and `make lint` before committing; both must pass (or `make check`).
 Configs: `.swiftformat`, `.swiftlint.yml`. Linting is intentionally **not** an Xcode
 build phase: the project enables `ENABLE_USER_SCRIPT_SANDBOXING`, which blocks a
-whole-tree SwiftLint run script from reading sources. Lint from the command line / CI.
+whole-tree SwiftLint run script from reading sources. Instead, CI
+(`.github/workflows/ci.yml`) runs `swiftformat --lint` + `swiftlint --strict` on every
+PR, so enforcement happens with zero local build/commit friction.
 
 - 4-space indent; opening braces on the same line; trailing commas in multiline
   literals (SwiftFormat owns comma style — SwiftLint's `trailing_comma` is disabled

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,10 @@ ContactManagerTests/     Swift Testing suites
 
 ## Code style
 
-Run `make format` and `make lint` before committing; both must pass. Configs:
-`.swiftformat`, `.swiftlint.yml` (SwiftLint also runs as a build phase).
+Run `make format` and `make lint` before committing; both must pass (or `make check`).
+Configs: `.swiftformat`, `.swiftlint.yml`. Linting is intentionally **not** an Xcode
+build phase: the project enables `ENABLE_USER_SCRIPT_SANDBOXING`, which blocks a
+whole-tree SwiftLint run script from reading sources. Lint from the command line / CI.
 
 - 4-space indent; opening braces on the same line; trailing commas in multiline
   literals (SwiftFormat owns comma style — SwiftLint's `trailing_comma` is disabled

--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -84,7 +84,6 @@
 			children = (
 				EBDDA2A3FA3C7375D63CFC55 /* ContactManagerApp.swift */,
 			);
-			name = App;
 			path = App;
 			sourceTree = "<group>";
 		};
@@ -97,7 +96,6 @@
 				B25751DDEC1515E341AF67F5 /* ContactField.swift */,
 				FAFE362455F20C848F729EEE /* ContactGroup.swift */,
 			);
-			name = Models;
 			path = Models;
 			sourceTree = "<group>";
 		};
@@ -108,7 +106,6 @@
 				A7276D515CA167FBF4C47299 /* VCard.swift */,
 				2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */,
 			);
-			name = Support;
 			path = Support;
 			sourceTree = "<group>";
 		};
@@ -121,7 +118,6 @@
 				2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */,
 				73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */,
 			);
-			name = Views;
 			path = Views;
 			sourceTree = "<group>";
 		};
@@ -181,7 +177,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DED817BB13A452AA00EC3234 /* Build configuration list for PBXNativeTarget "ContactManager" */;
 			buildPhases = (
-				31E30EDAEDB1AC28FD0090AA /* SwiftLint */,
 				DED8178513A452A900EC3234 /* Sources */,
 				DED8178613A452A900EC3234 /* Frameworks */,
 				DED8178713A452A900EC3234 /* Resources */,
@@ -219,6 +214,7 @@
 		DED8178013A452A900EC3234 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 2650;
 				ORGANIZATIONNAME = "Scott Densmore";
 			};
@@ -258,28 +254,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		31E30EDAEDB1AC28FD0090AA /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Lint Swift sources during build (warnings only). See .swiftlint.yml\nif command -v swiftlint >/dev/null 2>&1; then\n  swiftlint lint --quiet\nelse\n  echo \"warning: SwiftLint not installed — run ./scripts/bootstrap.sh (brew bundle)\"\nfi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		DED8178513A452A900EC3234 /* Sources */ = {
@@ -348,8 +322,10 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_GENERATE_TEST_COVERAGE_FILES = NO;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
@@ -367,6 +343,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 			};
 			name = Debug;
 		};
@@ -394,7 +371,9 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
@@ -406,6 +385,8 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
 			};
 			name = Release;
 		};
@@ -418,6 +399,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -453,6 +435,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -486,6 +469,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -514,6 +498,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;

--- a/ContactManager.xcodeproj/xcshareddata/xcschemes/ContactManager.xcscheme
+++ b/ContactManager.xcodeproj/xcshareddata/xcschemes/ContactManager.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1230"
+   LastUpgradeVersion = "2650"
    version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
## Summary

Fixes the spurious **"SwiftLint not installed"** build warning, keeps Xcode's recommended settings, and enforces linting via CI instead of a build phase — the lowest-local-friction option.

## Root cause
- The warning came from the SwiftLint run-script using `command -v swiftlint`: Xcode build phases don't inherit the shell PATH, so `/opt/homebrew/bin` isn't found.
- "Update to recommended settings" enabled **`ENABLE_USER_SCRIPT_SANDBOXING = YES`**. Even with PATH fixed, the sandbox **denies the SwiftLint script read access to the source tree** and the build fails. A whole-tree SwiftLint *build phase* is fundamentally incompatible with script sandboxing.

## Changes
- **Removed the SwiftLint build phase.** Kept the recommended settings (sandboxing on; `DEAD_CODE_STRIPPING`, `STRING_CATALOG_GENERATE_SYMBOLS`, Release `wholemodule`); bumped the scheme's upgrade marker.
- **Added CI** (`.github/workflows/ci.yml`): runs `swiftformat --lint` + `swiftlint --strict` on PRs/pushes. Zero local build/commit friction; enforcement happens on GitHub.
- Avoided the alternatives that would compromise the goals: disabling the recommended sandbox setting, or adding the SwiftLint SPM plugin (this project is dependency-free).
- `CLAUDE.md` updated.

## Test plan
- [x] Debug `clean test` — 21 tests pass, no sandbox/lint errors
- [x] Release build — succeeds (whole-module + dead-code stripping)
- [x] CI **Lint & Format** check passes on this PR
- [x] No `SwiftLint` phase remains in the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)