### PR TITLE
Add a trailing inspector pane

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		9506DFC07D9490AEDFB096EC /* ImageProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */; };
 		97E98BCB6784672DCB8C1625 /* VCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7276D515CA167FBF4C47299 /* VCard.swift */; };
 		A94AB327927F2F1FBBD81119 /* ContactGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFE362455F20C848F729EEE /* ContactGroup.swift */; };
+		C0D417119625FF46FA986771 /* ContactInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B570567907E6F1CD444A936 /* ContactInspectorView.swift */; };
 		C2A11D686722C70868435ACE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303A7F66E428BF3662142C0 /* SidebarView.swift */; };
 		E5EB465B5CE3964197D29ADF /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F82C8A388E97CC4F1106176 /* SampleData.swift */; };
 		FA63688E94483238D7C29FE9 /* DuplicateFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */; };
@@ -57,6 +58,7 @@
 		73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactDetailView.swift; sourceTree = "<group>"; };
 		7E7D5B554122CF852B0D825C /* VCardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTests.swift; sourceTree = "<group>"; };
 		833F1AF82CACF7B9E89BADCA /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		8B570567907E6F1CD444A936 /* ContactInspectorView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactInspectorView.swift; sourceTree = "<group>"; };
 		A7276D515CA167FBF4C47299 /* VCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCard.swift; sourceTree = "<group>"; };
 		B25751DDEC1515E341AF67F5 /* ContactField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactField.swift; sourceTree = "<group>"; };
 		B75D02267D3BC6C014143329 /* ContactModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactModelTests.swift; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 				2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */,
 				73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */,
 				54C373BD237429970D6A7C86 /* DuplicatesView.swift */,
+				8B570567907E6F1CD444A936 /* ContactInspectorView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -292,6 +295,7 @@
 				134F890B4875E8BF294A92B2 /* ContactStore.swift in Sources */,
 				827CF451F0B38B89C4469595 /* DuplicateFinder.swift in Sources */,
 				81F488BB8E6D53268C607C68 /* DuplicatesView.swift in Sources */,
