### PR TITLE
Import CSV: Google Contacts / Outlook / Apple exports

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -22,10 +22,12 @@
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
 		4EC36757044377406665E53B /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */; };
 		61F22EEDEE6075BD602203D5 /* VCardDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */; };
+		623A5F4AE958EAD5C2757F83 /* CSVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */; };
 		63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C12246003379D5966F0210 /* ContactEntityTests.swift */; };
 		6BF479700A4101F1353CBF78 /* ContactQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B27567532AC1A51FF4CC13A /* ContactQuery.swift */; };
 		6DDC44CAA558E1DB276460CF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833F1AF82CACF7B9E89BADCA /* ContentView.swift */; };
 		7755029B0E36200BB139ECFA /* VCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7D5B554122CF852B0D825C /* VCardTests.swift */; };
+		7CD9C3EBF737E415B2561168 /* CSV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2F2242E59F2C42DDD0736B /* CSV.swift */; };
 		7F3D3F509379FD171AEC3606 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DEAB729518FA2A6600E3570B /* Images.xcassets */; };
 		81F488BB8E6D53268C607C68 /* DuplicatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C373BD237429970D6A7C86 /* DuplicatesView.swift */; };
 		827CF451F0B38B89C4469595 /* DuplicateFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */; };
@@ -69,6 +71,7 @@
 		2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardDocument.swift; sourceTree = "<group>"; };
 		3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinderTests.swift; sourceTree = "<group>"; };
+		4E2F2242E59F2C42DDD0736B /* CSV.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSV.swift; sourceTree = "<group>"; };
 		54C373BD237429970D6A7C86 /* DuplicatesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicatesView.swift; sourceTree = "<group>"; };
 		5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingTests.swift; sourceTree = "<group>"; };
 		61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PersistentIdentifierEncoding.swift; sourceTree = "<group>"; };
@@ -89,6 +92,7 @@
 		B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTransfer.swift; sourceTree = "<group>"; };
 		B25751DDEC1515E341AF67F5 /* ContactField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactField.swift; sourceTree = "<group>"; };
 		B75D02267D3BC6C014143329 /* ContactModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactModelTests.swift; sourceTree = "<group>"; };
+		BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSVTests.swift; sourceTree = "<group>"; };
 		C7DCAF444714BC3726B212C4 /* UndoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UndoTests.swift; sourceTree = "<group>"; };
 		DEAB729518FA2A6600E3570B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		DED8178913A452A900EC3234 /* ContactManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ContactManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -153,6 +157,7 @@
 				2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */,
 				B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */,
 				1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */,
+				4E2F2242E59F2C42DDD0736B /* CSV.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -230,6 +235,7 @@
 				7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */,
 				F9F733D535CFC76FA07FB61E /* VCardTransferTests.swift */,
 				93C12246003379D5966F0210 /* ContactEntityTests.swift */,
+				BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -361,6 +367,7 @@
 				BBD79E7FD90E021417B527A9 /* FindContactIntent.swift in Sources */,
 				CEAC8F942C862FADB6C45220 /* SpotlightIndexer.swift in Sources */,
 				AC7E1126C65C59B15141CB79 /* ContentView+Import.swift in Sources */,
+				7CD9C3EBF737E415B2561168 /* CSV.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -377,6 +384,7 @@
 				3076738411F8C3FA073D1BE0 /* ContactsBridgeTests.swift in Sources */,
 				1BE87CA3661CF6390FF9EEC4 /* VCardTransferTests.swift in Sources */,
 				63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */,
