### PR TITLE
Add duplicate detection and merge

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -21,11 +21,14 @@
 		6DDC44CAA558E1DB276460CF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833F1AF82CACF7B9E89BADCA /* ContentView.swift */; };
 		7755029B0E36200BB139ECFA /* VCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7D5B554122CF852B0D825C /* VCardTests.swift */; };
 		7F3D3F509379FD171AEC3606 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DEAB729518FA2A6600E3570B /* Images.xcassets */; };
+		81F488BB8E6D53268C607C68 /* DuplicatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C373BD237429970D6A7C86 /* DuplicatesView.swift */; };
+		827CF451F0B38B89C4469595 /* DuplicateFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */; };
 		9506DFC07D9490AEDFB096EC /* ImageProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */; };
 		97E98BCB6784672DCB8C1625 /* VCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7276D515CA167FBF4C47299 /* VCard.swift */; };
 		A94AB327927F2F1FBBD81119 /* ContactGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFE362455F20C848F729EEE /* ContactGroup.swift */; };
 		C2A11D686722C70868435ACE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303A7F66E428BF3662142C0 /* SidebarView.swift */; };
 		E5EB465B5CE3964197D29ADF /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F82C8A388E97CC4F1106176 /* SampleData.swift */; };
+		FA63688E94483238D7C29FE9 /* DuplicateFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */; };
 		FA702A2E92FAC86D4587641B /* ContactManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDDA2A3FA3C7375D63CFC55 /* ContactManagerApp.swift */; };
 /* End PBXBuildFile section */
 
@@ -46,6 +49,8 @@
 		0F82C8A388E97CC4F1106176 /* SampleData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SampleData.swift; sourceTree = "<group>"; };
 		2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardDocument.swift; sourceTree = "<group>"; };
+		3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinderTests.swift; sourceTree = "<group>"; };
+		54C373BD237429970D6A7C86 /* DuplicatesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicatesView.swift; sourceTree = "<group>"; };
 		5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingTests.swift; sourceTree = "<group>"; };
 		617D7B082A403094284FBD38 /* ContactStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStore.swift; sourceTree = "<group>"; };
 		6303A7F66E428BF3662142C0 /* SidebarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
@@ -59,6 +64,7 @@
 		DED8178913A452A900EC3234 /* ContactManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ContactManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DED817AA13A452AA00EC3234 /* ContactManagerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContactManagerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEFCA6D1259AAB9C00DB0749 /* SharedSettings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SharedSettings.xcconfig; sourceTree = "<group>"; };
+		E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinder.swift; sourceTree = "<group>"; };
 		EBDDA2A3FA3C7375D63CFC55 /* ContactManagerApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactManagerApp.swift; sourceTree = "<group>"; };
 		F51E6728EF90B1D2BF8EA5AE /* Contact.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Contact.swift; sourceTree = "<group>"; };
 		F76507F3A1E2222FB64D7F31 /* ImageProcessing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessing.swift; sourceTree = "<group>"; };
@@ -100,6 +106,7 @@
 				B25751DDEC1515E341AF67F5 /* ContactField.swift */,
 				FAFE362455F20C848F729EEE /* ContactGroup.swift */,
 				617D7B082A403094284FBD38 /* ContactStore.swift */,
+				E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -122,6 +129,7 @@
 				08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */,
 				2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */,
 				73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */,
+				54C373BD237429970D6A7C86 /* DuplicatesView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -164,6 +172,7 @@
 				5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */,
 				7E7D5B554122CF852B0D825C /* VCardTests.swift */,
 				03763AB80D45F026EC585490 /* ContactStoreTests.swift */,
+				3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -281,6 +290,8 @@
 				97E98BCB6784672DCB8C1625 /* VCard.swift in Sources */,
 				61F22EEDEE6075BD602203D5 /* VCardDocument.swift in Sources */,
 				134F890B4875E8BF294A92B2 /* ContactStore.swift in Sources */,
