### PR TITLE
App Intents + Spotlight indexing

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
 		4EC36757044377406665E53B /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */; };
 		61F22EEDEE6075BD602203D5 /* VCardDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */; };
+		63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C12246003379D5966F0210 /* ContactEntityTests.swift */; };
 		6BF479700A4101F1353CBF78 /* ContactQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B27567532AC1A51FF4CC13A /* ContactQuery.swift */; };
 		6DDC44CAA558E1DB276460CF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833F1AF82CACF7B9E89BADCA /* ContentView.swift */; };
 		7755029B0E36200BB139ECFA /* VCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7D5B554122CF852B0D825C /* VCardTests.swift */; };
@@ -30,10 +31,17 @@
 		827CF451F0B38B89C4469595 /* DuplicateFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */; };
 		9506DFC07D9490AEDFB096EC /* ImageProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */; };
 		97E98BCB6784672DCB8C1625 /* VCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7276D515CA167FBF4C47299 /* VCard.swift */; };
+		A486AAFFBF01C05775A7BB38 /* ContactEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915AF700C971510D0B642590 /* ContactEntity.swift */; };
 		A94AB327927F2F1FBBD81119 /* ContactGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFE362455F20C848F729EEE /* ContactGroup.swift */; };
+		ABE65AD0BD5B666CD7272802 /* EntityModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2AA1D7BB15FC01B9CBA3B3 /* EntityModelContainer.swift */; };
+		AC7E1126C65C59B15141CB79 /* ContentView+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F852CE2356ADE83460064B /* ContentView+Import.swift */; };
 		B1393B1344A7D64B52C4B3D4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9795992CBF553603FD37928 /* SettingsView.swift */; };
+		BBD79E7FD90E021417B527A9 /* FindContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F6260FE20C27094AFB327A /* FindContactIntent.swift */; };
 		C2A11D686722C70868435ACE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303A7F66E428BF3662142C0 /* SidebarView.swift */; };
+		CD70772ECD6A854C66159FFD /* OpenContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B27494A51645ACA6BED8EA8 /* OpenContactIntent.swift */; };
 		CE55AD882E6631A9541B6106 /* ContactsBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */; };
+		CEAC8F942C862FADB6C45220 /* SpotlightIndexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */; };
+		CFFC58E9EA162230275F2301 /* ContactEntityQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874742D7DC5E9C20D3A88459 /* ContactEntityQuery.swift */; };
 		E5EB465B5CE3964197D29ADF /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F82C8A388E97CC4F1106176 /* SampleData.swift */; };
 		ECB7FDD8D0C3091EA0D42917 /* UndoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DCAF444714BC3726B212C4 /* UndoTests.swift */; };
 		FA63688E94483238D7C29FE9 /* DuplicateFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */; };
@@ -52,9 +60,11 @@
 
 /* Begin PBXFileReference section */
 		03763AB80D45F026EC585490 /* ContactStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStoreTests.swift; sourceTree = "<group>"; };
+		05F6260FE20C27094AFB327A /* FindContactIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FindContactIntent.swift; sourceTree = "<group>"; };
 		08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactListView.swift; sourceTree = "<group>"; };
 		0B27567532AC1A51FF4CC13A /* ContactQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactQuery.swift; sourceTree = "<group>"; };
 		0F82C8A388E97CC4F1106176 /* SampleData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SampleData.swift; sourceTree = "<group>"; };
+		1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotlightIndexer.swift; sourceTree = "<group>"; };
 		2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactsBridge.swift; sourceTree = "<group>"; };
 		2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardDocument.swift; sourceTree = "<group>"; };
@@ -64,12 +74,18 @@
 		61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PersistentIdentifierEncoding.swift; sourceTree = "<group>"; };
 		617D7B082A403094284FBD38 /* ContactStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStore.swift; sourceTree = "<group>"; };
 		6303A7F66E428BF3662142C0 /* SidebarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
+		66F852CE2356ADE83460064B /* ContentView+Import.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+Import.swift"; sourceTree = "<group>"; };
 		734D363DD0CB0BAA7AE9460B /* LayoutMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LayoutMetrics.swift; sourceTree = "<group>"; };
 		73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactDetailView.swift; sourceTree = "<group>"; };
+		7B27494A51645ACA6BED8EA8 /* OpenContactIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenContactIntent.swift; sourceTree = "<group>"; };
 		7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactsBridgeTests.swift; sourceTree = "<group>"; };
 		7E7D5B554122CF852B0D825C /* VCardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTests.swift; sourceTree = "<group>"; };
 		833F1AF82CACF7B9E89BADCA /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		874742D7DC5E9C20D3A88459 /* ContactEntityQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityQuery.swift; sourceTree = "<group>"; };
+		915AF700C971510D0B642590 /* ContactEntity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntity.swift; sourceTree = "<group>"; };
+		93C12246003379D5966F0210 /* ContactEntityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityTests.swift; sourceTree = "<group>"; };
 		A7276D515CA167FBF4C47299 /* VCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCard.swift; sourceTree = "<group>"; };
+		AC2AA1D7BB15FC01B9CBA3B3 /* EntityModelContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityModelContainer.swift; sourceTree = "<group>"; };
 		B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTransfer.swift; sourceTree = "<group>"; };
 		B25751DDEC1515E341AF67F5 /* ContactField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactField.swift; sourceTree = "<group>"; };
 		B75D02267D3BC6C014143329 /* ContactModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactModelTests.swift; sourceTree = "<group>"; };
@@ -136,8 +152,22 @@
 				61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */,
 				2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */,
 				B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */,
