### PR TITLE
Accessibility pass: VoiceOver labels and combined row elements

### DIFF
--- a/ContactManager/Views/AvatarView.swift
+++ b/ContactManager/Views/AvatarView.swift
@@ -38,6 +38,10 @@ struct AvatarView: View {
         }
         .frame(width: size, height: size)
         .clipShape(Circle())
+        // The avatar is always shown next to the contact's name (in list
+        // rows, the detail header, duplicate rows); treating it as
+        // decorative keeps VoiceOver from announcing a redundant "Image".
+        .accessibilityHidden(true)
         .task(id: contact.photoData) {
             let decoded = contact.photoData.flatMap { NSImage(data: $0) }
             // Animate the actual swap, which happens when `photo` updates.

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -94,6 +94,7 @@ struct ContactDetailView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(contact.fullName)
                     .font(.title2.weight(.semibold))
+                    .accessibilityAddTraits(.isHeader)
                 let role = [contact.jobTitle, contact.company]
                     .filter { !$0.isEmpty }
                     .joined(separator: " · ")
@@ -152,13 +153,20 @@ struct ContactDetailView: View {
 
     private func quickRow(label: String, value: String) -> some View {
         HStack {
-            Text(label)
-                .foregroundStyle(.secondary)
-            Spacer()
-            Text(value)
-                .textSelection(.enabled)
-                .lineLimit(1)
-                .truncationMode(.middle)
+            // Combined so VoiceOver reads "Email, name@example.com" as a
+            // single element, instead of "Email" and "name@example.com"
+            // separately. The copy button stays its own focusable element.
+            HStack {
+                Text(label)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(value)
+                    .textSelection(.enabled)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .accessibilityElement(children: .combine)
+
             Button {
                 copyToPasteboard(value)
             } label: {
@@ -297,9 +305,14 @@ private struct ContactFieldRow: View {
             }
             .labelsHidden()
             .fixedSize()
+            // labelsHidden strips the picker's visible label, but VoiceOver
+            // then only reads the current selection — confusing without
+            // context. Restore an explicit a11y label per kind.
+            .accessibilityLabel(field.kind == .email ? "Email label" : "Phone label")
 
             TextField(placeholder, text: $field.value)
                 .textContentType(field.kind == .email ? .emailAddress : .telephoneNumber)
+                .accessibilityLabel(field.kind == .email ? "Email address" : "Phone number")
         }
     }
 

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -103,5 +103,8 @@ struct ContactRow: View {
             }
         }
         .padding(.vertical, 2)
+        // Read the row as a single VoiceOver element ("John Smith, name@example.com")
+        // rather than three (avatar + name + subtitle).
+        .accessibilityElement(children: .combine)
     }
 }

--- a/ContactManager/Views/DuplicatesView.swift
+++ b/ContactManager/Views/DuplicatesView.swift
@@ -72,6 +72,9 @@ struct DuplicatesView: View {
                             Spacer()
                             Button("Merge") { merge(group.contacts) }
                                 .buttonStyle(.borderedProminent)
+                                .accessibilityLabel(
+                                    "Merge \(group.contacts.count) duplicate contacts"
+                                )
                         }
                     }
                 }
@@ -109,5 +112,6 @@ private struct DuplicateRow: View {
             }
         }
         .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
     }
 }

--- a/ContactManager/Views/DuplicatesView.swift
+++ b/ContactManager/Views/DuplicatesView.swift
@@ -73,7 +73,7 @@ struct DuplicatesView: View {
                             Button("Merge") { merge(group.contacts) }
                                 .buttonStyle(.borderedProminent)
                                 .accessibilityLabel(
-                                    "Merge \(group.contacts.count) duplicate contacts"
+                                    Text("Merge ^[\(group.contacts.count) duplicate contact](inflect: true)")
                                 )
                         }
                     }


### PR DESCRIPTION
## Summary
- VoiceOver was reading each row in the contact list, duplicates sheet, and the quick-info section of the detail view as 3–4 separate fragments. Combine them into one element so the announcement reads naturally ("John Smith, name@example.com").
- `AvatarView` is now `.accessibilityHidden(true)` — every place it appears, the contact's name is right next to it, so the image is decorative.
- `ContactFieldRow`'s label picker had `.labelsHidden()`, which made VoiceOver only announce the current selection. Restore explicit labels per kind ("Email label" / "Phone label") and label the value field the same way.
- The merge button in the duplicates sheet now reads "Merge N duplicate contacts" instead of bare "Merge".
- Mark the contact's name in the detail header as a heading.

This is the **B — Accessibility pass** item from the post-rewrite roadmap. Scope is intentionally code-side only; visual verification with VoiceOver (⌘F5) is up to you.

## Test plan
- [ ] `make check` (format + lint + 54/54 tests) green
- [ ] App launches; UI looks unchanged
- [ ] Turn on VoiceOver (⌘F5), navigate the contact list — each row announces as one element with name + subtitle
- [ ] Navigate the detail view — the email and phone label pickers announce their purpose, the merge button reads its count
- [ ] Open the Duplicates sheet — each row reads as one element, the Merge button announces the count

🤖 Generated with [Claude Code](https://claude.com/claude-code)