### PR TITLE
Consolidate the trailing toolbar; tidy the sidebar

### DIFF
--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -13,6 +13,7 @@ struct ContactListView: View {
     let totalCount: Int
     @Binding var searchText: String
     @Binding var sortOrder: ContactSortOrder
+    @Binding var isInspectorVisible: Bool
     @Binding var selection: Contact?
     var addContact: () -> Void
     var deleteContact: (Contact) -> Void
@@ -37,22 +38,10 @@ struct ContactListView: View {
             if let selection { deleteContact(selection) }
         }
         .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button(action: addContact) {
-                    Label("New Contact", systemImage: "plus")
-                }
-                .help("New Contact")
-            }
-            ToolbarItem(placement: .destructiveAction) {
-                Button(role: .destructive) {
-                    if let selection { deleteContact(selection) }
-                } label: {
-                    Label("Delete Contact", systemImage: "trash")
-                }
-                .help("Delete Contact")
-                .disabled(selection == nil)
-            }
-            ToolbarItem {
+            // One cohesive trailing group so the buttons render together in
+            // a single Liquid Glass capsule. The destructive trash button is
+            // gone; `.onDeleteCommand` above still handles ⌫ on selection.
+            ToolbarItemGroup(placement: .primaryAction) {
                 Menu {
                     Picker("Sort By", selection: $sortOrder) {
                         ForEach(ContactSortOrder.allCases) { order in
@@ -64,6 +53,18 @@ struct ContactListView: View {
                     Label("Sort", systemImage: "arrow.up.arrow.down")
                 }
                 .help("Sort Order")
+
+                Button(action: addContact) {
+                    Label("New Contact", systemImage: "plus")
+                }
+                .help("New Contact")
+
+                Button {
+                    isInspectorVisible.toggle()
+                } label: {
+                    Label("Inspector", systemImage: "sidebar.right")
+                }
+                .help("Toggle Inspector")
             }
         }
     }

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -69,6 +69,7 @@ struct ContentView: View {
                 totalCount: scopedContacts.count,
                 searchText: $searchText,
                 sortOrder: $sortOrder,
+                isInspectorVisible: $isInspectorVisible,
                 selection: $selectedContact,
                 addContact: addContact,
                 deleteContact: deleteContact
@@ -93,16 +94,6 @@ struct ContentView: View {
                     description: Text("Select a contact to see its details here.")
                 )
                 .inspectorColumnWidth(min: 240, ideal: 300, max: 420)
-            }
-        }
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    isInspectorVisible.toggle()
-                } label: {
-                    Label("Inspector", systemImage: "sidebar.right")
-                }
-                .help("Toggle Inspector")
             }
         }
         .frame(minWidth: 840, minHeight: 480)

--- a/ContactManager/Views/SidebarView.swift
+++ b/ContactManager/Views/SidebarView.swift
@@ -33,8 +33,12 @@ struct SidebarView: View {
                     .tag(SidebarItem.allContacts)
             }
 
-            if !groups.isEmpty {
-                Section("Groups") {
+            Section("Groups") {
+                if groups.isEmpty {
+                    Text("Use the + button above to add one.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
                     ForEach(groups) { group in
                         Label(group.displayName, systemImage: "folder")
                             .badge(group.contacts.count)


### PR DESCRIPTION
## Summary

The toolbar was rendering as **two floating Liquid Glass capsules** (sidebar.right + trash + + on one side, sort + search on the other) — visually disconnected from the content column. And the sidebar showed only "All Contacts" with no visible header, feeling empty.

## Fix
- **One trailing toolbar group.** `ContactListView` now owns a single `ToolbarItemGroup(placement: .primaryAction)` containing **Sort → New Contact → Inspector toggle**. That collapses into one Liquid Glass capsule instead of two.
- **Dropped the destructive trash button.** `⌫` on a selected row still deletes (`.onDeleteCommand`); the toolbar reads cleaner without it.
- **`ContentView`** passes the inspector binding into the list view and drops its now-duplicate inspector `ToolbarItem`.
- **Sidebar** always shows both sections — *Contacts* (with `All Contacts`) and *Groups* — and renders a small "Use the + button above to add one." hint when no groups exist, so the column doesn't feel sparse on first launch.

## Test plan
- [x] 54/54 tests pass
- [x] `swiftformat --lint` + `swiftlint --strict` clean
- [x] App builds and launches
- [ ] Eyeball the toolbar + sidebar via `⌘R`

🤖 Generated with [Claude Code](https://claude.com/claude-code)