+				1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */,
 			);
 			path = Support;
+			sourceTree = "<group>";
+		};
+		C80F354FEBD80D33AEC2F590 /* Intents */ = {
+			isa = PBXGroup;
+			children = (
+				AC2AA1D7BB15FC01B9CBA3B3 /* EntityModelContainer.swift */,
+				915AF700C971510D0B642590 /* ContactEntity.swift */,
+				874742D7DC5E9C20D3A88459 /* ContactEntityQuery.swift */,
+				7B27494A51645ACA6BED8EA8 /* OpenContactIntent.swift */,
+				05F6260FE20C27094AFB327A /* FindContactIntent.swift */,
+			);
+			name = Intents;
+			path = Intents;
 			sourceTree = "<group>";
 		};
 		C876089F42640D0818FE333F /* Views */ = {
@@ -151,6 +181,7 @@
 				54C373BD237429970D6A7C86 /* DuplicatesView.swift */,
 				734D363DD0CB0BAA7AE9460B /* LayoutMetrics.swift */,
 				F9795992CBF553603FD37928 /* SettingsView.swift */,
+				66F852CE2356ADE83460064B /* ContentView+Import.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -182,6 +213,7 @@
 				1A7FF215BB060EF1483FD33C /* Models */,
 				A34742F5CC5340B2EE610BF4 /* Support */,
 				C876089F42640D0818FE333F /* Views */,
+				C80F354FEBD80D33AEC2F590 /* Intents */,
 			);
 			path = ContactManager;
 			sourceTree = "<group>";
@@ -197,6 +229,7 @@
 				C7DCAF444714BC3726B212C4 /* UndoTests.swift */,
 				7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */,
 				F9F733D535CFC76FA07FB61E /* VCardTransferTests.swift */,
+				93C12246003379D5966F0210 /* ContactEntityTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -321,6 +354,13 @@
 				4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */,
 				CE55AD882E6631A9541B6106 /* ContactsBridge.swift in Sources */,
 				2EB13805320DA225F70D08F3 /* VCardTransfer.swift in Sources */,
+				ABE65AD0BD5B666CD7272802 /* EntityModelContainer.swift in Sources */,
+				A486AAFFBF01C05775A7BB38 /* ContactEntity.swift in Sources */,
+				CFFC58E9EA162230275F2301 /* ContactEntityQuery.swift in Sources */,
+				CD70772ECD6A854C66159FFD /* OpenContactIntent.swift in Sources */,
+				BBD79E7FD90E021417B527A9 /* FindContactIntent.swift in Sources */,
+				CEAC8F942C862FADB6C45220 /* SpotlightIndexer.swift in Sources */,
+				AC7E1126C65C59B15141CB79 /* ContentView+Import.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -336,6 +376,7 @@
 				ECB7FDD8D0C3091EA0D42917 /* UndoTests.swift in Sources */,
 				3076738411F8C3FA073D1BE0 /* ContactsBridgeTests.swift in Sources */,
 				1BE87CA3661CF6390FF9EEC4 /* VCardTransferTests.swift in Sources */,
+				63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -127,10 +127,7 @@ struct ContactManagerApp: App {
         // Publish the container for App Intents (Shortcuts/Spotlight queries)
         // and kick off an initial Spotlight reindex.
         EntityModelContainer.shared = container
-        Task.detached {
-            let entities = await (try? ContactEntityQuery().allEntities()) ?? []
-            await SpotlightIndexer.reindex(entities)
-        }
+        Task.detached { await SpotlightIndexer.shared.reindex() }
         return .ready(container)
     }
 

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -124,6 +124,13 @@ struct ContactManagerApp: App {
                 print("ContactManager: sample data seeding skipped — \(error)")
             }
         }
+        // Publish the container for App Intents (Shortcuts/Spotlight queries)
+        // and kick off an initial Spotlight reindex.
+        EntityModelContainer.shared = container
+        Task.detached {
+            let entities = await (try? ContactEntityQuery().allEntities()) ?? []
+            await SpotlightIndexer.reindex(entities)
+        }
         return .ready(container)
     }
 
@@ -174,4 +181,11 @@ extension Notification.Name {
     static let importSystemContactsRequested = Notification.Name("ContactManager.importSystemContactsRequested")
     static let exportVCardRequested = Notification.Name("ContactManager.exportVCardRequested")
     static let findDuplicatesRequested = Notification.Name("ContactManager.findDuplicatesRequested")
+    /// Posted by App Intents (and `Spotlight` taps via `ContentView`'s
+    /// `onContinueUserActivity`). UserInfo carries `id: String` — the
+    /// encoded `PersistentIdentifier` of the contact to select.
+    static let openContactRequested = Notification.Name("ContactManager.openContactRequested")
+    /// Posted by `ContactStore` after every successful mutation so observers
+    /// (currently the Spotlight indexer) can refresh derived state.
+    static let contactsDidChange = Notification.Name("ContactManager.contactsDidChange")
 }

