### PR TITLE
Import from macOS Contacts

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		15AD8E34CC4EF4BC81F8A159 /* ContactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */; };
 		23BF1F338E4C813308B5DEE2 /* ContactField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25751DDEC1515E341AF67F5 /* ContactField.swift */; };
 		2B9D4C628CAAECD10F00F5E2 /* LayoutMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734D363DD0CB0BAA7AE9460B /* LayoutMetrics.swift */; };
+		3076738411F8C3FA073D1BE0 /* ContactsBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */; };
 		4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */; };
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
 		4EC36757044377406665E53B /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */; };
@@ -30,6 +31,7 @@
 		A94AB327927F2F1FBBD81119 /* ContactGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFE362455F20C848F729EEE /* ContactGroup.swift */; };
 		B1393B1344A7D64B52C4B3D4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9795992CBF553603FD37928 /* SettingsView.swift */; };
 		C2A11D686722C70868435ACE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303A7F66E428BF3662142C0 /* SidebarView.swift */; };
+		CE55AD882E6631A9541B6106 /* ContactsBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */; };
 		E5EB465B5CE3964197D29ADF /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F82C8A388E97CC4F1106176 /* SampleData.swift */; };
 		ECB7FDD8D0C3091EA0D42917 /* UndoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DCAF444714BC3726B212C4 /* UndoTests.swift */; };
 		FA63688E94483238D7C29FE9 /* DuplicateFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */; };
@@ -51,6 +53,7 @@
 		08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactListView.swift; sourceTree = "<group>"; };
 		0B27567532AC1A51FF4CC13A /* ContactQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactQuery.swift; sourceTree = "<group>"; };
 		0F82C8A388E97CC4F1106176 /* SampleData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SampleData.swift; sourceTree = "<group>"; };
+		2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactsBridge.swift; sourceTree = "<group>"; };
 		2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardDocument.swift; sourceTree = "<group>"; };
 		3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinderTests.swift; sourceTree = "<group>"; };
@@ -61,6 +64,7 @@
 		6303A7F66E428BF3662142C0 /* SidebarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		734D363DD0CB0BAA7AE9460B /* LayoutMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LayoutMetrics.swift; sourceTree = "<group>"; };
 		73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactDetailView.swift; sourceTree = "<group>"; };
+		7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactsBridgeTests.swift; sourceTree = "<group>"; };
 		7E7D5B554122CF852B0D825C /* VCardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTests.swift; sourceTree = "<group>"; };
 		833F1AF82CACF7B9E89BADCA /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		A7276D515CA167FBF4C47299 /* VCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCard.swift; sourceTree = "<group>"; };
@@ -126,6 +130,7 @@
 				A7276D515CA167FBF4C47299 /* VCard.swift */,
 				2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */,
 				61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */,
+				2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -185,6 +190,7 @@
 				03763AB80D45F026EC585490 /* ContactStoreTests.swift */,
 				3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */,
 				C7DCAF444714BC3726B212C4 /* UndoTests.swift */,
+				7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -307,6 +313,7 @@
 				2B9D4C628CAAECD10F00F5E2 /* LayoutMetrics.swift in Sources */,
 				B1393B1344A7D64B52C4B3D4 /* SettingsView.swift in Sources */,
 				4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */,
+				CE55AD882E6631A9541B6106 /* ContactsBridge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -320,6 +327,7 @@
 				0ABBB9962C4AC14A077728FF /* ContactStoreTests.swift in Sources */,
 				FA63688E94483238D7C29FE9 /* DuplicateFinderTests.swift in Sources */,
 				ECB7FDD8D0C3091EA0D42917 /* UndoTests.swift in Sources */,
