### PR TITLE
Drag and drop: contact → Finder, vCard → list, image → avatar

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -13,8 +13,10 @@
 		14C13B18A26BC44F834915C1 /* ContactModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75D02267D3BC6C014143329 /* ContactModelTests.swift */; };
 		14E0C9EBEF8212F3F9B2777D /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51E6728EF90B1D2BF8EA5AE /* Contact.swift */; };
 		15AD8E34CC4EF4BC81F8A159 /* ContactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */; };
+		1BE87CA3661CF6390FF9EEC4 /* VCardTransferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F733D535CFC76FA07FB61E /* VCardTransferTests.swift */; };
 		23BF1F338E4C813308B5DEE2 /* ContactField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25751DDEC1515E341AF67F5 /* ContactField.swift */; };
 		2B9D4C628CAAECD10F00F5E2 /* LayoutMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734D363DD0CB0BAA7AE9460B /* LayoutMetrics.swift */; };
+		2EB13805320DA225F70D08F3 /* VCardTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */; };
 		3076738411F8C3FA073D1BE0 /* ContactsBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */; };
 		4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */; };
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
@@ -68,6 +70,7 @@
 		7E7D5B554122CF852B0D825C /* VCardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTests.swift; sourceTree = "<group>"; };
 		833F1AF82CACF7B9E89BADCA /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		A7276D515CA167FBF4C47299 /* VCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCard.swift; sourceTree = "<group>"; };
+		B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTransfer.swift; sourceTree = "<group>"; };
 		B25751DDEC1515E341AF67F5 /* ContactField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactField.swift; sourceTree = "<group>"; };
 		B75D02267D3BC6C014143329 /* ContactModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactModelTests.swift; sourceTree = "<group>"; };
 		C7DCAF444714BC3726B212C4 /* UndoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UndoTests.swift; sourceTree = "<group>"; };
@@ -80,6 +83,7 @@
 		F51E6728EF90B1D2BF8EA5AE /* Contact.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Contact.swift; sourceTree = "<group>"; };
 		F76507F3A1E2222FB64D7F31 /* ImageProcessing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessing.swift; sourceTree = "<group>"; };
 		F9795992CBF553603FD37928 /* SettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		F9F733D535CFC76FA07FB61E /* VCardTransferTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTransferTests.swift; sourceTree = "<group>"; };
 		FAFE362455F20C848F729EEE /* ContactGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactGroup.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -131,6 +135,7 @@
 				2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */,
 				61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */,
 				2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */,
+				B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -191,6 +196,7 @@
 				3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */,
 				C7DCAF444714BC3726B212C4 /* UndoTests.swift */,
 				7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */,
+				F9F733D535CFC76FA07FB61E /* VCardTransferTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -314,6 +320,7 @@
 				B1393B1344A7D64B52C4B3D4 /* SettingsView.swift in Sources */,
 				4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */,
 				CE55AD882E6631A9541B6106 /* ContactsBridge.swift in Sources */,
+				2EB13805320DA225F70D08F3 /* VCardTransfer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -328,6 +335,7 @@
 				FA63688E94483238D7C29FE9 /* DuplicateFinderTests.swift in Sources */,
 				ECB7FDD8D0C3091EA0D42917 /* UndoTests.swift in Sources */,
 				3076738411F8C3FA073D1BE0 /* ContactsBridgeTests.swift in Sources */,
