### PR TITLE
Move the search field to the toolbar's principal area

### DIFF
--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -36,7 +36,10 @@ struct ContactListView: View {
             max: LayoutMetrics.listMaxWidth
         )
         .animation(.smooth, value: sortOrder)
-        .searchable(text: $searchText, prompt: "Search Contacts")
+        // Place the search in the toolbar's principal (centered) area so the
+        // field anchors to the middle of the window instead of stretching
+        // across the trailing edge and overlapping the inspector pane.
+        .searchable(text: $searchText, placement: .toolbarPrincipal, prompt: "Search Contacts")
         .overlay { emptyState }
         .onDeleteCommand {
             if let selection { deleteContact(selection) }


### PR DESCRIPTION
## Summary

With the inspector open, the search field rendered at the trailing toolbar edge with a wide background that visually overlapped the inspector column. Place the field in `.toolbarPrincipal` so it anchors to the center of the toolbar instead.

## Why not the iOS-style minimize behavior?
macOS Tahoe has `searchToolbarBehavior(.minimize)` declared in the SDK — that would render the search as a magnifying-glass button that expands on click — but the `.minimize` case is explicitly `@available(macOS, unavailable)`. So `.toolbarPrincipal` placement is the cleanest macOS-compatible option.

## Test plan
- [x] 54/54 tests pass
- [x] `swiftformat --lint` + `swiftlint --strict` clean
- [x] App builds and launches
- [ ] Open the inspector and confirm the search bar no longer overlaps it

🤖 Generated with [Claude Code](https://claude.com/claude-code)