+				827CF451F0B38B89C4469595 /* DuplicateFinder.swift in Sources */,
+				81F488BB8E6D53268C607C68 /* DuplicatesView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -292,6 +303,7 @@
 				9506DFC07D9490AEDFB096EC /* ImageProcessingTests.swift in Sources */,
 				7755029B0E36200BB139ECFA /* VCardTests.swift in Sources */,
 				0ABBB9962C4AC14A077728FF /* ContactStoreTests.swift in Sources */,
+				FA63688E94483238D7C29FE9 /* DuplicateFinderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -38,6 +38,12 @@ struct ContactManagerApp: App {
                 }
                 .keyboardShortcut("n", modifiers: .command)
             }
+            CommandGroup(after: .pasteboard) {
+                Button("Find Duplicates…") {
+                    NotificationCenter.default.post(name: .findDuplicatesRequested, object: nil)
+                }
+                .keyboardShortcut("d", modifiers: [.command, .shift])
+            }
             CommandGroup(replacing: .importExport) {
                 Button("Import vCard…") {
                     NotificationCenter.default.post(name: .importVCardRequested, object: nil)
@@ -123,4 +129,5 @@ extension Notification.Name {
     static let newContactRequested = Notification.Name("ContactManager.newContactRequested")
     static let importVCardRequested = Notification.Name("ContactManager.importVCardRequested")
     static let exportVCardRequested = Notification.Name("ContactManager.exportVCardRequested")
+    static let findDuplicatesRequested = Notification.Name("ContactManager.findDuplicatesRequested")
 }

--- a/ContactManager/Models/ContactStore.swift
+++ b/ContactManager/Models/ContactStore.swift
@@ -107,7 +107,12 @@ struct ContactStore {
     /// group memberships are unioned, and a missing photo is adopted.
     @discardableResult
     func merge(_ contacts: [Contact]) throws -> Contact {
-        let ordered = contacts.sorted { $0.createdAt < $1.createdAt }
+        // Earliest created wins, with a stable tiebreaker so the choice is
+        // deterministic even when timestamps are identical.
+        let ordered = contacts.sorted { lhs, rhs in
+            if lhs.createdAt != rhs.createdAt { return lhs.createdAt < rhs.createdAt }
+            return String(describing: lhs.persistentModelID) < String(describing: rhs.persistentModelID)
+        }
         guard let primary = ordered.first else {
             throw ContactStoreError.nothingToMerge
         }
@@ -126,16 +131,21 @@ struct ContactStore {
     }
 
     private func fillEmptyFields(of primary: Contact, from other: Contact) {
-        if primary.firstName.isEmpty { primary.firstName = other.firstName }
-        if primary.lastName.isEmpty { primary.lastName = other.lastName }
-        if primary.company.isEmpty { primary.company = other.company }
-        if primary.jobTitle.isEmpty { primary.jobTitle = other.jobTitle }
-        if primary.street.isEmpty { primary.street = other.street }
-        if primary.city.isEmpty { primary.city = other.city }
-        if primary.state.isEmpty { primary.state = other.state }
-        if primary.postalCode.isEmpty { primary.postalCode = other.postalCode }
-        if primary.country.isEmpty { primary.country = other.country }
-        if primary.notes.isEmpty { primary.notes = other.notes }
+        /// Treat whitespace-only values as empty, consistent with the rest of
+        /// the codebase (Contact.fullName, primaryEmail, etc.).
+        func isBlank(_ value: String) -> Bool {
+            value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        if isBlank(primary.firstName) { primary.firstName = other.firstName }
+        if isBlank(primary.lastName) { primary.lastName = other.lastName }
+        if isBlank(primary.company) { primary.company = other.company }
+        if isBlank(primary.jobTitle) { primary.jobTitle = other.jobTitle }
+        if isBlank(primary.street) { primary.street = other.street }
+        if isBlank(primary.city) { primary.city = other.city }
+        if isBlank(primary.state) { primary.state = other.state }
+        if isBlank(primary.postalCode) { primary.postalCode = other.postalCode }
+        if isBlank(primary.country) { primary.country = other.country }
+        if isBlank(primary.notes) { primary.notes = other.notes }
         if primary.birthday == nil { primary.birthday = other.birthday }
         if primary.photoData == nil { primary.photoData = other.photoData }
     }

--- a/ContactManager/Models/ContactStore.swift
+++ b/ContactManager/Models/ContactStore.swift
@@ -99,6 +99,84 @@ struct ContactStore {
         try saveOrRollback()
     }
 
+    // MARK: - Merge duplicates
+
+    /// Merges several contacts into one canonical contact (the earliest
+    /// created), then deletes the rest. Empty fields on the canonical contact
+    /// are filled from the others, emails/phones are unioned and de-duplicated,
+    /// group memberships are unioned, and a missing photo is adopted.
+    @discardableResult
+    func merge(_ contacts: [Contact]) throws -> Contact {
+        let ordered = contacts.sorted { $0.createdAt < $1.createdAt }
+        guard let primary = ordered.first else {
+            throw ContactStoreError.nothingToMerge
+        }
+        let others = ordered.dropFirst()
+        guard !others.isEmpty else { return primary }
+
+        for other in others {
+            fillEmptyFields(of: primary, from: other)
+            adoptGroups(into: primary, from: other)
+        }
+        mergeFields(into: primary, from: Array(others))
+
+        others.forEach(context.delete)
+        try saveOrRollback()
+        return primary
+    }
+
+    private func fillEmptyFields(of primary: Contact, from other: Contact) {
+        if primary.firstName.isEmpty { primary.firstName = other.firstName }
+        if primary.lastName.isEmpty { primary.lastName = other.lastName }
+        if primary.company.isEmpty { primary.company = other.company }
+        if primary.jobTitle.isEmpty { primary.jobTitle = other.jobTitle }
+        if primary.street.isEmpty { primary.street = other.street }
+        if primary.city.isEmpty { primary.city = other.city }
+        if primary.state.isEmpty { primary.state = other.state }
+        if primary.postalCode.isEmpty { primary.postalCode = other.postalCode }
+        if primary.country.isEmpty { primary.country = other.country }
+        if primary.notes.isEmpty { primary.notes = other.notes }
+        if primary.birthday == nil { primary.birthday = other.birthday }
+        if primary.photoData == nil { primary.photoData = other.photoData }
+    }
+
+    private func adoptGroups(into primary: Contact, from other: Contact) {
+        let existing = Set(primary.groups.map(\.persistentModelID))
+        for group in other.groups where !existing.contains(group.persistentModelID) {
+            primary.groups.append(group)
+        }
+    }
+
+    /// Reassigns every contact's email/phone fields to `primary`, dropping
+    /// blanks and value-duplicates and reindexing for a stable order.
+    private func mergeFields(into primary: Contact, from others: [Contact]) {
+        for kind in FieldKind.allCases {
+            let candidates = primary.fields(of: kind) + others.flatMap { $0.fields(of: kind) }
+            var seenValues: Set<String> = []
+            var keptIndex = 0
+            for field in candidates {
+                let normalized = normalizedValue(of: field)
+                if normalized.isEmpty || seenValues.contains(normalized) {
+                    context.delete(field)
+                    continue
+                }
+                seenValues.insert(normalized)
+                field.contact = primary
+                field.sortIndex = keptIndex
+                keptIndex += 1
+            }
+        }
+    }
+
+    private func normalizedValue(of field: ContactField) -> String {
+        switch field.kind {
+        case .email:
+            field.value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        case .phone:
+            String(field.value.filter(\.isNumber))
+        }
+    }
+
     // MARK: - vCard import / export
 
     /// Parses a vCard document and inserts the contacts it describes.
@@ -149,6 +227,16 @@ struct ContactStore {
         } catch {
             context.rollback()
             throw error
+        }
+    }
+}
+
+enum ContactStoreError: LocalizedError {
+    case nothingToMerge
+
+    var errorDescription: String? {
+        switch self {
+        case .nothingToMerge: "There were no contacts to merge."
         }
     }
 }

--- a/ContactManager/Models/DuplicateFinder.swift
+++ b/ContactManager/Models/DuplicateFinder.swift
@@ -1,0 +1,91 @@
+//
+//  DuplicateFinder.swift
+//  ContactManager
+//
+//  Pure, testable duplicate detection. Two contacts are treated as duplicates
+//  when they share a normalized email, phone number, or full name. Matches are
+//  surfaced for the user to review before merging, so the heuristic favors
+//  recall over precision.
+//
+
+import Foundation
+
+enum DuplicateFinder {
+    /// Groups of contacts that look like duplicates of one another. Only groups
+    /// with more than one contact are returned, each sorted, and the groups are
+    /// ordered for stable presentation.
+    static func duplicateGroups(in contacts: [Contact]) -> [[Contact]] {
+        guard contacts.count > 1 else { return [] }
+
+        var unionFind = UnionFind(count: contacts.count)
+        var ownerOfKey: [String: Int] = [:]
+
+        for (index, contact) in contacts.enumerated() {
+            for key in matchKeys(for: contact) {
+                if let owner = ownerOfKey[key] {
+                    unionFind.union(owner, index)
+                } else {
+                    ownerOfKey[key] = index
+                }
+            }
+        }
+
+        var groupsByRoot: [Int: [Contact]] = [:]
+        for index in contacts.indices {
+            groupsByRoot[unionFind.root(of: index), default: []].append(contacts[index])
+        }
+
+        return groupsByRoot.values
+            .filter { $0.count > 1 }
+            .map { ContactQuery.sorted($0) }
+            .sorted { ($0.first?.sortKey ?? "") < ($1.first?.sortKey ?? "") }
+    }
+
+    /// Normalized keys identifying a contact for matching. A shared key between
+    /// two contacts marks them as duplicates.
+    static func matchKeys(for contact: Contact) -> Set<String> {
+        var keys: Set<String> = []
+
+        for email in contact.emails {
+            let normalized = email.value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if !normalized.isEmpty { keys.insert("email:\(normalized)") }
+        }
+        for phone in contact.phones {
+            let digits = String(phone.value.filter(\.isNumber))
+            // Ignore very short fragments (e.g. extensions) to avoid false matches.
+            if digits.count >= 7 { keys.insert("phone:\(digits)") }
+        }
+
+        let name = [contact.firstName, contact.lastName]
+            .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        if !name.isEmpty { keys.insert("name:\(name)") }
+
+        return keys
+    }
+}
+
+/// Minimal weighted-free union-find with path compression, over array indices.
+private struct UnionFind {
+    private var parent: [Int]
+
+    init(count: Int) {
+        parent = Array(0 ..< count)
+    }
+
+    mutating func root(of index: Int) -> Int {
+        var current = index
+        while parent[current] != current {
+            parent[current] = parent[parent[current]] // path halving
+            current = parent[current]
+        }
+        return current
+    }
+
+    mutating func union(_ lhs: Int, _ rhs: Int) {
+        let lhsRoot = root(of: lhs)
+        let rhsRoot = root(of: rhs)
+        if lhsRoot != rhsRoot { parent[lhsRoot] = rhsRoot }
+    }
+}

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
     @State private var isImportingVCard = false
     @State private var isExportingVCard = false
     @State private var exportDocument = VCardDocument(text: "")
+    @State private var showingDuplicates = false
 
     private var store: ContactStore { ContactStore(context) }
 
@@ -88,6 +89,12 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .exportVCardRequested)) { _ in
             exportDocument = VCardDocument(text: store.exportVCards(contacts))
             isExportingVCard = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .findDuplicatesRequested)) { _ in
+            showingDuplicates = true
+        }
+        .sheet(isPresented: $showingDuplicates) {
+            DuplicatesView()
         }
         .fileImporter(isPresented: $isImportingVCard, allowedContentTypes: [.vCard]) { result in
             handleImport(result)

--- a/ContactManager/Views/DuplicatesView.swift
+++ b/ContactManager/Views/DuplicatesView.swift
@@ -1,0 +1,111 @@
+//
+//  DuplicatesView.swift
+//  ContactManager
+//
+//  A review sheet listing groups of likely-duplicate contacts, each with a
+//  Merge action. Detection is delegated to the pure `DuplicateFinder`; merging
+//  goes through `ContactStore`.
+//
+
+import SwiftData
+import SwiftUI
+
+struct DuplicatesView: View {
+    @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+
+    @Query(sort: [SortDescriptor(\Contact.lastName), SortDescriptor(\Contact.firstName)])
+    private var contacts: [Contact]
+
+    @State private var errorMessage: String?
+
+    private var store: ContactStore { ContactStore(context) }
+
+    private var duplicateGroups: [DuplicateGroup] {
+        DuplicateFinder.duplicateGroups(in: contacts).map { group in
+            DuplicateGroup(id: group.map(\.persistentModelID).hashValue, contacts: group)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Duplicates")
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+                .alert(
+                    "Couldn't Merge",
+                    isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } }),
+                    presenting: errorMessage
+                ) { _ in
+                    Button("OK", role: .cancel) {}
+                } message: { message in
+                    Text(message)
+                }
+        }
+        .frame(minWidth: 440, minHeight: 380)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if duplicateGroups.isEmpty {
+            ContentUnavailableView(
+                "No Duplicates",
+                systemImage: "person.crop.circle.badge.checkmark",
+                description: Text("Every contact looks unique.")
+            )
+        } else {
+            List {
+                ForEach(duplicateGroups) { group in
+                    Section {
+                        ForEach(group.contacts) { contact in
+                            DuplicateRow(contact: contact)
+                        }
+                    } header: {
+                        HStack {
+                            Text("^[\(group.contacts.count) possible duplicate](inflect: true)")
+                            Spacer()
+                            Button("Merge") { merge(group.contacts) }
+                                .buttonStyle(.borderedProminent)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func merge(_ group: [Contact]) {
+        do {
+            try store.merge(group)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct DuplicateGroup: Identifiable {
+    let id: Int
+    let contacts: [Contact]
+}
+
+private struct DuplicateRow: View {
+    let contact: Contact
+
+    var body: some View {
+        HStack(spacing: 10) {
+            AvatarView(contact: contact, size: 32)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(contact.fullName)
+                if let subtitle = contact.subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/ContactManager/Views/DuplicatesView.swift
+++ b/ContactManager/Views/DuplicatesView.swift
@@ -22,8 +22,10 @@ struct DuplicatesView: View {
     private var store: ContactStore { ContactStore(context) }
 
     private var duplicateGroups: [DuplicateGroup] {
-        DuplicateFinder.duplicateGroups(in: contacts).map { group in
-            DuplicateGroup(id: group.map(\.persistentModelID).hashValue, contacts: group)
+        // Each contact belongs to at most one group, so the first member's
+        // identifier is a stable, unique id for the group.
+        DuplicateFinder.duplicateGroups(in: contacts).compactMap { group in
+            group.first.map { DuplicateGroup(id: $0.persistentModelID, contacts: group) }
         }
     }
 
@@ -87,7 +89,7 @@ struct DuplicatesView: View {
 }
 
 private struct DuplicateGroup: Identifiable {
-    let id: Int
+    let id: PersistentIdentifier
     let contacts: [Contact]
 }
 

--- a/ContactManagerTests/ContactStoreTests.swift
+++ b/ContactManagerTests/ContactStoreTests.swift
@@ -198,6 +198,74 @@ struct ContactStoreTests {
         #expect(restored.primaryPhone == "+1 (555) 0100")
     }
 
+    // MARK: - Journey: merge duplicates
+
+    @Test func mergeUnionsFieldsAndKeepsEarliestAsPrimary() throws {
+        let older = try store.createContact()
+        older.firstName = "Ada"
+        try store.addField(.email, value: "ada@work.com", to: older)
+
+        let newer = try store.createContact()
+        newer.lastName = "Lovelace"
+        newer.company = "Analytical"
+        try store.addField(.email, value: "ada@work.com", to: newer) // duplicate email
+        try store.addField(.phone, value: "+1 (555) 0100", to: newer)
+        try context.save()
+
+        // Order in the argument shouldn't matter — earliest created wins.
+        let merged = try store.merge([newer, older])
+        #expect(merged.persistentModelID == older.persistentModelID)
+        #expect(try count(Contact.self) == 1)
+
+        #expect(merged.emails.map(\.value) == ["ada@work.com"]) // de-duplicated
+        #expect(merged.phones.map(\.value) == ["+1 (555) 0100"])
+        #expect(try count(ContactField.self) == 2)
+
+        // Empty fields filled from the other contact.
+        #expect(merged.firstName == "Ada")
+        #expect(merged.lastName == "Lovelace")
+        #expect(merged.company == "Analytical")
+    }
+
+    @Test func mergeUnionsGroupsAndAdoptsMissingPhoto() throws {
+        let work = try store.createGroup(named: "Work")
+        let friends = try store.createGroup(named: "Friends")
+
+        let primary = try store.createContact(in: work)
+        primary.firstName = "Ada"
+        let other = try store.createContact(in: friends)
+        other.firstName = "Ada"
+        try store.setPhotoData(Data([0x01, 0x02, 0x03]), on: other)
+        try context.save()
+
+        let merged = try store.merge([primary, other])
+        #expect(Set(merged.groups.map(\.name)) == ["Work", "Friends"])
+        #expect(merged.photoData != nil) // adopted from the other contact
+        #expect(try count(Contact.self) == 1)
+        #expect(try count(ContactGroup.self) == 2) // groups themselves survive
+    }
+
+    @Test func mergeDropsBlankFields() throws {
+        let withBlank = try store.createContact()
+        withBlank.firstName = "Ada"
+        try store.addField(.email, to: withBlank) // blank value
+
+        let withEmail = try store.createContact()
+        withEmail.firstName = "Ada"
+        try store.addField(.email, value: "ada@x.com", to: withEmail)
+        try context.save()
+
+        let merged = try store.merge([withBlank, withEmail])
+        #expect(merged.emails.map(\.value) == ["ada@x.com"])
+    }
+
+    @Test func mergingASingleContactIsANoOp() throws {
+        let contact = try store.createContact()
+        let result = try store.merge([contact])
+        #expect(result.persistentModelID == contact.persistentModelID)
+        #expect(try count(Contact.self) == 1)
+    }
+
     // MARK: - Journey: search across the store
 
     @Test func searchSpansNameCompanyEmailAndNotes() throws {

--- a/ContactManagerTests/DuplicateFinderTests.swift
+++ b/ContactManagerTests/DuplicateFinderTests.swift
@@ -1,0 +1,80 @@
+//
+//  DuplicateFinderTests.swift
+//  ContactManagerTests
+//
+//  Pure tests for duplicate detection: matching by email/phone/name, transitive
+//  grouping, and avoiding false positives.
+//
+
+@testable import ContactManager
+import Testing
+
+@MainActor
+struct DuplicateFinderTests {
+    private func contact(
+        first: String = "",
+        last: String = "",
+        emails: [String] = [],
+        phones: [String] = []
+    ) -> Contact {
+        let contact = Contact(firstName: first, lastName: last)
+        contact.fields =
+            emails.enumerated().map { ContactField(kind: .email, value: $1, sortIndex: $0) }
+                + phones.enumerated().map { ContactField(kind: .phone, value: $1, sortIndex: $0) }
+        return contact
+    }
+
+    @Test func matchesByEmailCaseInsensitively() {
+        let ada = contact(first: "Ada", emails: ["ada@x.com"])
+        let dupe = contact(first: "A.", emails: ["ADA@X.COM"])
+        let other = contact(first: "Bob", emails: ["bob@x.com"])
+
+        let groups = DuplicateFinder.duplicateGroups(in: [ada, dupe, other])
+        #expect(groups.count == 1)
+        #expect(groups.first?.count == 2)
+    }
+
+    @Test func matchesByPhoneIgnoringFormatting() {
+        let ada = contact(first: "Ada", phones: ["+1 (555) 123-4567"])
+        let dupe = contact(first: "A", phones: ["15551234567"])
+
+        #expect(DuplicateFinder.duplicateGroups(in: [ada, dupe]).count == 1)
+    }
+
+    @Test func matchesByFullNameCaseInsensitively() {
+        let ada = contact(first: "Ada", last: "Lovelace")
+        let dupe = contact(first: "ada", last: "lovelace")
+
+        #expect(DuplicateFinder.duplicateGroups(in: [ada, dupe]).count == 1)
+    }
+
+    @Test func groupsTransitiveMatchesIntoOne() {
+        // ada ~ middle by email; middle ~ tail by phone → all three in one group.
+        let ada = contact(first: "Ada", emails: ["shared@x.com"])
+        let middle = contact(first: "Middle", emails: ["shared@x.com"], phones: ["5551112222"])
+        let tail = contact(first: "Tail", phones: ["555 111 2222"])
+
+        let groups = DuplicateFinder.duplicateGroups(in: [ada, middle, tail])
+        #expect(groups.count == 1)
+        #expect(groups.first?.count == 3)
+    }
+
+    @Test func distinctContactsAreNotGrouped() {
+        let ada = contact(first: "Ada", last: "Lovelace", emails: ["ada@x.com"])
+        let alan = contact(first: "Alan", last: "Turing", emails: ["alan@y.com"])
+
+        #expect(DuplicateFinder.duplicateGroups(in: [ada, alan]).isEmpty)
+    }
+
+    @Test func shortPhoneFragmentsDoNotMatch() {
+        let ada = contact(first: "Ada", phones: ["123"])
+        let bob = contact(first: "Bob", phones: ["123"])
+
+        #expect(DuplicateFinder.duplicateGroups(in: [ada, bob]).isEmpty)
+    }
+
+    @Test func emptyOrSingleInputYieldsNoGroups() {
+        #expect(DuplicateFinder.duplicateGroups(in: []).isEmpty)
+        #expect(DuplicateFinder.duplicateGroups(in: [contact(first: "Solo")]).isEmpty)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ ContactManager/
 - Contact photos (downscaled on import) with an initials avatar fallback.
 - User-defined groups (sidebar create/rename/delete) with per-contact membership.
 - vCard 3.0 import and export (File ▸ Import/Export vCard…).
+- Duplicate detection & merge (Edit ▸ Find Duplicates…) — review and combine contacts that share an email, phone, or name.
 - Liquid Glass styling, glass-prominent actions, and smooth list/selection animations.
 - Sample contacts seeded on first launch.
 


### PR DESCRIPTION
## Summary

First of the new features (chosen as the starting point: pure, testable, high-value, and fully verifiable here). Finds contacts that look like duplicates and lets you review and merge them — handy after a vCard import.

## How it works
- **`DuplicateFinder`** (pure) — groups contacts that share a normalized **email**, **phone** (digits, ≥ 7), or **full name**, using union-find so matches are transitive (A↔B by email, B↔C by phone ⇒ one group). Favors recall since merges are user-reviewed.
- **`ContactStore.merge(_:)`** — merges a group into the **earliest-created** contact: fills empty scalar fields, unions + de-duplicates emails/phones (dropping blanks), unions group memberships, adopts a missing photo, deletes the rest. Saves atomically with rollback.
- **UI** — **Edit ▸ Find Duplicates…** (`⇧⌘D`) opens a review sheet listing each duplicate group with a **Merge** action; empty state when there are none.

## Tests (+11 → **43 across 5 suites**)
- `DuplicateFinderTests` (7): match by email/phone/name, transitive grouping, no false positives, short-phone fragments ignored, empty/single input.
- `ContactStoreTests` merge journeys (4): union+dedup fields & earliest-as-primary, union groups + adopt photo, drop blanks, single-contact no-op.

## Test plan
- [x] `swiftformat --lint` + `swiftlint --strict` clean
- [x] 43/43 tests pass
- [x] App builds and launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)