+				3076738411F8C3FA073D1BE0 /* ContactsBridgeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -446,6 +454,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_NSContactsUsageDescription = "ContactManager imports contacts from your system Contacts when you choose Import from Contacts…";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Scott Densmore. All rights reserved.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -481,6 +490,7 @@
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_NSContactsUsageDescription = "ContactManager imports contacts from your system Contacts when you choose Import from Contacts…";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Scott Densmore. All rights reserved.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -60,6 +60,10 @@ struct ContactManagerApp: App {
                 .keyboardShortcut("d", modifiers: [.command, .shift])
             }
             CommandGroup(replacing: .importExport) {
+                Button("Import from Contacts…") {
+                    NotificationCenter.default.post(name: .importSystemContactsRequested, object: nil)
+                }
+                .keyboardShortcut("m", modifiers: [.command, .shift])
                 Button("Import vCard…") {
                     NotificationCenter.default.post(name: .importVCardRequested, object: nil)
                 }
@@ -167,6 +171,7 @@ extension Notification.Name {
     /// Posted by menu commands; observed by `ContentView`.
     static let newContactRequested = Notification.Name("ContactManager.newContactRequested")
     static let importVCardRequested = Notification.Name("ContactManager.importVCardRequested")
+    static let importSystemContactsRequested = Notification.Name("ContactManager.importSystemContactsRequested")
     static let exportVCardRequested = Notification.Name("ContactManager.exportVCardRequested")
     static let findDuplicatesRequested = Notification.Name("ContactManager.findDuplicatesRequested")
 }

--- a/ContactManager/Support/ContactsBridge.swift
+++ b/ContactManager/Support/ContactsBridge.swift
@@ -57,7 +57,10 @@ enum ContactsBridge {
 
     private static func ensureAccess(store: CNContactStore) async throws {
         switch CNContactStore.authorizationStatus(for: .contacts) {
-        case .authorized: return
+        // `.limited` (macOS 15+) means the user granted access to a subset
+        // of contacts via the system picker; `enumerateContacts` will
+        // return only that subset, which is exactly the behavior we want.
+        case .authorized, .limited: return
         case .denied: throw AccessError.denied
         case .restricted: throw AccessError.restricted
         case .notDetermined:

--- a/ContactManager/Support/ContactsBridge.swift
+++ b/ContactManager/Support/ContactsBridge.swift
@@ -1,0 +1,120 @@
+//
+//  ContactsBridge.swift
+//  ContactManager
+//
+//  Reads contacts from the user's macOS Contacts (Address Book) store via
+//  the `Contacts` framework and maps them to our own `ParsedContact`
+//  values so import flows through the same path as vCard import.
+//
+//  The fetch + mapping pipeline is pure (no SwiftData), so it's testable
+//  with `CNMutableContact` fixtures.
+//
+
+import Contacts
+import Foundation
+
+enum ContactsBridge {
+    /// Errors surfaced to the user. Anything else (e.g. an unexpected
+    /// `CNError`) is rethrown so the caller can show its message.
+    enum AccessError: LocalizedError {
+        case denied
+        case restricted
+
+        var errorDescription: String? {
+            switch self {
+            case .denied:
+                "ContactManager doesn't have permission to read your Contacts. " +
+                    "Enable it in System Settings ▸ Privacy & Security ▸ Contacts."
+            case .restricted:
+                "Access to Contacts is restricted on this Mac."
+            }
+        }
+    }
+
+    /// Keys we need from each unified contact. Listed once so a future
+    /// addition (e.g. notes) is a one-line change.
+    private static let keysToFetch: [CNKeyDescriptor] = [
+        CNContactGivenNameKey, CNContactFamilyNameKey,
+        CNContactOrganizationNameKey, CNContactJobTitleKey,
+        CNContactEmailAddressesKey, CNContactPhoneNumbersKey,
+        CNContactPostalAddressesKey, CNContactBirthdayKey,
+        CNContactImageDataKey,
+    ].map { $0 as CNKeyDescriptor }
+
+    /// Requests permission if needed and returns the unified contact list
+    /// mapped to `ParsedContact`. Safe to call off the main actor.
+    static func fetchAllParsed() async throws -> [ParsedContact] {
+        let store = CNContactStore()
+        try await ensureAccess(store: store)
+
+        let request = CNContactFetchRequest(keysToFetch: keysToFetch)
+        var parsed: [ParsedContact] = []
+        try store.enumerateContacts(with: request) { cnContact, _ in
+            parsed.append(self.parsed(from: cnContact))
+        }
+        return parsed
+    }
+
+    private static func ensureAccess(store: CNContactStore) async throws {
+        switch CNContactStore.authorizationStatus(for: .contacts) {
+        case .authorized: return
+        case .denied: throw AccessError.denied
+        case .restricted: throw AccessError.restricted
+        case .notDetermined:
+            let granted = try await store.requestAccess(for: .contacts)
+            if !granted { throw AccessError.denied }
+        @unknown default:
+            throw AccessError.denied
+        }
+    }
+
+    // MARK: - Mapping (pure)
+
+    /// Translates a `CNContact` to our `ParsedContact`. Visible for tests.
+    static func parsed(from cnContact: CNContact) -> ParsedContact {
+        var parsed = ParsedContact(
+            firstName: cnContact.givenName,
+            lastName: cnContact.familyName,
+            company: cnContact.organizationName,
+            jobTitle: cnContact.jobTitle
+        )
+        if let birthday = cnContact.birthday {
+            parsed.birthday = Calendar(identifier: .gregorian).date(from: birthday)
+        }
+        if let primary = cnContact.postalAddresses.first?.value {
+            parsed.street = primary.street
+            parsed.city = primary.city
+            parsed.state = primary.state
+            parsed.postalCode = primary.postalCode
+            parsed.country = primary.country
+        }
+        parsed.emails = cnContact.emailAddresses.map { entry in
+            (label: emailLabel(from: entry.label), value: entry.value as String)
+        }
+        parsed.phones = cnContact.phoneNumbers.map { entry in
+            (label: phoneLabel(from: entry.label), value: entry.value.stringValue)
+        }
+        parsed.photoData = cnContact.imageData
+        return parsed
+    }
+
+    private static func emailLabel(from raw: String?) -> FieldLabel {
+        switch raw {
+        case CNLabelHome: .home
+        case CNLabelWork: .work
+        case CNLabelOther: .other
+        default: .other
+        }
+    }
+
+    private static func phoneLabel(from raw: String?) -> FieldLabel {
+        switch raw {
+        case CNLabelPhoneNumberMobile, CNLabelPhoneNumberiPhone: .mobile
+        case CNLabelPhoneNumberMain: .main
+        case CNLabelHome: .home
+        case CNLabelWork: .work
+        case CNLabelPhoneNumberOtherFax, CNLabelOther: .other
+        default: .other
+        }
+    }
+}

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -131,6 +131,9 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .findDuplicatesRequested)) { _ in
             showingDuplicates = true
         }
+        .onReceive(NotificationCenter.default.publisher(for: .importSystemContactsRequested)) { _ in
+            importSystemContacts()
+        }
         .sheet(isPresented: $showingDuplicates) {
             DuplicatesView()
         }
@@ -205,6 +208,33 @@ struct ContentView: View {
             if wasSelected { sidebarSelection = .allContacts }
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - System Contacts import
+
+    private func importSystemContacts() {
+        Task {
+            // Permission prompt + fetch + mapping all run off the main actor;
+            // only the final insert hops back here.
+            let parsed: [ParsedContact]
+            do {
+                parsed = try await Task.detached(priority: .userInitiated) {
+                    try await ContactsBridge.fetchAllParsed()
+                }.value
+            } catch {
+                errorMessage = error.localizedDescription
+                return
+            }
+            guard !parsed.isEmpty else {
+                errorMessage = "No contacts were found in your system Contacts."
+                return
+            }
+            do {
+                try store.importContacts(parsed)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 

--- a/ContactManagerTests/ContactsBridgeTests.swift
+++ b/ContactManagerTests/ContactsBridgeTests.swift
@@ -1,0 +1,115 @@
+//
+//  ContactsBridgeTests.swift
+//  ContactManagerTests
+//
+//  Tests for the pure `CNContact` → `ParsedContact` mapping. The fetch
+//  itself isn't tested here — it needs a real address book + user
+//  permission, neither of which we have in CI.
+//
+
+@testable import ContactManager
+import Contacts
+import Foundation
+import Testing
+
+struct ContactsBridgeTests {
+    @Test func mapsTopLevelFields() {
+        let cn = CNMutableContact()
+        cn.givenName = "Ada"
+        cn.familyName = "Lovelace"
+        cn.organizationName = "Analytical Engine Co."
+        cn.jobTitle = "Mathematician"
+
+        let parsed = ContactsBridge.parsed(from: cn)
+        #expect(parsed.firstName == "Ada")
+        #expect(parsed.lastName == "Lovelace")
+        #expect(parsed.company == "Analytical Engine Co.")
+        #expect(parsed.jobTitle == "Mathematician")
+    }
+
+    @Test func mapsEmailsWithLabels() {
+        let cn = CNMutableContact()
+        cn.emailAddresses = [
+            CNLabeledValue(label: CNLabelHome, value: "ada@home.test" as NSString),
+            CNLabeledValue(label: CNLabelWork, value: "ada@work.test" as NSString),
+            CNLabeledValue(label: "iCloud", value: "ada@icloud.test" as NSString),
+        ]
+
+        let parsed = ContactsBridge.parsed(from: cn)
+        #expect(parsed.emails.count == 3)
+        #expect(parsed.emails[0].label == .home)
+        #expect(parsed.emails[0].value == "ada@home.test")
+        #expect(parsed.emails[1].label == .work)
+        // Unknown label falls back to .other rather than dropping the value.
+        #expect(parsed.emails[2].label == .other)
+        #expect(parsed.emails[2].value == "ada@icloud.test")
+    }
+
+    @Test func mapsPhonesWithSpecializedLabels() {
+        let cn = CNMutableContact()
+        cn.phoneNumbers = [
+            CNLabeledValue(
+                label: CNLabelPhoneNumberMobile,
+                value: CNPhoneNumber(stringValue: "+1 555 0100")
+            ),
+            CNLabeledValue(
+                label: CNLabelPhoneNumberiPhone,
+                value: CNPhoneNumber(stringValue: "+1 555 0101")
+            ),
+            CNLabeledValue(
+                label: CNLabelPhoneNumberMain,
+                value: CNPhoneNumber(stringValue: "+1 555 0102")
+            ),
+        ]
+
+        let parsed = ContactsBridge.parsed(from: cn)
+        #expect(parsed.phones.map(\.label) == [.mobile, .mobile, .main])
+        #expect(parsed.phones.map(\.value) == ["+1 555 0100", "+1 555 0101", "+1 555 0102"])
+    }
+
+    @Test func mapsFirstPostalAddress() {
+        let cn = CNMutableContact()
+        let address = CNMutablePostalAddress()
+        address.street = "12 Mayfair"
+        address.city = "London"
+        address.state = ""
+        address.postalCode = "W1"
+        address.country = "United Kingdom"
+        cn.postalAddresses = [CNLabeledValue(label: CNLabelHome, value: address)]
+
+        let parsed = ContactsBridge.parsed(from: cn)
+        #expect(parsed.street == "12 Mayfair")
+        #expect(parsed.city == "London")
+        #expect(parsed.postalCode == "W1")
+        #expect(parsed.country == "United Kingdom")
+    }
+
+    @Test func mapsBirthdayToGregorianDate() throws {
+        let cn = CNMutableContact()
+        cn.birthday = DateComponents(year: 1815, month: 12, day: 10)
+        let parsed = ContactsBridge.parsed(from: cn)
+        let birthday = try #require(parsed.birthday)
+        let parts = Calendar(identifier: .gregorian)
+            .dateComponents([.year, .month, .day], from: birthday)
+        #expect(parts.year == 1815)
+        #expect(parts.month == 12)
+        #expect(parts.day == 10)
+    }
+
+    @Test func passesThroughPhotoData() {
+        let cn = CNMutableContact()
+        let payload = Data([0x89, 0x50, 0x4E, 0x47])
+        cn.imageData = payload
+        let parsed = ContactsBridge.parsed(from: cn)
+        #expect(parsed.photoData == payload)
+    }
+
+    @Test func handlesEmptyContact() {
+        let parsed = ContactsBridge.parsed(from: CNMutableContact())
+        #expect(parsed.firstName.isEmpty)
+        #expect(parsed.emails.isEmpty)
+        #expect(parsed.phones.isEmpty)
+        #expect(parsed.birthday == nil)
+        #expect(parsed.photoData == nil)
+    }
+}

--- a/ContactManagerTests/ContactsBridgeTests.swift
+++ b/ContactManagerTests/ContactsBridgeTests.swift
@@ -14,13 +14,13 @@ import Testing
 
 struct ContactsBridgeTests {
     @Test func mapsTopLevelFields() {
-        let cn = CNMutableContact()
-        cn.givenName = "Ada"
-        cn.familyName = "Lovelace"
-        cn.organizationName = "Analytical Engine Co."
-        cn.jobTitle = "Mathematician"
+        let cnContact = CNMutableContact()
+        cnContact.givenName = "Ada"
+        cnContact.familyName = "Lovelace"
+        cnContact.organizationName = "Analytical Engine Co."
+        cnContact.jobTitle = "Mathematician"
 
-        let parsed = ContactsBridge.parsed(from: cn)
+        let parsed = ContactsBridge.parsed(from: cnContact)
         #expect(parsed.firstName == "Ada")
         #expect(parsed.lastName == "Lovelace")
         #expect(parsed.company == "Analytical Engine Co.")
@@ -28,14 +28,14 @@ struct ContactsBridgeTests {
     }
 
     @Test func mapsEmailsWithLabels() {
-        let cn = CNMutableContact()
-        cn.emailAddresses = [
+        let cnContact = CNMutableContact()
+        cnContact.emailAddresses = [
             CNLabeledValue(label: CNLabelHome, value: "ada@home.test" as NSString),
             CNLabeledValue(label: CNLabelWork, value: "ada@work.test" as NSString),
             CNLabeledValue(label: "iCloud", value: "ada@icloud.test" as NSString),
         ]
 
-        let parsed = ContactsBridge.parsed(from: cn)
+        let parsed = ContactsBridge.parsed(from: cnContact)
         #expect(parsed.emails.count == 3)
         #expect(parsed.emails[0].label == .home)
         #expect(parsed.emails[0].value == "ada@home.test")
@@ -46,8 +46,8 @@ struct ContactsBridgeTests {
     }
 
     @Test func mapsPhonesWithSpecializedLabels() {
-        let cn = CNMutableContact()
-        cn.phoneNumbers = [
+        let cnContact = CNMutableContact()
+        cnContact.phoneNumbers = [
             CNLabeledValue(
                 label: CNLabelPhoneNumberMobile,
                 value: CNPhoneNumber(stringValue: "+1 555 0100")
@@ -62,32 +62,33 @@ struct ContactsBridgeTests {
             ),
         ]
 
-        let parsed = ContactsBridge.parsed(from: cn)
+        let parsed = ContactsBridge.parsed(from: cnContact)
         #expect(parsed.phones.map(\.label) == [.mobile, .mobile, .main])
         #expect(parsed.phones.map(\.value) == ["+1 555 0100", "+1 555 0101", "+1 555 0102"])
     }
 
     @Test func mapsFirstPostalAddress() {
-        let cn = CNMutableContact()
+        let cnContact = CNMutableContact()
         let address = CNMutablePostalAddress()
-        address.street = "12 Mayfair"
-        address.city = "London"
-        address.state = ""
-        address.postalCode = "W1"
-        address.country = "United Kingdom"
-        cn.postalAddresses = [CNLabeledValue(label: CNLabelHome, value: address)]
+        address.street = "1 Infinite Loop"
+        address.city = "Cupertino"
+        address.state = "CA"
+        address.postalCode = "95014"
+        address.country = "United States"
+        cnContact.postalAddresses = [CNLabeledValue(label: CNLabelWork, value: address)]
 
-        let parsed = ContactsBridge.parsed(from: cn)
-        #expect(parsed.street == "12 Mayfair")
-        #expect(parsed.city == "London")
-        #expect(parsed.postalCode == "W1")
-        #expect(parsed.country == "United Kingdom")
+        let parsed = ContactsBridge.parsed(from: cnContact)
+        #expect(parsed.street == "1 Infinite Loop")
+        #expect(parsed.city == "Cupertino")
+        #expect(parsed.state == "CA")
+        #expect(parsed.postalCode == "95014")
+        #expect(parsed.country == "United States")
     }
 
     @Test func mapsBirthdayToGregorianDate() throws {
-        let cn = CNMutableContact()
-        cn.birthday = DateComponents(year: 1815, month: 12, day: 10)
-        let parsed = ContactsBridge.parsed(from: cn)
+        let cnContact = CNMutableContact()
+        cnContact.birthday = DateComponents(year: 1815, month: 12, day: 10)
+        let parsed = ContactsBridge.parsed(from: cnContact)
         let birthday = try #require(parsed.birthday)
         let parts = Calendar(identifier: .gregorian)
             .dateComponents([.year, .month, .day], from: birthday)
@@ -97,10 +98,10 @@ struct ContactsBridgeTests {
     }
 
     @Test func passesThroughPhotoData() {
-        let cn = CNMutableContact()
+        let cnContact = CNMutableContact()
         let payload = Data([0x89, 0x50, 0x4E, 0x47])
-        cn.imageData = payload
-        let parsed = ContactsBridge.parsed(from: cn)
+        cnContact.imageData = payload
+        let parsed = ContactsBridge.parsed(from: cnContact)
         #expect(parsed.photoData == payload)
     }
 

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ build: ## Build the app
 test: ## Run the test suite
 	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DESTINATION)' test
 
-lint: ## Lint sources with SwiftLint
-	swiftlint lint --quiet
+lint: ## Lint sources with SwiftLint (strict — matches CI; warnings fail)
+	swiftlint lint --quiet --strict
 
 lint-fix: ## Autocorrect SwiftLint violations where possible
 	swiftlint --fix


### PR DESCRIPTION
## Summary
- Adds **File ▸ Import from Contacts… (⌘⇧M)**: reads the user's system address book via the `Contacts` framework and pipes the results through the same `ContactStore.importContacts` path used for vCard import. So a fresh install no longer starts empty if you already have contacts on the Mac. This is the **E — macOS Contacts framework bridge** item from the post-rewrite roadmap; scoped to one-way import only.
- New `ContactsBridge` (Support) wraps `CNContactStore`: requests permission when `notDetermined`, fetches all unified contacts, maps each `CNContact` to a `ParsedContact`. Mapping is pure and testable.
- Label translation: `CNLabelPhoneNumberMobile` / `iPhone` → `.mobile`; unknown labels fall back to `.other` instead of dropping the value.
- `NSContactsUsageDescription` added via `INFOPLIST_KEY_*` build settings (project uses a generated Info.plist). App isn't sandboxed today so no `personal-information.addressbook` entitlement is needed.
- Permission + fetch + mapping run on a detached `userInitiated` Task; only the insert hops back to the main actor.
- 7 new `ContactsBridgeTests` cover the pure mapping with `CNMutableContact` fixtures. Total: **61 tests across 7 suites** (was 54/6).

### Not in this PR
- Notes are skipped because reading them requires a separate entitlement on macOS 13+.
- Write-back to the system store (export to Contacts) — separate PR if you want it.

## Test plan
- [ ] `make check` (format + lint + 61 tests) green
- [ ] App launches; **File ▸ Import from Contacts…** appears with ⌘⇧M
- [ ] First invocation triggers the system permission prompt with the usage string
- [ ] After granting, contacts from the system store appear in the list, with the right labels for emails/phones
- [ ] Denying access → error alert points the user to System Settings
- [ ] Re-running after the import doesn't crash (no dedup yet — users can run Find Duplicates… afterwards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)