+				623A5F4AE958EAD5C2757F83 /* CSVTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -68,6 +68,9 @@ struct ContactManagerApp: App {
                     NotificationCenter.default.post(name: .importVCardRequested, object: nil)
                 }
                 .keyboardShortcut("i", modifiers: [.command, .shift])
+                Button("Import CSV…") {
+                    NotificationCenter.default.post(name: .importCSVRequested, object: nil)
+                }
                 Button("Export vCard…") {
                     NotificationCenter.default.post(name: .exportVCardRequested, object: nil)
                 }
@@ -175,6 +178,7 @@ extension Notification.Name {
     /// Posted by menu commands; observed by `ContentView`.
     static let newContactRequested = Notification.Name("ContactManager.newContactRequested")
     static let importVCardRequested = Notification.Name("ContactManager.importVCardRequested")
+    static let importCSVRequested = Notification.Name("ContactManager.importCSVRequested")
     static let importSystemContactsRequested = Notification.Name("ContactManager.importSystemContactsRequested")
     static let exportVCardRequested = Notification.Name("ContactManager.exportVCardRequested")
     static let findDuplicatesRequested = Notification.Name("ContactManager.findDuplicatesRequested")

--- a/ContactManager/Support/CSV.swift
+++ b/ContactManager/Support/CSV.swift
@@ -216,7 +216,10 @@ enum CSV {
         "displayname": .scalar(.fullName),
         "company": .scalar(.company), "companyname": .scalar(.company),
         "organization": .scalar(.company), "organizationname": .scalar(.company),
-        "jobtitle": .scalar(.jobTitle), "title": .scalar(.jobTitle),
+        // Deliberately not mapping bare "Title": in Outlook/Apple CSV
+        // exports that's the honorific (Mr./Mrs./Dr.), not the role —
+        // mapping it here silently overwrote the real "Job Title".
+        "jobtitle": .scalar(.jobTitle),
         "organizationtitle": .scalar(.jobTitle), "position": .scalar(.jobTitle),
         "notes": .scalar(.notes), "note": .scalar(.notes),
         "birthday": .scalar(.birthday), "dob": .scalar(.birthday),

--- a/ContactManager/Support/CSV.swift
+++ b/ContactManager/Support/CSV.swift
@@ -1,0 +1,317 @@
+//
+//  CSV.swift
+//  ContactManager
+//
+//  A small RFC-4180-ish CSV reader plus a header-based mapper that turns
+//  Google Contacts / Outlook / Apple CSV exports into `ParsedContact`
+//  values so they flow through the same `ContactStore.importContacts`
+//  pipeline used by vCard and the macOS Contacts bridge.
+//
+//  Scope choices for the first version:
+//  - Birthdays are accepted in ISO `yyyy-MM-dd` form only (Google's
+//    export format). Locale-dependent forms fall through silently —
+//    same behavior as the vCard reader.
+//  - "Address 1 - …" columns from Google fill the single address slot
+//    we model. Address 2+ is intentionally dropped; we don't have
+//    multi-address support today.
+//  - Custom-labelled email/phone columns ("Home Phone", "E-mail 1 -
+//    Value", etc.) collect into the contact's `emails`/`phones` list
+//    in column order, preserving the label encoded in the header.
+//
+
+import Foundation
+
+enum CSV {
+    // MARK: - Parsing
+
+    /// Parses a CSV document into rows of fields. Handles `CR`/`LF`/`CRLF`
+    /// line endings, double-quoted fields containing commas or newlines,
+    /// and `""` as the escape for a literal quote inside a quoted field.
+    /// A leading UTF-8 BOM (`\u{FEFF}`) is stripped.
+    static func parse(_ text: String) -> [[String]] {
+        var input = text
+        if input.first == "\u{FEFF}" { input.removeFirst() }
+
+        var state = ParseState()
+        var cursor = input.startIndex
+        while cursor < input.endIndex {
+            let char = input[cursor]
+            cursor = state.inQuotes
+                ? state.handleQuoted(char: char, cursor: cursor, in: input)
+                : state.handleUnquoted(char: char, cursor: cursor, in: input)
+        }
+        // Trailing field/row when the file doesn't end with a newline.
+        if !state.field.isEmpty || !state.row.isEmpty {
+            state.endRow()
+        }
+        return state.rows
+    }
+
+    /// Mutable scratchpad used by `parse(_:)`. Pulled out so each
+    /// transition stays small enough for SwiftLint's body-length budget.
+    private struct ParseState {
+        var rows: [[String]] = []
+        var row: [String] = []
+        var field = ""
+        var inQuotes = false
+
+        mutating func endField() {
+            row.append(field); field = ""
+        }
+
+        mutating func endRow() {
+            endField(); rows.append(row); row = []
+        }
+
+        mutating func handleQuoted(char: Character, cursor: String.Index, in input: String) -> String.Index {
+            if char == "\"" {
+                let next = input.index(after: cursor)
+                if next < input.endIndex, input[next] == "\"" {
+                    // Doubled-quote escape: keep one literal quote.
+                    field.append("\"")
+                    return input.index(after: next)
+                }
+                inQuotes = false
+            } else {
+                field.append(char)
+            }
+            return input.index(after: cursor)
+        }
+
+        mutating func handleUnquoted(
+            char: Character, cursor: String.Index, in input: String
+        ) -> String.Index {
+            switch char {
+            case "\"": inQuotes = true
+            case ",": endField()
+            // Swift collapses CRLF into a single `Character`, so the third
+            // case below catches `\r\n` files (Windows / Excel exports);
+            // standalone `\r` (classic Mac) still wraps the row.
+            case "\n", "\r", "\r\n": endRow()
+            default: field.append(char)
+            }
+            return input.index(after: cursor)
+        }
+    }
+
+    // MARK: - Mapping
+
+    /// Parses a CSV contact export. Returns `nil` if the header row
+    /// doesn't include any column we recognize — the caller surfaces
+    /// "couldn't recognize this CSV" instead of importing nothing.
+    static func parseContacts(_ text: String) -> [ParsedContact]? {
+        var rows = parse(text)
+        guard let headers = rows.first else { return nil }
+        rows.removeFirst()
+
+        let columns = headers.map(column(forHeader:))
+        guard columns.contains(where: { $0 != nil }) else { return nil }
+
+        return rows.compactMap { row in
+            let contact = makeContact(row: row, columns: columns)
+            // Skip rows where literally nothing mapped — empty trailing
+            // lines or schema-only stub rows shouldn't become contacts.
+            return contact.isEmpty ? nil : contact
+        }
+    }
+
+    private static func makeContact(
+        row: [String], columns: [Column?]
+    ) -> ParsedContact {
+        var parsed = ParsedContact()
+        // The "full name" column is handled after the loop so explicit
+        // First/Last columns win regardless of column ordering.
+        var fullName = ""
+        for (index, column) in columns.enumerated() {
+            guard let column, index < row.count else { continue }
+            let value = row[index].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty else { continue }
+            if case .scalar(.fullName) = column {
+                fullName = value
+                continue
+            }
+            apply(column: column, value: value, to: &parsed)
+        }
+        if parsed.firstName.isEmpty, parsed.lastName.isEmpty, !fullName.isEmpty {
+            splitName(fullName, into: &parsed)
+        }
+        return parsed
+    }
+
+    private static func apply(
+        column: Column, value: String, to parsed: inout ParsedContact
+    ) {
+        switch column {
+        case .scalar(.firstName): parsed.firstName = value
+        case .scalar(.lastName): parsed.lastName = value
+        case .scalar(.fullName): break // handled in makeContact
+        case .scalar(.company): parsed.company = value
+        case .scalar(.jobTitle): parsed.jobTitle = value
+        case .scalar(.notes): parsed.notes = value
+        case .scalar(.birthday): parsed.birthday = parseBirthday(value)
+        case .scalar(.street): parsed.street = value
+        case .scalar(.city): parsed.city = value
+        case .scalar(.state): parsed.state = value
+        case .scalar(.postalCode): parsed.postalCode = value
+        case .scalar(.country): parsed.country = value
+        case .email(let label): parsed.emails.append((label, value))
+        case .phone(let label): parsed.phones.append((label, value))
+        }
+    }
+
+    private static func splitName(_ name: String, into parsed: inout ParsedContact) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let lastSpace = trimmed.lastIndex(of: " ") {
+            parsed.firstName = String(trimmed[..<lastSpace])
+                .trimmingCharacters(in: .whitespaces)
+            parsed.lastName = String(trimmed[trimmed.index(after: lastSpace)...])
+                .trimmingCharacters(in: .whitespaces)
+        } else {
+            parsed.firstName = trimmed
+        }
+    }
+
+    private static let isoBirthdayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = .autoupdatingCurrent
+        return formatter
+    }()
+
+    private static func parseBirthday(_ value: String) -> Date? {
+        isoBirthdayFormatter.date(from: value)
+    }
+
+    // MARK: - Header → column
+
+    /// Which `ParsedContact` field a scalar column writes to. Kept at the
+    /// top of `CSV` (not nested inside `Column`) so SwiftLint's nesting
+    /// rule stays happy.
+    enum ScalarColumn: Equatable {
+        case firstName, lastName, fullName
+        case company, jobTitle, notes, birthday
+        case street, city, state, postalCode, country
+    }
+
+    /// Internal column kinds. Scalars overwrite the matching `ParsedContact`
+    /// field; `.email`/`.phone` append to their list so multiple columns
+    /// map to multiple values.
+    enum Column: Equatable {
+        case scalar(ScalarColumn)
+        case email(FieldLabel)
+        case phone(FieldLabel)
+    }
+
+    /// Direct header-name → column map. Keys are the normalized form
+    /// (`normalize(_:)` strips spaces/punctuation and lowercases), so
+    /// `"First Name"`, `"first_name"`, and `"first.name"` all match
+    /// `"firstname"`. Lookup keeps `column(forHeader:)` data-driven
+    /// instead of a giant `switch`.
+    private static let headerTable: [String: Column] = [
+        "firstname": .scalar(.firstName), "givenname": .scalar(.firstName),
+        "lastname": .scalar(.lastName), "surname": .scalar(.lastName),
+        "familyname": .scalar(.lastName),
+        "name": .scalar(.fullName), "fullname": .scalar(.fullName),
+        "displayname": .scalar(.fullName),
+        "company": .scalar(.company), "companyname": .scalar(.company),
+        "organization": .scalar(.company), "organizationname": .scalar(.company),
+        "jobtitle": .scalar(.jobTitle), "title": .scalar(.jobTitle),
+        "organizationtitle": .scalar(.jobTitle), "position": .scalar(.jobTitle),
+        "notes": .scalar(.notes), "note": .scalar(.notes),
+        "birthday": .scalar(.birthday), "dob": .scalar(.birthday),
+        "dateofbirth": .scalar(.birthday),
+        "street": .scalar(.street), "address": .scalar(.street),
+        "streetaddress": .scalar(.street),
+        "homestreet": .scalar(.street), "businessstreet": .scalar(.street),
+        "city": .scalar(.city),
+        "homecity": .scalar(.city), "businesscity": .scalar(.city),
+        "state": .scalar(.state), "region": .scalar(.state),
+        "province": .scalar(.state),
+        "homestate": .scalar(.state), "businessstate": .scalar(.state),
+        "zip": .scalar(.postalCode), "zipcode": .scalar(.postalCode),
+        "postalcode": .scalar(.postalCode),
+        "homepostalcode": .scalar(.postalCode),
+        "businesspostalcode": .scalar(.postalCode),
+        "country": .scalar(.country),
+        "homecountry": .scalar(.country), "businesscountry": .scalar(.country),
+        "email": .email(.home), "emailaddress": .email(.home),
+        "primaryemail": .email(.home),
+        "homeemail": .email(.home), "personalemail": .email(.home),
+        "workemail": .email(.work), "businessemail": .email(.work),
+        "phone": .phone(.mobile), "phonenumber": .phone(.mobile),
+        "primaryphone": .phone(.mobile),
+        "homephone": .phone(.home),
+        "workphone": .phone(.work), "businessphone": .phone(.work),
+        "mobilephone": .phone(.mobile), "mobile": .phone(.mobile),
+        "cellphone": .phone(.mobile), "cell": .phone(.mobile),
+        "mainphone": .phone(.main),
+        "otherphone": .phone(.other),
+    ]
+
+    /// Google Contacts "Address 1 - …" columns after stripping the prefix.
+    private static let address1Table: [String: ScalarColumn] = [
+        "street": .street, "city": .city,
+        "region": .state, "state": .state,
+        "postalcode": .postalCode, "country": .country,
+    ]
+
+    /// Matches a single CSV header cell. Returns `nil` for headers we
+    /// don't model (custom fields, separator columns like "E-mail 1 -
+    /// Type"). The lookup is case- and punctuation-insensitive.
+    static func column(forHeader raw: String) -> Column? {
+        let header = normalize(raw)
+        if let direct = headerTable[header] { return direct }
+        // Google Contacts "Address 1 - …" columns.
+        if let suffix = stripPrefix(header, prefix: "address1"),
+           let scalar = address1Table[suffix] {
+            return .scalar(scalar)
+        }
+        // Google's indexed multi-value columns: "E-mail 1 - Value" /
+        // "Phone 2 - Value". After normalize: "email1value" / "phone2value".
+        if isIndexedColumn(header, base: "email", suffix: "value") {
+            return .email(.home)
+        }
+        if isIndexedColumn(header, base: "phone", suffix: "value") {
+            return .phone(.mobile)
+        }
+        return nil
+    }
+
+    /// Lowercases and strips characters that vary across exporters (spaces,
+    /// hyphens, underscores, slashes, dots) so headers compare structurally.
+    private static func normalize(_ raw: String) -> String {
+        var out = ""
+        out.reserveCapacity(raw.count)
+        for char in raw.lowercased() where char.isLetter || char.isNumber {
+            out.append(char)
+        }
+        return out
+    }
+
+    private static func stripPrefix(_ haystack: String, prefix: String) -> String? {
+        guard haystack.hasPrefix(prefix) else { return nil }
+        return String(haystack.dropFirst(prefix.count))
+    }
+
+    private static func isIndexedColumn(_ header: String, base: String, suffix: String) -> Bool {
+        guard header.hasPrefix(base), header.hasSuffix(suffix) else { return false }
+        let middle = header.dropFirst(base.count).dropLast(suffix.count)
+        return !middle.isEmpty && middle.allSatisfy(\.isNumber)
+    }
+}
+
+// MARK: - ParsedContact helpers used during CSV mapping
+
+extension ParsedContact {
+    /// Considered "empty" for the purpose of dropping schema-only stub
+    /// rows: every scalar field is blank and there are no fields/photos.
+    var isEmpty: Bool {
+        firstName.isEmpty && lastName.isEmpty && company.isEmpty
+            && jobTitle.isEmpty && notes.isEmpty && birthday == nil
+            && street.isEmpty && city.isEmpty && state.isEmpty
+            && postalCode.isEmpty && country.isEmpty
+            && emails.isEmpty && phones.isEmpty
+            && photoData == nil
+    }
+}

--- a/ContactManager/Views/ContentView+Import.swift
+++ b/ContactManager/Views/ContentView+Import.swift
@@ -12,6 +12,12 @@
 import Foundation
 import SwiftUI
 
+private enum CSVImportOutcome {
+    case parsed([ParsedContact])
+    case unrecognized
+    case unreadable
+}
+
 extension ContentView {
     // MARK: - System Contacts import
 
@@ -66,6 +72,52 @@ extension ContentView {
                 try store.importContacts(parsed)
             } catch {
                 errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    // MARK: - CSV import
+
+    func handleCSVImport(_ result: Result<URL, Error>) {
+        switch result {
+        case .failure(let error):
+            errorMessage = error.localizedDescription
+        case .success(let url):
+            Task {
+                let outcome: CSVImportOutcome = await Task.detached {
+                    let didAccess = url.startAccessingSecurityScopedResource()
+                    defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+                    guard let data = try? Data(contentsOf: url) else { return .unreadable }
+                    // CSV exports are commonly UTF-8 but Excel still emits
+                    // UTF-16 with a BOM; try both before giving up.
+                    let text: String
+                    if let utf8 = String(data: data, encoding: .utf8) {
+                        text = utf8
+                    } else if let utf16 = String(data: data, encoding: .utf16) {
+                        text = utf16
+                    } else {
+                        return .unreadable
+                    }
+                    guard let parsed = CSV.parseContacts(text) else { return .unrecognized }
+                    return .parsed(parsed)
+                }.value
+
+                switch outcome {
+                case .unreadable:
+                    errorMessage = "That file couldn't be read as a CSV."
+                case .unrecognized:
+                    errorMessage = "Couldn't recognize the CSV — the header row " +
+                        "doesn't include any known contact columns (e.g. First Name, " +
+                        "Email, Phone)."
+                case .parsed(let contacts) where contacts.isEmpty:
+                    errorMessage = "No contacts were found in that file."
+                case .parsed(let contacts):
+                    do {
+                        try store.importContacts(contacts)
+                    } catch {
+                        errorMessage = error.localizedDescription
+                    }
+                }
             }
         }
     }

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -30,6 +30,7 @@ struct ContentView: View {
     @AppStorage("defaultGroupID") private var defaultGroupID: String = ""
 
     @State private var isImportingVCard = false
+    @State private var isImportingCSV = false
     @State private var isExportingVCard = false
     @State private var exportDocument = VCardDocument(text: "")
     @State private var showingDuplicates = false
@@ -130,6 +131,9 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .importVCardRequested)) { _ in
             isImportingVCard = true
         }
+        .onReceive(NotificationCenter.default.publisher(for: .importCSVRequested)) { _ in
+            isImportingCSV = true
+        }
         .onReceive(NotificationCenter.default.publisher(for: .exportVCardRequested)) { _ in
             exportDocument = VCardDocument(text: store.exportVCards(contacts))
             isExportingVCard = true
@@ -158,6 +162,9 @@ struct ContentView: View {
         }
         .fileImporter(isPresented: $isImportingVCard, allowedContentTypes: [.vCard]) { result in
             handleImport(result)
+        }
+        .fileImporter(isPresented: $isImportingCSV, allowedContentTypes: [.commaSeparatedText]) { result in
+            handleCSVImport(result)
         }
         .fileExporter(
             isPresented: $isExportingVCard,

--- a/ContactManagerTests/CSVTests.swift
+++ b/ContactManagerTests/CSVTests.swift
@@ -90,6 +90,14 @@ struct CSVTests {
         #expect(CSV.column(forHeader: "Photo") == nil)
     }
 
+    @Test func doesNotConflateOutlookTitleWithJobTitle() {
+        // "Title" in Outlook/Apple exports is the honorific (Mr./Mrs./Dr.),
+        // not the role. It must not map to jobTitle or it would overwrite
+        // a real "Job Title" cell depending on column order.
+        #expect(CSV.column(forHeader: "Title") == nil)
+        #expect(CSV.column(forHeader: "Job Title") == .scalar(.jobTitle))
+    }
+
     @Test func headersAreCaseAndPunctuationInsensitive() {
         #expect(CSV.column(forHeader: "FIRST_NAME") == .scalar(.firstName))
         #expect(CSV.column(forHeader: "first.name") == .scalar(.firstName))

--- a/ContactManagerTests/CSVTests.swift
+++ b/ContactManagerTests/CSVTests.swift
@@ -1,0 +1,211 @@
+//
+//  CSVTests.swift
+//  ContactManagerTests
+//
+//  Coverage for the pure CSV reader plus the header-based mapper that
+//  turns Google Contacts / Outlook / Apple exports into ParsedContacts.
+//
+
+@testable import ContactManager
+import Foundation
+import Testing
+
+struct CSVTests {
+    // MARK: - Parser
+
+    @Test func parsesSimpleRows() {
+        let rows = CSV.parse("a,b,c\n1,2,3\n")
+        #expect(rows == [["a", "b", "c"], ["1", "2", "3"]])
+    }
+
+    @Test func parsesWithoutTrailingNewline() {
+        let rows = CSV.parse("a,b,c\n1,2,3")
+        #expect(rows.count == 2)
+        #expect(rows.last == ["1", "2", "3"])
+    }
+
+    @Test func handlesQuotedFieldsWithCommas() {
+        let rows = CSV.parse("name,note\n\"Doe, John\",\"hello, world\"\n")
+        #expect(rows == [["name", "note"], ["Doe, John", "hello, world"]])
+    }
+
+    @Test func handlesEscapedQuotesInsideQuotedField() {
+        let rows = CSV.parse("a,b\n\"she said \"\"hi\"\"\",ok\n")
+        #expect(rows.last == ["she said \"hi\"", "ok"])
+    }
+
+    @Test func handlesEmbeddedNewlinesInQuotedFields() {
+        let rows = CSV.parse("note\n\"line one\nline two\"\n")
+        #expect(rows.last == ["line one\nline two"])
+    }
+
+    @Test func handlesCRLFAndLineFeedLineEndings() {
+        let crlf = CSV.parse("a,b\r\n1,2\r\n")
+        let lineFeed = CSV.parse("a,b\n1,2\n")
+        #expect(crlf == lineFeed)
+        #expect(crlf == [["a", "b"], ["1", "2"]])
+    }
+
+    @Test func stripsLeadingUTF8BOM() {
+        let rows = CSV.parse("\u{FEFF}a,b\n1,2\n")
+        #expect(rows.first == ["a", "b"])
+    }
+
+    @Test func emptyFieldsRoundTrip() {
+        let rows = CSV.parse("a,b,c\n,,3\n")
+        #expect(rows.last == ["", "", "3"])
+    }
+
+    // MARK: - Header mapping
+
+    @Test func recognizesGoogleContactsHeaders() {
+        #expect(CSV.column(forHeader: "First Name") == .scalar(.firstName))
+        #expect(CSV.column(forHeader: "Last Name") == .scalar(.lastName))
+        #expect(CSV.column(forHeader: "Organization Name") == .scalar(.company))
+        #expect(CSV.column(forHeader: "Organization Title") == .scalar(.jobTitle))
+        #expect(CSV.column(forHeader: "E-mail 1 - Value") == .email(.home))
+        #expect(CSV.column(forHeader: "Phone 1 - Value") == .phone(.mobile))
+        #expect(CSV.column(forHeader: "Address 1 - Street") == .scalar(.street))
+        #expect(CSV.column(forHeader: "Address 1 - City") == .scalar(.city))
+        #expect(CSV.column(forHeader: "Address 1 - Region") == .scalar(.state))
+        #expect(CSV.column(forHeader: "Address 1 - Postal Code") == .scalar(.postalCode))
+        #expect(CSV.column(forHeader: "Address 1 - Country") == .scalar(.country))
+        #expect(CSV.column(forHeader: "Birthday") == .scalar(.birthday))
+    }
+
+    @Test func recognizesOutlookHeaders() {
+        #expect(CSV.column(forHeader: "Company") == .scalar(.company))
+        #expect(CSV.column(forHeader: "Job Title") == .scalar(.jobTitle))
+        #expect(CSV.column(forHeader: "E-mail Address") == .email(.home))
+        #expect(CSV.column(forHeader: "Home Phone") == .phone(.home))
+        #expect(CSV.column(forHeader: "Business Phone") == .phone(.work))
+        #expect(CSV.column(forHeader: "Mobile Phone") == .phone(.mobile))
+        #expect(CSV.column(forHeader: "Home Street") == .scalar(.street))
+        #expect(CSV.column(forHeader: "Business City") == .scalar(.city))
+    }
+
+    @Test func ignoresUnknownHeaders() {
+        #expect(CSV.column(forHeader: "Yomi Name") == nil)
+        #expect(CSV.column(forHeader: "Custom Field 1") == nil)
+        #expect(CSV.column(forHeader: "Photo") == nil)
+    }
+
+    @Test func headersAreCaseAndPunctuationInsensitive() {
+        #expect(CSV.column(forHeader: "FIRST_NAME") == .scalar(.firstName))
+        #expect(CSV.column(forHeader: "first.name") == .scalar(.firstName))
+        #expect(CSV.column(forHeader: "  Mobile Phone  ") == .phone(.mobile))
+    }
+
+    // MARK: - Contact mapping
+
+    @Test func parsesGoogleContactsExport() throws {
+        let headerLine = "First Name,Last Name,Organization Name,Organization Title,"
+            + "E-mail 1 - Value,Phone 1 - Value,Address 1 - Street,"
+            + "Address 1 - City,Address 1 - Region,Address 1 - Postal Code,"
+            + "Address 1 - Country,Birthday"
+        let valueLine = "Ada,Lovelace,Analytical Engine Co.,Mathematician,"
+            + "ada@analytical.engine,+1 555 0100,12 Mayfair,London,,W1,"
+            + "United Kingdom,1815-12-10"
+        let csv = "\(headerLine)\n\(valueLine)"
+        let parsed = try #require(CSV.parseContacts(csv))
+        #expect(parsed.count == 1)
+        let row = parsed[0]
+        #expect(row.firstName == "Ada")
+        #expect(row.lastName == "Lovelace")
+        #expect(row.company == "Analytical Engine Co.")
+        #expect(row.jobTitle == "Mathematician")
+        #expect(row.street == "12 Mayfair")
+        #expect(row.city == "London")
+        #expect(row.postalCode == "W1")
+        #expect(row.country == "United Kingdom")
+        #expect(row.emails.count == 1)
+        #expect(row.emails[0].value == "ada@analytical.engine")
+        #expect(row.emails[0].label == .home)
+        #expect(row.phones.count == 1)
+        #expect(row.phones[0].value == "+1 555 0100")
+        #expect(row.phones[0].label == .mobile)
+        let parts = try Calendar(identifier: .gregorian)
+            .dateComponents([.year, .month, .day], from: #require(row.birthday))
+        #expect(parts.year == 1815)
+        #expect(parts.month == 12)
+        #expect(parts.day == 10)
+    }
+
+    @Test func parsesOutlookExportWithLabeledPhones() throws {
+        let csv = """
+        First Name,Last Name,Company,E-mail Address,Home Phone,Mobile Phone,Business Phone
+        Grace,Hopper,US Navy,grace@navy.mil,+1 555 0001,+1 555 0002,+1 555 0003
+        """
+        let parsed = try #require(CSV.parseContacts(csv))
+        let row = parsed[0]
+        #expect(row.emails.map(\.value) == ["grace@navy.mil"])
+        #expect(row.phones.map(\.value) == ["+1 555 0001", "+1 555 0002", "+1 555 0003"])
+        #expect(row.phones.map(\.label) == [.home, .mobile, .work])
+    }
+
+    @Test func collectsMultipleIndexedEmailsFromGoogle() throws {
+        let csv = """
+        First Name,E-mail 1 - Value,E-mail 2 - Value
+        Margaret,first@example.com,second@example.com
+        """
+        let parsed = try #require(CSV.parseContacts(csv))
+        #expect(parsed[0].emails.map(\.value) == ["first@example.com", "second@example.com"])
+    }
+
+    @Test func splitsFullNameOnLastSpaceWhenFirstAndLastAreMissing() throws {
+        let csv = """
+        Name,Email
+        Søren Kierkegaard,soren@example.com
+        """
+        let parsed = try #require(CSV.parseContacts(csv))
+        #expect(parsed[0].firstName == "Søren")
+        #expect(parsed[0].lastName == "Kierkegaard")
+    }
+
+    @Test func keepsExplicitFirstAndLastWhenAFullNameColumnIsAlsoPresent() throws {
+        let csv = """
+        Name,First Name,Last Name
+        Alan M. Turing,Alan,Turing
+        """
+        let parsed = try #require(CSV.parseContacts(csv))
+        #expect(parsed[0].firstName == "Alan")
+        #expect(parsed[0].lastName == "Turing")
+    }
+
+    @Test func returnsNilForUnrecognizedHeaders() {
+        let csv = "Yomi Name,Custom Field\nAlan,Whatever\n"
+        #expect(CSV.parseContacts(csv) == nil)
+    }
+
+    @Test func dropsEmptyRows() throws {
+        let csv = """
+        First Name,Email
+        Ada,ada@example.com
+        ,
+        Grace,grace@example.com
+        """
+        let parsed = try #require(CSV.parseContacts(csv))
+        #expect(parsed.count == 2)
+        #expect(parsed.map(\.firstName) == ["Ada", "Grace"])
+    }
+
+    @Test func handlesQuotedFieldsWithCommasInValues() throws {
+        let csv = """
+        First Name,Last Name,Notes
+        Ada,Lovelace,"Loves semicolons, commas, and Bernoulli numbers."
+        """
+        let parsed = try #require(CSV.parseContacts(csv))
+        #expect(parsed[0].notes == "Loves semicolons, commas, and Bernoulli numbers.")
+    }
+
+    @Test func skipsValuesWithUnparseableBirthdays() throws {
+        let csv = """
+        First Name,Birthday
+        Ada,Dec 10 1815
+        """
+        let parsed = try #require(CSV.parseContacts(csv))
+        // Non-ISO format → no birthday rather than wrong birthday.
+        #expect(parsed[0].birthday == nil)
+        #expect(parsed[0].firstName == "Ada")
+    }
+}


### PR DESCRIPTION
## Summary
Adds **File ▸ Import CSV…**: reads a contact CSV, maps known headers to `ParsedContact`, and inserts via the existing `ContactStore.importContacts` path so the operation joins the "Import Contacts" undo group. This is the **K — CSV import** item from the post-rewrite roadmap.

### What ships
- **`CSV` (Support)** — a small RFC-4180-ish reader (CRLF/LF, quoted fields with embedded commas and newlines, `""` escaping, leading UTF-8 BOM stripped) plus a header-based mapper that recognizes **Google Contacts** (`First Name`, `Organization Name`, `E-mail 1 - Value`, `Address 1 - Street`, …) and **Outlook / Apple** forms (`Home Phone`, `Business Phone`, `Mobile`, …). Unknown columns are dropped rather than failing the whole file; if no recognized column appears the call returns `nil` and the caller surfaces "couldn't recognize this CSV" instead of importing nothing.
- **Multi-value handling**: `E-mail 1 - Value` / `E-mail 2 - Value` etc. all collect into the contact's emails list; Outlook-labeled phones (Home/Business/Mobile) preserve their label.
- **Full-name resolution**: when a `Name` / `Display Name` column is present but `First Name` / `Last Name` aren't, split on the last space. Explicit first/last columns always win.
- **Birthdays** accepted in ISO `yyyy-MM-dd` only — Google's export format. Other locales fall through silently (same behavior as the vCard reader).
- Import handler tries UTF-8 first, falls back to UTF-16 for the occasional Excel export, and surfaces a clear error when neither decodes.

### Not in this PR
- Column-mapping UI (manual remap for unrecognized CSVs).
- Custom-label preservation for Google's separate `E-mail N - Type` columns (today imported emails default to `.home` unless the column itself encodes a label).
- CSV *export* (vCard export is still the canonical out-flow).

### Tests
21 new `CSVTests` cover parser corner cases (quoted commas, escaped quotes, embedded newlines, CRLF vs LF — Swift collapses `\\r\\n` into a single grapheme so the switch handles it as its own case) and the mapper (Google + Outlook fixtures, multi-value columns, full-name splitting, unrecognized headers, empty rows, quoted notes). Total: **93 tests across 10 suites** (was 72/9).

## Test plan
- [ ] `make check` (format + lint + 93 tests) green
- [ ] App launches; **File ▸ Import CSV…** appears in the menu
- [ ] Export your Google Contacts as CSV and import it → contacts appear with the right names, emails, phones, and labels
- [ ] Import a CSV with only `Name` (no First/Last) → name is split on the last space
- [ ] Import a CSV with no recognized columns → see the "couldn't recognize this CSV" alert
- [ ] **Edit ▸ Undo Import Contacts** rolls back the import

🤖 Generated with [Claude Code](https://claude.com/claude-code)