--- a/ContactManager/Intents/ContactEntity.swift
+++ b/ContactManager/Intents/ContactEntity.swift
@@ -39,17 +39,19 @@ struct ContactEntity: AppEntity, IndexedEntity {
         attrs.contentDescription = subtitleText
         if !emails.isEmpty { attrs.emailAddresses = emails }
         if !phones.isEmpty { attrs.phoneNumbers = phones }
-        if !company.isEmpty { attrs.organizations = [company] }
-        if !jobTitle.isEmpty { attrs.title = jobTitle }
+        if !company.isBlank { attrs.organizations = [company] }
+        if !jobTitle.isBlank { attrs.title = jobTitle }
         return attrs
     }
 
     /// Subtitle preferences match the contact list row: primary email, then
-    /// primary phone, then company. Returns `nil` if everything is empty.
+    /// primary phone, then company. Whitespace-only values are treated as
+    /// empty (same as `Contact.subtitle`) so Shortcuts/Spotlight never show
+    /// a blank-looking subtitle.
     private var subtitleText: String? {
-        if let first = emails.first, !first.isEmpty { return first }
-        if let first = phones.first, !first.isEmpty { return first }
-        if !company.isEmpty { return company }
+        if let first = emails.first(where: { !$0.isBlank }) { return first }
+        if let first = phones.first(where: { !$0.isBlank }) { return first }
+        if !company.isBlank { return company }
         return nil
     }
 }
@@ -62,7 +64,17 @@ extension ContactEntity {
         displayName = contact.fullName
         company = contact.company
         jobTitle = contact.jobTitle
-        emails = contact.emails.map(\.value).filter { !$0.isEmpty }
-        phones = contact.phones.map(\.value).filter { !$0.isEmpty }
+        // Drop blank/whitespace-only values so Spotlight doesn't index
+        // empty rows. Matches `Contact.primaryEmail/primaryPhone` semantics.
+        emails = contact.emails.map(\.value).filter { !$0.isBlank }
+        phones = contact.phones.map(\.value).filter { !$0.isBlank }
+    }
+}
+
+private extension String {
+    /// Treats whitespace-only strings as empty, matching how the rest of
+    /// the codebase decides whether a contact field is "set".
+    var isBlank: Bool {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }

--- a/ContactManager/Intents/ContactEntity.swift
+++ b/ContactManager/Intents/ContactEntity.swift
@@ -1,0 +1,68 @@
+//
+//  ContactEntity.swift
+//  ContactManager
+//
+//  The App Intents identity for a `Contact`. Conforms to `IndexedEntity`
+//  so the same value also drives the CoreSpotlight attribute set,
+//  avoiding a parallel "Spotlight model" alongside the intents model.
+//
+
+import AppIntents
+import CoreSpotlight
+import Foundation
+
+struct ContactEntity: AppEntity, IndexedEntity {
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Contact")
+    static let defaultQuery = ContactEntityQuery()
+
+    /// Stable identifier: the contact's `PersistentIdentifier` encoded as
+    /// a string (same scheme used by the default-group preference).
+    var id: String
+    var displayName: String
+    var company: String
+    var jobTitle: String
+    var emails: [String]
+    var phones: [String]
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: "\(displayName)",
+            subtitle: subtitleText.map { "\($0)" }
+        )
+    }
+
+    /// CoreSpotlight metadata built from the same fields the entity carries,
+    /// so Spotlight's preview shows the same info Shortcuts/Siri reads.
+    var attributeSet: CSSearchableItemAttributeSet {
+        let attrs = CSSearchableItemAttributeSet(contentType: .contact)
+        attrs.displayName = displayName
+        attrs.contentDescription = subtitleText
+        if !emails.isEmpty { attrs.emailAddresses = emails }
+        if !phones.isEmpty { attrs.phoneNumbers = phones }
+        if !company.isEmpty { attrs.organizations = [company] }
+        if !jobTitle.isEmpty { attrs.title = jobTitle }
+        return attrs
+    }
+
+    /// Subtitle preferences match the contact list row: primary email, then
+    /// primary phone, then company. Returns `nil` if everything is empty.
+    private var subtitleText: String? {
+        if let first = emails.first, !first.isEmpty { return first }
+        if let first = phones.first, !first.isEmpty { return first }
+        if !company.isEmpty { return company }
+        return nil
+    }
+}
+
+extension ContactEntity {
+    /// Snapshot a SwiftData `Contact` into an entity value. Safe to call
+    /// off the main actor as long as the `Contact` is fetched there too.
+    init(contact: Contact) {
+        id = contact.persistentModelID.storedString ?? ""
+        displayName = contact.fullName
+        company = contact.company
+        jobTitle = contact.jobTitle
+        emails = contact.emails.map(\.value).filter { !$0.isEmpty }
+        phones = contact.phones.map(\.value).filter { !$0.isEmpty }
+    }
+}