+				1BE87CA3661CF6390FF9EEC4 /* VCardTransferTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Support/VCardTransfer.swift
+++ b/ContactManager/Support/VCardTransfer.swift
@@ -1,0 +1,50 @@
+//
+//  VCardTransfer.swift
+//  ContactManager
+//
+//  A `Transferable` wrapping a single contact's vCard payload + suggested
+//  filename. Dragging a row hands one of these to Finder, which receives
+//  a `.vcf` file named after the contact.
+//
+
+import Foundation
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct VCardTransfer: Transferable {
+    /// File-system-safe stem, without the `.vcf` extension. Computed by
+    /// `suggestedFilename(for:)` so the sanitization is testable.
+    let suggestedName: String
+    /// The vCard 3.0 text the file will contain.
+    let text: String
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(exportedContentType: .vCard) { transfer in
+            // Write to a per-drag tempdir so multiple drags don't collide on
+            // a shared filename. Finder copies the file out by the time the
+            // OS clears the temp dir at next launch.
+            let directory = FileManager.default.temporaryDirectory
+                .appending(path: "vcard-drag-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(
+                at: directory, withIntermediateDirectories: true
+            )
+            let url = directory.appending(path: "\(transfer.suggestedName).vcf")
+            try Data(transfer.text.utf8).write(to: url)
+            return SentTransferredFile(url, allowAccessingOriginalFile: false)
+        }
+    }
+
+    /// Pure helper: produces a filename stem ("Ada Lovelace") from the
+    /// contact's `fullName`, falling back to "Contact" for an unnamed one
+    /// and stripping characters that are illegal on macOS file systems.
+    static func suggestedFilename(for displayName: String) -> String {
+        let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base = trimmed.isEmpty ? "Contact" : trimmed
+        // Forward slash and colon are the only path-illegal characters on
+        // HFS+/APFS; replace them rather than dropping them so two distinct
+        // names don't collapse into one.
+        return base
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ":", with: "-")
+    }
+}

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -133,6 +133,12 @@ struct ContactDetailView: View {
         ) { result in
             handleImport(result)
         }
+        // Drop an image from Finder (or another app) directly on the avatar.
+        .dropDestination(for: URL.self) { urls, _ in
+            guard let url = urls.first else { return false }
+            handleImport(.success(url))
+            return true
+        }
     }
 
     // MARK: - Quick primary info

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -16,6 +16,8 @@ struct ContactListView: View {
     @Binding var selection: Contact?
     var addContact: () -> Void
     var deleteContact: (Contact) -> Void
+    /// Called when a `.vcf` file is dropped onto the list from Finder.
+    var importVCardURLs: ([URL]) -> Void
 
     var body: some View {
         List(selection: $selection) {
@@ -24,6 +26,8 @@ struct ContactListView: View {
                     ForEach(section.contacts) { contact in
                         ContactRow(contact: contact)
                             .tag(contact)
+                            // Drag a row to Finder to write `<Name>.vcf`.
+                            .draggable(transfer(for: contact))
                     }
                 }
             }
@@ -37,6 +41,14 @@ struct ContactListView: View {
         .animation(.smooth, value: sortOrder)
         .searchable(text: $searchText, prompt: "Search Contacts")
         .overlay { emptyState }
+        // Accept `.vcf` drops from Finder. Filtering on extension keeps
+        // arbitrary file drops from triggering a no-op import.
+        .dropDestination(for: URL.self) { urls, _ in
+            let vcards = urls.filter { $0.pathExtension.lowercased() == "vcf" }
+            guard !vcards.isEmpty else { return false }
+            importVCardURLs(vcards)
+            return true
+        }
         .onDeleteCommand {
             if let selection { deleteContact(selection) }
         }
@@ -63,6 +75,13 @@ struct ContactListView: View {
                 .help("New Contact")
             }
         }
+    }
+
+    private func transfer(for contact: Contact) -> VCardTransfer {
+        VCardTransfer(
+            suggestedName: VCardTransfer.suggestedFilename(for: contact.fullName),
+            text: VCard.card(for: contact)
+        )
     }
 
     @ViewBuilder

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -91,7 +91,8 @@ struct ContentView: View {
                 sortOrder: $sortOrder,
                 selection: $selectedContact,
                 addContact: addContact,
-                deleteContact: deleteContact
+                deleteContact: deleteContact,
+                importVCardURLs: importVCardURLs
             )
         } detail: {
             Group {
@@ -239,6 +240,34 @@ struct ContentView: View {
     }
 
     // MARK: - vCard import
+
+    /// Imports one or more vCard files dropped onto the contact list.
+    private func importVCardURLs(_ urls: [URL]) {
+        Task {
+            let parsed: [ParsedContact] = await Task.detached {
+                var all: [ParsedContact] = []
+                for url in urls {
+                    let didAccess = url.startAccessingSecurityScopedResource()
+                    defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+                    guard let data = try? Data(contentsOf: url),
+                          let text = String(data: data, encoding: .utf8)
+                    else { continue }
+                    all.append(contentsOf: VCard.parse(text))
+                }
+                return all
+            }.value
+
+            guard !parsed.isEmpty else {
+                errorMessage = "No contacts were found in that file."
+                return
+            }
+            do {
+                try store.importContacts(parsed)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
 
     private func handleImport(_ result: Result<URL, Error>) {
         switch result {

--- a/ContactManagerTests/VCardTransferTests.swift
+++ b/ContactManagerTests/VCardTransferTests.swift
@@ -1,0 +1,32 @@
+//
+//  VCardTransferTests.swift
+//  ContactManagerTests
+//
+//  Filename sanitization for the drag-to-Finder export.
+//
+
+@testable import ContactManager
+import Testing
+
+struct VCardTransferTests {
+    @Test func usesContactNameWhenPresent() {
+        #expect(VCardTransfer.suggestedFilename(for: "Ada Lovelace") == "Ada Lovelace")
+    }
+
+    @Test func fallsBackToContactForEmptyName() {
+        #expect(VCardTransfer.suggestedFilename(for: "") == "Contact")
+        #expect(VCardTransfer.suggestedFilename(for: "   ") == "Contact")
+    }
+
+    @Test func replacesPathIllegalCharacters() {
+        // `/` and `:` are illegal in HFS+/APFS filenames; both should be
+        // rewritten rather than dropped so two distinct names don't collide.
+        #expect(VCardTransfer.suggestedFilename(for: "AC/DC") == "AC-DC")
+        #expect(VCardTransfer.suggestedFilename(for: "9:30 Club") == "9-30 Club")
+        #expect(VCardTransfer.suggestedFilename(for: "/:/") == "---")
+    }
+
+    @Test func keepsInternationalCharacters() {
+        #expect(VCardTransfer.suggestedFilename(for: "Søren Kierkegaard") == "Søren Kierkegaard")
+    }
+}


### PR DESCRIPTION
## Summary
Three Mac-native drag-and-drop affordances that ride on the existing `VCard`, `ImageProcessing`, and `ContactStore.importContacts` infrastructure. This is the **G — Drag-and-drop** item from the post-rewrite roadmap.

- **Drag a contact row to Finder** → writes `<Name>.vcf`. Implemented as a small `VCardTransfer: Transferable` that lands the payload as a file in a per-drag tempdir. Filename comes from `Contact.fullName`, falls back to "Contact" for an empty name, and rewrites `/` and `:` (HFS+/APFS-illegal) so two distinct contact names can't collide on disk.
- **Drop `.vcf` files onto the contact list** → filtered by extension, parsed off the main actor, inserted via the existing `store.importContacts` path so the operation joins the Edit ▸ Undo group named "Import Contacts".
- **Drop an image onto the avatar well** → routed through the same `handleImport(.success(url))` path as the photo picker, so the avatar pipeline (ImageIO downscale → JPEG) runs and an undecodable file surfaces the same error alert.

Scope-limited to single-contact drag for the first PR — multi-select drag from `List` on macOS has been historically finicky and is better as its own follow-up.

## Test plan
- [ ] `make check` (format + lint + 65 tests across 8 suites) green
- [ ] App launches
- [ ] Drag a contact row to Desktop → `<Name>.vcf` lands there, double-clicking it opens in Contacts.app showing the right data
- [ ] Drag a `.vcf` from Finder onto the contact list → new contact appears; Edit ▸ Undo Import Contacts works
- [ ] Drag a `.png`/`.jpg` from Finder onto the avatar well → the photo replaces the initials; undo restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)