+				C0D417119625FF46FA986771 /* ContactInspectorView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -2,9 +2,11 @@
 //  ContactDetailView.swift
 //  ContactManager
 //
-//  The detail column's editable form. Focuses on text fields and uses the
-//  ContactStore for mutations; the avatar, photo controls, quick-copy
-//  email/phone, and group membership live in the trailing inspector pane.
+//  The detail column's editable form. Text fields bind directly to the
+//  SwiftData model (autosaved by the context); add/remove field actions and
+//  the birthday toggle go through ContactStore. The avatar + photo controls,
+//  quick-copy email/phone, and group-membership toggles live in the
+//  trailing inspector pane.
 //
 
 import SwiftData

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -2,27 +2,23 @@
 //  ContactDetailView.swift
 //  ContactManager
 //
-//  Trailing column: an editable form bound directly to the SwiftData model.
-//  Edits autosave through the model context.
+//  The detail column's editable form. Focuses on text fields and uses the
+//  ContactStore for mutations; the avatar, photo controls, quick-copy
+//  email/phone, and group membership live in the trailing inspector pane.
 //
 
 import SwiftData
 import SwiftUI
-import UniformTypeIdentifiers
 
 struct ContactDetailView: View {
     @Environment(\.modelContext) private var context
     @Bindable var contact: Contact
-    @Query(sort: \ContactGroup.name) private var allGroups: [ContactGroup]
-    @State private var isImportingPhoto = false
     @State private var errorMessage: String?
 
     private var store: ContactStore { ContactStore(context) }
 
     var body: some View {
         Form {
-            header
-
             Section("Name") {
                 TextField("First Name", text: $contact.firstName)
                 TextField("Last Name", text: $contact.lastName)
@@ -51,17 +47,6 @@ struct ContactDetailView: View {
                 }
             }
 
-            Section("Groups") {
-                if allGroups.isEmpty {
-                    Text("No groups yet. Create one in the sidebar.")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(allGroups) { group in
-                        Toggle(group.displayName, isOn: membership(in: group))
-                    }
-                }
-            }
-
             Section("Notes") {
                 TextField("Notes", text: $contact.notes, axis: .vertical)
                     .lineLimit(3 ... 10)
@@ -77,56 +62,6 @@ struct ContactDetailView: View {
             Button("OK", role: .cancel) {}
         } message: { message in
             Text(message)
-        }
-    }
-
-    // MARK: - Header
-
-    private var header: some View {
-        Section {
-            HStack(spacing: 16) {
-                photoWell
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(contact.fullName)
-                        .font(.title2.weight(.semibold))
-                    let role = [contact.jobTitle, contact.company]
-                        .filter { !$0.isEmpty }
-                        .joined(separator: " · ")
-                    if !role.isEmpty {
-                        Text(role).foregroundStyle(.secondary)
-                    }
-                }
-                Spacer()
-            }
-            .padding(.vertical, 4)
-        }
-    }
-
-    /// Tappable avatar that offers choosing or removing a photo.
-    private var photoWell: some View {
-        Menu {
-            Button("Choose Photo…") { isImportingPhoto = true }
-            if contact.photoData != nil {
-                Button("Remove Photo", role: .destructive, action: removePhoto)
-            }
-        } label: {
-            AvatarView(contact: contact, size: 72)
-                .overlay(alignment: .bottomTrailing) {
-                    Image(systemName: "camera.circle.fill")
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(.white, .blue)
-                        .font(.system(size: 22))
-                        .background(.white, in: Circle())
-                }
-        }
-        .buttonStyle(.plain)
-        .help("Change Photo")
-        .accessibilityLabel("Change Photo")
-        .fileImporter(
-            isPresented: $isImportingPhoto,
-            allowedContentTypes: [.image]
-        ) { result in
-            handleImport(result)
         }
     }
 
@@ -153,48 +88,6 @@ struct ContactDetailView: View {
 
     // MARK: - Actions
 
-    private func handleImport(_ result: Result<URL, Error>) {
-        switch result {
-        case .failure(let error):
-            errorMessage = error.localizedDescription
-        case .success(let url):
-            // Read the picked file while its security scope is held, then hand
-            // the bytes off; downscaling happens off the main actor below.
-            let didAccess = url.startAccessingSecurityScopedResource()
-            defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
-            do {
-                let fileData = try Data(contentsOf: url)
-                processPhoto(fileData)
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-        }
-    }
-
-    private func processPhoto(_ fileData: Data) {
-        Task {
-            // Decode/downscale off the main actor so large images don't block UI.
-            let avatar = await Task.detached { ImageProcessing.avatarData(from: fileData) }.value
-            guard let avatar else {
-                errorMessage = "That file couldn't be read as an image."
-                return
-            }
-            do {
-                try store.setPhotoData(avatar, on: contact)
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-        }
-    }
-
-    private func removePhoto() {
-        do {
-            try store.setPhotoData(nil, on: contact)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
     private func addField(kind: FieldKind) {
         do {
             try store.addField(kind, to: contact)
@@ -209,21 +102,6 @@ struct ContactDetailView: View {
         } catch {
             errorMessage = error.localizedDescription
         }
-    }
-
-    // MARK: - Group membership
-
-    private func membership(in group: ContactGroup) -> Binding<Bool> {
-        Binding(
-            get: { contact.groups.contains { $0.persistentModelID == group.persistentModelID } },
-            set: { isMember in
-                do {
-                    try store.setMembership(of: contact, in: group, isMember: isMember)
-                } catch {
-                    errorMessage = error.localizedDescription
-                }
-            }
-        )
     }
 
     // MARK: - Birthday bindings

--- a/ContactManager/Views/ContactInspectorView.swift
+++ b/ContactManager/Views/ContactInspectorView.swift
@@ -163,28 +163,25 @@ struct ContactInspectorView: View {
         case .failure(let error):
             errorMessage = error.localizedDescription
         case .success(let url):
-            let didAccess = url.startAccessingSecurityScopedResource()
-            defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
-            do {
-                let fileData = try Data(contentsOf: url)
-                processPhoto(fileData)
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-        }
-    }
+            Task {
+                // Read the file and run the avatar pipeline off the main actor
+                // so a multi-megabyte photo can't hitch the UI.
+                let avatar: Data? = await Task.detached {
+                    let didAccess = url.startAccessingSecurityScopedResource()
+                    defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+                    guard let fileData = try? Data(contentsOf: url) else { return nil }
+                    return ImageProcessing.avatarData(from: fileData)
+                }.value
 
-    private func processPhoto(_ fileData: Data) {
-        Task {
-            let avatar = await Task.detached { ImageProcessing.avatarData(from: fileData) }.value
-            guard let avatar else {
-                errorMessage = "That file couldn't be read as an image."
-                return
-            }
-            do {
-                try store.setPhotoData(avatar, on: contact)
-            } catch {
-                errorMessage = error.localizedDescription
+                guard let avatar else {
+                    errorMessage = "That file couldn't be read as an image."
+                    return
+                }
+                do {
+                    try store.setPhotoData(avatar, on: contact)
+                } catch {
+                    errorMessage = error.localizedDescription
+                }
             }
         }
     }

--- a/ContactManager/Views/ContactInspectorView.swift
+++ b/ContactManager/Views/ContactInspectorView.swift
@@ -1,0 +1,199 @@
+//
+//  ContactInspectorView.swift
+//  ContactManager
+//
+//  Trailing inspector pane that shows a contact's identity (avatar + photo
+//  controls, name, role), quick-copy primary email/phone, and group
+//  membership toggles — keeping the detail form focused on text fields.
+//
+
+import AppKit
+import SwiftData
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ContactInspectorView: View {
+    @Environment(\.modelContext) private var context
+    @Bindable var contact: Contact
+    @Query(sort: \ContactGroup.name) private var allGroups: [ContactGroup]
+
+    @State private var isImportingPhoto = false
+    @State private var errorMessage: String?
+
+    private var store: ContactStore { ContactStore(context) }
+
+    var body: some View {
+        Form {
+            Section { identityHeader }
+
+            Section("Email") {
+                if let email = contact.primaryEmail {
+                    quickRow(email)
+                } else {
+                    Text("No email").foregroundStyle(.secondary)
+                }
+            }
+
+            Section("Phone") {
+                if let phone = contact.primaryPhone {
+                    quickRow(phone)
+                } else {
+                    Text("No phone").foregroundStyle(.secondary)
+                }
+            }
+
+            Section("Groups") {
+                if allGroups.isEmpty {
+                    Text("No groups yet. Create one in the sidebar.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(allGroups) { group in
+                        Toggle(group.displayName, isOn: membership(in: group))
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .alert(
+            "Couldn't Save Changes",
+            isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } }),
+            presenting: errorMessage
+        ) { _ in
+            Button("OK", role: .cancel) {}
+        } message: { message in
+            Text(message)
+        }
+    }
+
+    // MARK: - Identity
+
+    private var identityHeader: some View {
+        VStack(spacing: 10) {
+            photoWell
+            VStack(spacing: 2) {
+                Text(contact.fullName)
+                    .font(.title3.weight(.semibold))
+                    .multilineTextAlignment(.center)
+                let role = [contact.jobTitle, contact.company]
+                    .filter { !$0.isEmpty }
+                    .joined(separator: " · ")
+                if !role.isEmpty {
+                    Text(role)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 6)
+    }
+
+    /// Tappable avatar that offers choosing or removing a photo.
+    private var photoWell: some View {
+        Menu {
+            Button("Choose Photo…") { isImportingPhoto = true }
+            if contact.photoData != nil {
+                Button("Remove Photo", role: .destructive, action: removePhoto)
+            }
+        } label: {
+            AvatarView(contact: contact, size: 96)
+                .overlay(alignment: .bottomTrailing) {
+                    Image(systemName: "camera.circle.fill")
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(.white, .blue)
+                        .font(.system(size: 26))
+                        .background(.white, in: Circle())
+                }
+        }
+        .buttonStyle(.plain)
+        .help("Change Photo")
+        .accessibilityLabel("Change Photo")
+        .fileImporter(
+            isPresented: $isImportingPhoto,
+            allowedContentTypes: [.image]
+        ) { result in
+            handleImport(result)
+        }
+    }
+
+    // MARK: - Quick rows
+
+    private func quickRow(_ text: String) -> some View {
+        HStack {
+            Text(text)
+                .textSelection(.enabled)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+            Button {
+                copyToPasteboard(text)
+            } label: {
+                Image(systemName: "doc.on.doc")
+            }
+            .buttonStyle(.borderless)
+            .help("Copy")
+            .accessibilityLabel("Copy \(text)")
+        }
+    }
+
+    private func copyToPasteboard(_ value: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
+    }
+
+    // MARK: - Group membership
+
+    private func membership(in group: ContactGroup) -> Binding<Bool> {
+        Binding(
+            get: { contact.groups.contains { $0.persistentModelID == group.persistentModelID } },
+            set: { isMember in
+                do {
+                    try store.setMembership(of: contact, in: group, isMember: isMember)
+                } catch {
+                    errorMessage = error.localizedDescription
+                }
+            }
+        )
+    }
+
+    // MARK: - Photo actions
+
+    private func handleImport(_ result: Result<URL, Error>) {
+        switch result {
+        case .failure(let error):
+            errorMessage = error.localizedDescription
+        case .success(let url):
+            let didAccess = url.startAccessingSecurityScopedResource()
+            defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+            do {
+                let fileData = try Data(contentsOf: url)
+                processPhoto(fileData)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func processPhoto(_ fileData: Data) {
+        Task {
+            let avatar = await Task.detached { ImageProcessing.avatarData(from: fileData) }.value
+            guard let avatar else {
+                errorMessage = "That file couldn't be read as an image."
+                return
+            }
+            do {
+                try store.setPhotoData(avatar, on: contact)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func removePhoto() {
+        do {
+            try store.setPhotoData(nil, on: contact)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentView: View {
     @State private var errorMessage: String?
     @State private var searchText = ""
     @AppStorage("contactSortOrder") private var sortOrder: ContactSortOrder = .lastName
+    @AppStorage("contactInspectorVisible") private var isInspectorVisible = true
 
     @State private var isImportingVCard = false
     @State private var isExportingVCard = false
@@ -77,6 +78,30 @@ struct ContentView: View {
                     .id(selectedContact.persistentModelID)
             } else {
                 ContactPlaceholderView()
+            }
+        }
+        .inspector(isPresented: $isInspectorVisible) {
+            if let selectedContact {
+                ContactInspectorView(contact: selectedContact)
+                    .id(selectedContact.persistentModelID)
+                    .inspectorColumnWidth(min: 240, ideal: 300, max: 420)
+            } else {
+                ContentUnavailableView(
+                    "No Contact Selected",
+                    systemImage: "sidebar.right",
+                    description: Text("Select a contact to see its details here.")
+                )
+                .inspectorColumnWidth(min: 240, ideal: 300, max: 420)
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    isInspectorVisible.toggle()
+                } label: {
+                    Label("Inspector", systemImage: "sidebar.right")
+                }
+                .help("Toggle Inspector")
             }
         }
         .frame(minWidth: 840, minHeight: 480)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ContactManager/
 
 ## Features
 
-- Three-column native layout with a Liquid Glass toolbar.
+- Three-column native layout with a Liquid Glass toolbar and a toggleable trailing inspector pane.
 - Create, edit (inline, autosaving), and delete contacts.
 - Multiple labeled emails and phone numbers per contact (add/remove inline).
 - Company, job title, postal address, birthday, and free-form notes.


### PR DESCRIPTION
## Summary

Lays out the detail like a modern macOS Tahoe app: the photo / identity / groups move into a real **trailing inspector** column, and the detail form becomes a clean stack of text fields.

## Changes
- **`ContactInspectorView`** — large avatar + photo well (Choose / Remove Photo), name + role summary, primary **email/phone quick rows** with one-tap **Copy** buttons, and group-membership toggles.
- **`ContactDetailView`** slimmed to Name, Work, Email, Phone, Address, Birthday, Notes. The avatar header and Groups section move to the inspector; the navigation title handles the contact name.
- **`ContentView`** — `.inspector(isPresented:)` drives the trailing column; a toolbar button (`sidebar.right`) toggles it. Visibility is remembered with `@AppStorage("contactInspectorVisible")`. When no contact is selected the inspector shows a tidy empty state.

No behavior changes to the underlying data ops — every photo/membership action still routes through `ContactStore`, which is journey-tested.

## Test plan
- [x] 47/47 tests pass
- [x] `swiftformat --lint` + `swiftlint --strict` clean
- [x] App builds and launches
- [ ] Eyeball the inspector via `⌘R` and try the toggle (`sidebar.right` in the toolbar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)