--- a/ContactManager/Intents/ContactEntityQuery.swift
+++ b/ContactManager/Intents/ContactEntityQuery.swift
@@ -1,0 +1,59 @@
+//
+//  ContactEntityQuery.swift
+//  ContactManager
+//
+//  Lookup paths for `ContactEntity`: by id (Shortcuts handoff + Spotlight
+//  open), by free-text string (Find Contact intent), and "all" (Spotlight
+//  re-index and the Shortcuts picker).
+//
+
+import AppIntents
+import Foundation
+import SwiftData
+
+struct ContactEntityQuery: EntityQuery, EnumerableEntityQuery, EntityStringQuery {
+    func entities(for identifiers: [ContactEntity.ID]) async throws -> [ContactEntity] {
+        guard let container = EntityModelContainer.shared else { return [] }
+        let wanted = Set(identifiers)
+        return try await Self.snapshot(container: container) { contacts in
+            contacts.filter { wanted.contains($0.persistentModelID.storedString ?? "") }
+        }
+    }
+
+    func entities(matching string: String) async throws -> [ContactEntity] {
+        guard let container = EntityModelContainer.shared else { return [] }
+        let needle = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !needle.isEmpty else { return [] }
+        return try await Self.snapshot(container: container) { contacts in
+            // Reuse the same matcher the contact list uses so Shortcuts and
+            // in-app search behave the same.
+            ContactQuery.filtered(contacts, matching: needle)
+        }
+    }
+
+    func suggestedEntities() async throws -> [ContactEntity] {
+        try await allEntities()
+    }
+
+    func allEntities() async throws -> [ContactEntity] {
+        guard let container = EntityModelContainer.shared else { return [] }
+        return try await Self.snapshot(container: container) { $0 }
+    }
+
+    /// Fetches every contact on a fresh background context, applies the
+    /// caller's filter, and maps to entity values. The fetch and the
+    /// mapping both happen on the same actor as the context (none here),
+    /// so the resulting `[ContactEntity]` is safe to send to App Intents
+    /// callers on any actor.
+    private static func snapshot(
+        container: ModelContainer,
+        filter: (_ contacts: [Contact]) -> [Contact]
+    ) async throws -> [ContactEntity] {
+        let context = ModelContext(container)
+        let descriptor = FetchDescriptor<Contact>(
+            sortBy: [SortDescriptor(\.lastName), SortDescriptor(\.firstName)]
+        )
+        let contacts = try context.fetch(descriptor)
+        return filter(contacts).map(ContactEntity.init(contact:))
+    }
+}

--- a/ContactManager/Intents/EntityModelContainer.swift
+++ b/ContactManager/Intents/EntityModelContainer.swift
@@ -1,0 +1,20 @@
+//
+//  EntityModelContainer.swift
+//  ContactManager
+//
+//  A process-wide handle to the app's `ModelContainer`. App Intents and
+//  CoreSpotlight queries need to read contacts without going through the
+//  SwiftUI environment; the app sets this once after `loadContainer()`
+//  succeeds and the entity query reads it from any actor.
+//
+
+import Foundation
+import SwiftData
+
+enum EntityModelContainer {
+    /// The shared container, populated by `ContactManagerApp` after the
+    /// store loads. `nil` if loading failed or we're running under tests.
+    /// Reads are nominally racy but in practice the container is set once
+    /// during app launch before any query runs.
+    nonisolated(unsafe) static var shared: ModelContainer?
+}

--- a/ContactManager/Intents/EntityModelContainer.swift
+++ b/ContactManager/Intents/EntityModelContainer.swift
@@ -7,14 +7,22 @@
 //  SwiftUI environment; the app sets this once after `loadContainer()`
 //  succeeds and the entity query reads it from any actor.
 //
+//  Access is guarded by an `OSAllocatedUnfairLock` so concurrent reads
+//  during a launch-time setup are well-defined. The lock is held only
+//  long enough to read or write the container reference itself.
+//
 
 import Foundation
+import os
 import SwiftData
 
 enum EntityModelContainer {
+    private static let storage = OSAllocatedUnfairLock<ModelContainer?>(initialState: nil)
+
     /// The shared container, populated by `ContactManagerApp` after the
     /// store loads. `nil` if loading failed or we're running under tests.
-    /// Reads are nominally racy but in practice the container is set once
-    /// during app launch before any query runs.
-    nonisolated(unsafe) static var shared: ModelContainer?
+    static var shared: ModelContainer? {
+        get { storage.withLock { $0 } }
+        set { storage.withLock { $0 = newValue } }
+    }
 }

--- a/ContactManager/Intents/FindContactIntent.swift
+++ b/ContactManager/Intents/FindContactIntent.swift
@@ -1,0 +1,25 @@
+//
+//  FindContactIntent.swift
+//  ContactManager
+//
+//  Shortcut/Siri action: returns contacts matching a query string. The
+//  results can be piped into downstream actions (e.g. Open Contact).
+//
+
+import AppIntents
+import Foundation
+
+struct FindContactIntent: AppIntent {
+    static let title: LocalizedStringResource = "Find Contact"
+    static let description = IntentDescription(
+        "Search ContactManager by name, company, email, or notes."
+    )
+
+    @Parameter(title: "Query") var query: String
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<[ContactEntity]> {
+        let matches = try await ContactEntityQuery().entities(matching: query)
+        return .result(value: matches)
+    }
+}

