### PR TITLE
Set Debug Swift optimization to -Onone for SwiftUI previews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ pattern), then build to confirm it compiles.
   The `.glassEffect()` modifier / `GlassEffectContainer` are not in this SDK's SwiftUI
   interface; use `.buttonStyle(.glass)` / `.buttonStyle(.glassProminent)` for explicit glass.
 - `SWIFT_VERSION` is 5.0 (language mode 5). Full Swift 6 strict-concurrency is a future migration.
+- Build settings are per-configuration: Debug uses `SWIFT_OPTIMIZATION_LEVEL = -Onone`
+  (required for SwiftUI `#Preview`), Release uses `-O` + `SWIFT_COMPILATION_MODE = wholemodule`.
 
 ## Workflow
 

--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
@@ -387,6 +388,7 @@
 				SDKROOT = macosx;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## Summary

Previewing `ContentView` failed with:
> "ContactManager.app" needs an unoptimized build to be able to preview. Current setting is "-O" but needs to be "-Onone".

### Cause
The project was converted from Objective-C and never set `SWIFT_OPTIMIZATION_LEVEL` (it only had the legacy *GCC* optimization flag). With the setting unset, Debug fell back to the build-system default of `-O`. SwiftUI `#Preview` requires an unoptimized `-Onone` build.

### Fix
Set `SWIFT_OPTIMIZATION_LEVEL` explicitly per configuration at the project level (both targets inherit):
- **Debug** → `-Onone`
- **Release** → `-O` (still `SWIFT_COMPILATION_MODE = wholemodule`)

Documented the per-config settings in `CLAUDE.md`.

## Test plan
- [x] `xcodebuild -showBuildSettings` (Debug) now reports `SWIFT_OPTIMIZATION_LEVEL = -Onone`
- [x] Debug build + 21 tests pass
- [x] Release build settings unchanged (`-O` + whole-module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)