--- a/ContactManager/Intents/OpenContactIntent.swift
+++ b/ContactManager/Intents/OpenContactIntent.swift
@@ -1,0 +1,32 @@
+//
+//  OpenContactIntent.swift
+//  ContactManager
+//
+//  Shortcut/Siri action: brings ContactManager forward and selects the
+//  chosen contact. The actual navigation is handled by `ContentView`
+//  observing `Notification.Name.openContactRequested`.
+//
+
+import AppIntents
+import Foundation
+
+struct OpenContactIntent: AppIntent {
+    static let title: LocalizedStringResource = "Open Contact"
+    static let description = IntentDescription(
+        "Opens ContactManager and selects the chosen contact."
+    )
+    /// Tells the system to launch the app for us before `perform()` runs.
+    static let openAppWhenRun = true
+
+    @Parameter(title: "Contact") var target: ContactEntity
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        NotificationCenter.default.post(
+            name: .openContactRequested,
+            object: nil,
+            userInfo: ["id": target.id]
+        )
+        return .result()
+    }
+}

--- a/ContactManager/Models/ContactStore.swift
+++ b/ContactManager/Models/ContactStore.swift
@@ -257,6 +257,9 @@ struct ContactStore {
             try context.save()
             undoManager?.endUndoGrouping()
             undoManager?.setActionName(actionName)
+            // Observed by ContentView to refresh the Spotlight index. Fired
+            // after the save commits so observers see the post-mutation state.
+            NotificationCenter.default.post(name: .contactsDidChange, object: nil)
             return result
         } catch {
             context.rollback()

--- a/ContactManager/Support/SpotlightIndexer.swift
+++ b/ContactManager/Support/SpotlightIndexer.swift
@@ -1,0 +1,40 @@
+//
+//  SpotlightIndexer.swift
+//  ContactManager
+//
+//  Pushes contacts into Spotlight's index. The first launch indexes the
+//  full set; subsequent calls do the same — the contact corpus stays
+//  modest enough that a full reindex on every mutation is cheaper than
+//  tracking per-row deltas.
+//
+
+import CoreSpotlight
+import Foundation
+
+enum SpotlightIndexer {
+    /// Identifier scope so we can clear *our* items without touching
+    /// anything else Spotlight has indexed for this app.
+    static let domainIdentifier = "com.scottdensmore.ContactManager.contacts"
+
+    /// Replaces our entire indexed set with the supplied entities. Errors
+    /// are logged but not surfaced — Spotlight indexing failure is a
+    /// quality-of-life regression, not a user-visible error worth alerting.
+    static func reindex(_ entities: [ContactEntity]) async {
+        let index = CSSearchableIndex.default()
+        let items = entities.map { entity in
+            CSSearchableItem(
+                uniqueIdentifier: entity.id,
+                domainIdentifier: domainIdentifier,
+                attributeSet: entity.attributeSet
+            )
+        }
+        do {
+            try await index.deleteSearchableItems(withDomainIdentifiers: [domainIdentifier])
+            if !items.isEmpty {
+                try await index.indexSearchableItems(items)
+            }
+        } catch {
+            print("Spotlight reindex failed: \(error)")
+        }
+    }
+}

--- a/ContactManager/Support/SpotlightIndexer.swift
+++ b/ContactManager/Support/SpotlightIndexer.swift
@@ -2,34 +2,41 @@
 //  SpotlightIndexer.swift
 //  ContactManager
 //
-//  Pushes contacts into Spotlight's index. The first launch indexes the
-//  full set; subsequent calls do the same — the contact corpus stays
-//  modest enough that a full reindex on every mutation is cheaper than
-//  tracking per-row deltas.
+//  Pushes contacts into Spotlight's index. An actor so back-to-back calls
+//  during a burst of mutations serialize cleanly — a delete-then-index
+//  pair must not interleave with another pair or Spotlight ends up
+//  reflecting an older snapshot (or empty).
+//
+//  Each call fetches a fresh snapshot via `ContactEntityQuery` instead of
+//  trusting a caller-supplied list, because `@Query`'s post-save refresh
+//  is asynchronous and can lag a `ContactStore.mutate` notification.
 //
 
 import CoreSpotlight
 import Foundation
 
-enum SpotlightIndexer {
+actor SpotlightIndexer {
+    static let shared = SpotlightIndexer()
+
     /// Identifier scope so we can clear *our* items without touching
     /// anything else Spotlight has indexed for this app.
     static let domainIdentifier = "com.scottdensmore.ContactManager.contacts"
 
-    /// Replaces our entire indexed set with the supplied entities. Errors
-    /// are logged but not surfaced — Spotlight indexing failure is a
-    /// quality-of-life regression, not a user-visible error worth alerting.
-    static func reindex(_ entities: [ContactEntity]) async {
+    /// Replaces our entire indexed set with a freshly-fetched snapshot.
+    /// Errors are logged but not surfaced — a Spotlight indexing failure
+    /// is a quality-of-life regression, not a user-visible error.
+    func reindex() async {
+        let entities = await (try? ContactEntityQuery().allEntities()) ?? []
         let index = CSSearchableIndex.default()
         let items = entities.map { entity in
             CSSearchableItem(
                 uniqueIdentifier: entity.id,
-                domainIdentifier: domainIdentifier,
+                domainIdentifier: Self.domainIdentifier,
                 attributeSet: entity.attributeSet
             )
         }
         do {
-            try await index.deleteSearchableItems(withDomainIdentifiers: [domainIdentifier])
+            try await index.deleteSearchableItems(withDomainIdentifiers: [Self.domainIdentifier])
             if !items.isEmpty {
                 try await index.indexSearchableItems(items)
             }

--- a/ContactManager/Views/ContentView+Import.swift
+++ b/ContactManager/Views/ContentView+Import.swift
@@ -1,0 +1,104 @@
+//
+//  ContentView+Import.swift
+//  ContactManager
+//
+//  Import handlers (system Contacts, vCard file picker, vCard URL drops)
+//  factored out of `ContentView` so the main view stays focused on
+//  composition and state. Each handler runs the parse off the main
+//  actor and routes inserts through `ContactStore` so they participate
+//  in the existing Undo group.
+//
+
+import Foundation
+import SwiftUI
+
+extension ContentView {
+    // MARK: - System Contacts import
+
+    func importSystemContacts() {
+        Task {
+            // Permission prompt + fetch + mapping all run off the main actor;
+            // only the final insert hops back here.
+            let parsed: [ParsedContact]
+            do {
+                parsed = try await Task.detached(priority: .userInitiated) {
+                    try await ContactsBridge.fetchAllParsed()
+                }.value
+            } catch {
+                errorMessage = error.localizedDescription
+                return
+            }
+            guard !parsed.isEmpty else {
+                errorMessage = "No contacts were found in your system Contacts."
+                return
+            }
+            do {
+                try store.importContacts(parsed)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    // MARK: - vCard import
+
+    /// Imports one or more vCard files dropped onto the contact list.
+    func importVCardURLs(_ urls: [URL]) {
+        Task {
+            let parsed: [ParsedContact] = await Task.detached {
+                var all: [ParsedContact] = []
+                for url in urls {
+                    let didAccess = url.startAccessingSecurityScopedResource()
+                    defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+                    guard let data = try? Data(contentsOf: url),
+                          let text = String(data: data, encoding: .utf8)
+                    else { continue }
+                    all.append(contentsOf: VCard.parse(text))
+                }
+                return all
+            }.value
+
+            guard !parsed.isEmpty else {
+                errorMessage = "No contacts were found in that file."
+                return
+            }
+            do {
+                try store.importContacts(parsed)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func handleImport(_ result: Result<URL, Error>) {
+        switch result {
+        case .failure(let error):
+            errorMessage = error.localizedDescription
+        case .success(let url):
+            Task {
+                // Read and parse off the main actor so large files don't block UI.
+                let parsed: [ParsedContact]? = await Task.detached {
+                    let didAccess = url.startAccessingSecurityScopedResource()
+                    defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+                    guard let data = try? Data(contentsOf: url),
+                          let text = String(data: data, encoding: .utf8) else { return nil }
+                    return VCard.parse(text)
+                }.value
+
+                guard let parsed else {
+                    errorMessage = "That file couldn't be read as a vCard."
+                    return
+                }
+                guard !parsed.isEmpty else {
+                    errorMessage = "No contacts were found in that file."
+                    return
+                }
+                do {
+                    try store.importContacts(parsed)
+                } catch {
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+}

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -7,6 +7,7 @@
 //  import/export.
 //
 
+import CoreSpotlight
 import SwiftData
 import SwiftUI
 
@@ -21,7 +22,9 @@ struct ContentView: View {
 
     @State private var sidebarSelection: SidebarItem? = .allContacts
     @State private var selectedContact: Contact?
-    @State private var errorMessage: String?
+    // Internal so the import handlers in `ContentView+Import.swift` can
+    // set this when a parse/insert fails.
+    @State var errorMessage: String?
     @State private var searchText = ""
     @AppStorage("contactSortOrder") private var sortOrder: ContactSortOrder = .lastName
     @AppStorage("defaultGroupID") private var defaultGroupID: String = ""
@@ -31,7 +34,9 @@ struct ContentView: View {
     @State private var exportDocument = VCardDocument(text: "")
     @State private var showingDuplicates = false
 
-    private var store: ContactStore { ContactStore(context) }
+    /// Internal so the import handlers in `ContentView+Import.swift` can
+    /// reach the same store the main view uses.
+    var store: ContactStore { ContactStore(context) }
 
     /// The group backing the current sidebar selection, if any.
     private var selectedGroup: ContactGroup? {
@@ -135,6 +140,18 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .importSystemContactsRequested)) { _ in
             importSystemContacts()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .openContactRequested)) { note in
+            selectContact(byEncodedID: note.userInfo?["id"] as? String)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .contactsDidChange)) { _ in
+            // The @Query above will have refreshed; snapshot it for Spotlight.
+            let snapshot = contacts.map(ContactEntity.init(contact:))
+            Task { await SpotlightIndexer.reindex(snapshot) }
+        }
+        .onContinueUserActivity(CSSearchableItemActionType) { activity in
+            let id = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String
+            selectContact(byEncodedID: id)
+        }
         .sheet(isPresented: $showingDuplicates) {
             DuplicatesView()
         }
@@ -212,93 +229,18 @@ struct ContentView: View {
         }
     }
 
-    // MARK: - System Contacts import
+    // MARK: - Open by ID (Spotlight + App Intents)
 
-    private func importSystemContacts() {
-        Task {
-            // Permission prompt + fetch + mapping all run off the main actor;
-            // only the final insert hops back here.
-            let parsed: [ParsedContact]
-            do {
-                parsed = try await Task.detached(priority: .userInitiated) {
-                    try await ContactsBridge.fetchAllParsed()
-                }.value
-            } catch {
-                errorMessage = error.localizedDescription
-                return
-            }
-            guard !parsed.isEmpty else {
-                errorMessage = "No contacts were found in your system Contacts."
-                return
-            }
-            do {
-                try store.importContacts(parsed)
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-        }
-    }
-
-    // MARK: - vCard import
-
-    /// Imports one or more vCard files dropped onto the contact list.
-    private func importVCardURLs(_ urls: [URL]) {
-        Task {
-            let parsed: [ParsedContact] = await Task.detached {
-                var all: [ParsedContact] = []
-                for url in urls {
-                    let didAccess = url.startAccessingSecurityScopedResource()
-                    defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
-                    guard let data = try? Data(contentsOf: url),
-                          let text = String(data: data, encoding: .utf8)
-                    else { continue }
-                    all.append(contentsOf: VCard.parse(text))
-                }
-                return all
-            }.value
-
-            guard !parsed.isEmpty else {
-                errorMessage = "No contacts were found in that file."
-                return
-            }
-            do {
-                try store.importContacts(parsed)
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-        }
-    }
-
-    private func handleImport(_ result: Result<URL, Error>) {
-        switch result {
-        case .failure(let error):
-            errorMessage = error.localizedDescription
-        case .success(let url):
-            Task {
-                // Read and parse off the main actor so large files don't block UI.
-                let parsed: [ParsedContact]? = await Task.detached {
-                    let didAccess = url.startAccessingSecurityScopedResource()
-                    defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
-                    guard let data = try? Data(contentsOf: url),
-                          let text = String(data: data, encoding: .utf8) else { return nil }
-                    return VCard.parse(text)
-                }.value
-
-                guard let parsed else {
-                    errorMessage = "That file couldn't be read as a vCard."
-                    return
-                }
-                guard !parsed.isEmpty else {
-                    errorMessage = "No contacts were found in that file."
-                    return
-                }
-                do {
-                    try store.importContacts(parsed)
-                } catch {
-                    errorMessage = error.localizedDescription
-                }
-            }
-        }
+    private func selectContact(byEncodedID encoded: String?) {
+        guard let encoded,
+              let id = PersistentIdentifier.decode(stored: encoded),
+              let contact = contacts.first(where: { $0.persistentModelID == id })
+        else { return }
+        // Drop a group selection so the contact is guaranteed visible in the
+        // middle column even if the user arrived via Spotlight while a
+        // narrower group was active.
+        if case .group = sidebarSelection { sidebarSelection = .allContacts }
+        withAnimation(.snappy) { selectedContact = contact }
     }
 }
 

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -144,9 +144,10 @@ struct ContentView: View {
             selectContact(byEncodedID: note.userInfo?["id"] as? String)
         }
         .onReceive(NotificationCenter.default.publisher(for: .contactsDidChange)) { _ in
-            // The @Query above will have refreshed; snapshot it for Spotlight.
-            let snapshot = contacts.map(ContactEntity.init(contact:))
-            Task { await SpotlightIndexer.reindex(snapshot) }
+            // The indexer fetches its own snapshot — `@Query`'s post-save
+            // refresh is asynchronous and can still reflect pre-save state
+            // when this notification fires.
+            Task { await SpotlightIndexer.shared.reindex() }
         }
         .onContinueUserActivity(CSSearchableItemActionType) { activity in
             let id = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String

--- a/ContactManagerTests/ContactEntityTests.swift
+++ b/ContactManagerTests/ContactEntityTests.swift
@@ -1,0 +1,91 @@
+//
+//  ContactEntityTests.swift
+//  ContactManagerTests
+//
+//  Coverage of the pure `Contact` → `ContactEntity` mapping and the
+//  derived Spotlight attribute set. The query and `SpotlightIndexer`
+//  live behind a process-wide model container that's set up at app
+//  launch; integration coverage for those would need a parallel
+//  container fixture and is left for a future pass.
+//
+
+@testable import ContactManager
+import CoreSpotlight
+import Foundation
+import SwiftData
+import Testing
+
+@MainActor
+struct ContactEntityTests {
+    private func sampleContact() -> Contact {
+        let contact = Contact(
+            firstName: "Ada", lastName: "Lovelace",
+            company: "Analytical Engine Co.", jobTitle: "Mathematician"
+        )
+        contact.fields = [
+            ContactField(kind: .email, label: .work, value: "ada@analytical.engine", sortIndex: 0),
+            ContactField(kind: .email, label: .home, value: "ada@home.test", sortIndex: 1),
+            ContactField(kind: .phone, label: .mobile, value: "+1 555 0100", sortIndex: 0),
+        ]
+        return contact
+    }
+
+    @Test func snapshotsScalarFields() {
+        let entity = ContactEntity(contact: sampleContact())
+        #expect(entity.displayName == "Ada Lovelace")
+        #expect(entity.company == "Analytical Engine Co.")
+        #expect(entity.jobTitle == "Mathematician")
+    }
+
+    @Test func snapshotsContactEmailsAndPhones() {
+        let entity = ContactEntity(contact: sampleContact())
+        #expect(entity.emails == ["ada@analytical.engine", "ada@home.test"])
+        #expect(entity.phones == ["+1 555 0100"])
+    }
+
+    @Test func skipsBlankFieldValues() {
+        let contact = Contact(firstName: "Blank", lastName: "Fields")
+        contact.fields = [
+            ContactField(kind: .email, label: .home, value: "", sortIndex: 0),
+            ContactField(kind: .email, label: .work, value: "real@example.com", sortIndex: 1),
+        ]
+        let entity = ContactEntity(contact: contact)
+        #expect(entity.emails == ["real@example.com"])
+    }
+
+    @Test func attributeSetReflectsAllPopulatedFields() {
+        let attrs = ContactEntity(contact: sampleContact()).attributeSet
+        #expect(attrs.displayName == "Ada Lovelace")
+        #expect(attrs.contentDescription == "ada@analytical.engine")
+        #expect(attrs.emailAddresses == ["ada@analytical.engine", "ada@home.test"])
+        #expect(attrs.phoneNumbers == ["+1 555 0100"])
+        #expect(attrs.organizations == ["Analytical Engine Co."])
+        #expect(attrs.title == "Mathematician")
+    }
+
+    @Test func attributeSetOmitsEmptyFields() {
+        let contact = Contact(firstName: "Solo", lastName: "Name")
+        let attrs = ContactEntity(contact: contact).attributeSet
+        #expect(attrs.displayName == "Solo Name")
+        #expect(attrs.contentDescription == nil)
+        #expect(attrs.emailAddresses == nil)
+        #expect(attrs.phoneNumbers == nil)
+        #expect(attrs.organizations == nil)
+        #expect(attrs.title == nil)
+    }
+
+    @Test func subtitleFallsBackToCompanyWhenNoEmailOrPhone() {
+        let contact = Contact(firstName: "Solo", lastName: "Worker", company: "Acme")
+        let attrs = ContactEntity(contact: contact).attributeSet
+        #expect(attrs.contentDescription == "Acme")
+    }
+
+    @Test func entityIdMatchesEncodedPersistentIdentifier() throws {
+        // The id is reused by `selectContact(byEncodedID:)` and the
+        // default-group preference — they must agree on the encoding.
+        let contact = sampleContact()
+        let entity = ContactEntity(contact: contact)
+        let decoded = try #require(PersistentIdentifier.decode(stored: entity.id))
+        #expect(decoded == contact.persistentModelID)
+    }
+}


### PR DESCRIPTION
## Summary
A single `ContactEntity` (App Intents + CoreSpotlight via `IndexedEntity`) powers Spotlight lookup, Shortcuts/Siri actions, and Spotlight's contact preview from the same value type — no parallel "Spotlight model". This is the **F — App Intents + Spotlight indexing** item from the post-rewrite roadmap.

### What ships
- **`ContactEntity: AppEntity, IndexedEntity`** — id is the encoded `PersistentIdentifier` (same scheme the default-group preference uses); `attributeSet` builds a `.contact` CoreSpotlight item with emails / phones / organization / title.
- **`ContactEntityQuery`** — id lookup, free-text matching (reusing `ContactQuery.filtered` so Shortcuts and in-app search behave identically), enumerable for reindex.
- **`OpenContactIntent` + `FindContactIntent`** — first two Shortcuts/Siri actions. Open posts a notification observed by `ContentView`; Find returns `[ContactEntity]` for downstream actions.
- **`SpotlightIndexer`** — full reindex after every store mutation (`ContactStore.mutate` now posts `contactsDidChange`, observed in `ContentView` which snapshots the @Query). Full reindex stays cheap at typical sizes.
- **Spotlight tap handler** — `ContentView.onContinueUserActivity(CSSearchableItemActionType)` routes through the same selection helper the Open intent uses; both drop a narrower group selection so the chosen contact is guaranteed visible.

### Plumbing
- `EntityModelContainer.shared` is a process-wide handle the app sets after `loadContainer()` succeeds; the query reads it from any actor. Skipped under tests so the test target still owns the only container.
- `ContentView`'s import handlers moved into a `ContentView+Import.swift` extension so the struct body stays under SwiftLint's `type_body_length` cap. Required dropping `private` on two members (`errorMessage`, `store`); they're still module-internal.
- Total now **72 tests across 9 suites** (was 65/8).

### Not in this PR
- `CreateContactIntent` (parameter form needs design).
- `AppShortcutsProvider` registration for predefined Siri phrases — the intents are already discoverable via the Shortcuts app; adding pre-bound phrases is a follow-up.

## Test plan
- [ ] `make check` (format + lint + 72 tests across 9 suites) green
- [ ] App launches
- [ ] Type a contact's name in **Spotlight (⌘Space)** → result appears; pressing Return opens ContactManager and selects them
- [ ] Open **Shortcuts.app** → "Open Contact" / "Find Contact" actions appear under ContactManager
- [ ] Build a one-step "Open Contact" shortcut, run it → app comes to front with the chosen contact selected
- [ ] Delete a contact → its Spotlight result is gone within a few seconds (full reindex on save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)