### PR TITLE
Open a contact in a new window

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		61F22EEDEE6075BD602203D5 /* VCardDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */; };
 		623A5F4AE958EAD5C2757F83 /* CSVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */; };
 		63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C12246003379D5966F0210 /* ContactEntityTests.swift */; };
+		64A0899508308C671981B72F /* ContactWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B17AADA860AEDB87017DF0B /* ContactWindowView.swift */; };
 		6BF479700A4101F1353CBF78 /* ContactQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B27567532AC1A51FF4CC13A /* ContactQuery.swift */; };
 		6DDC44CAA558E1DB276460CF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833F1AF82CACF7B9E89BADCA /* ContentView.swift */; };
 		7755029B0E36200BB139ECFA /* VCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7D5B554122CF852B0D825C /* VCardTests.swift */; };
@@ -80,6 +81,7 @@
 		66F852CE2356ADE83460064B /* ContentView+Import.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+Import.swift"; sourceTree = "<group>"; };
 		734D363DD0CB0BAA7AE9460B /* LayoutMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LayoutMetrics.swift; sourceTree = "<group>"; };
 		73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactDetailView.swift; sourceTree = "<group>"; };
+		7B17AADA860AEDB87017DF0B /* ContactWindowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactWindowView.swift; sourceTree = "<group>"; };
 		7B27494A51645ACA6BED8EA8 /* OpenContactIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenContactIntent.swift; sourceTree = "<group>"; };
 		7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactsBridgeTests.swift; sourceTree = "<group>"; };
 		7E7D5B554122CF852B0D825C /* VCardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTests.swift; sourceTree = "<group>"; };
@@ -187,6 +189,7 @@
 				734D363DD0CB0BAA7AE9460B /* LayoutMetrics.swift */,
 				F9795992CBF553603FD37928 /* SettingsView.swift */,
 				66F852CE2356ADE83460064B /* ContentView+Import.swift */,
+				7B17AADA860AEDB87017DF0B /* ContactWindowView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -368,6 +371,7 @@
 				CEAC8F942C862FADB6C45220 /* SpotlightIndexer.swift in Sources */,
 				AC7E1126C65C59B15141CB79 /* ContentView+Import.swift in Sources */,
 				7CD9C3EBF737E415B2561168 /* CSV.swift in Sources */,
+				64A0899508308C671981B72F /* ContactWindowView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -31,6 +31,20 @@ struct ContactManagerApp: App {
                 }
             }
         }
+        // Detached single-contact window. The value type is the encoded
+        // `PersistentIdentifier` string (the same scheme used by App
+        // Intents/Spotlight) so it round-trips cleanly through
+        // `OpenWindowAction` and SwiftUI's window-restoration store.
+        WindowGroup(id: "contact", for: String.self) { $encodedID in
+            switch loadState {
+            case .ready(let container):
+                ContactWindowView(encodedID: encodedID)
+                    .modelContainer(container)
+            case .testing, .failed:
+                EmptyView()
+            }
+        }
+        .defaultSize(width: 520, height: 640)
         Settings {
             // The Settings scene gets its own model container injection so
             // the default-group picker can @Query groups. When the store

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -19,6 +19,9 @@ struct ContactListView: View {
     /// Called when a `.vcf` file is dropped onto the list from Finder.
     var importVCardURLs: ([URL]) -> Void
 
+    /// SwiftUI's `OpenWindowAction` for the detached-contact window.
+    @Environment(\.openWindow) private var openWindow
+
     var body: some View {
         List(selection: $selection) {
             ForEach(sections) { section in
@@ -28,6 +31,7 @@ struct ContactListView: View {
                             .tag(contact)
                             // Drag a row to Finder to write `<Name>.vcf`.
                             .draggable(transfer(for: contact))
+                            .contextMenu { rowContextMenu(for: contact) }
                     }
                 }
             }
@@ -82,6 +86,23 @@ struct ContactListView: View {
             suggestedName: VCardTransfer.suggestedFilename(for: contact.fullName),
             text: VCard.card(for: contact)
         )
+    }
+
+    @ViewBuilder
+    private func rowContextMenu(for contact: Contact) -> some View {
+        Button("Open in New Window") {
+            // The detached window resolves the contact via its encoded
+            // `PersistentIdentifier` — the same scheme used by App
+            // Intents/Spotlight, so closed windows can survive a relaunch
+            // (or fail gracefully if the contact was deleted in between).
+            if let encoded = contact.persistentModelID.storedString {
+                openWindow(id: "contact", value: encoded)
+            }
+        }
+        Divider()
+        Button("Delete", role: .destructive) {
+            deleteContact(contact)
+        }
     }
 
     @ViewBuilder

--- a/ContactManager/Views/ContactWindowView.swift
+++ b/ContactManager/Views/ContactWindowView.swift
@@ -1,0 +1,52 @@
+//
+//  ContactWindowView.swift
+//  ContactManager
+//
+//  The single-contact detached window — opened via the row context menu
+//  ("Open in New Window"). The window receives the contact's encoded
+//  `PersistentIdentifier` (same string scheme used by App Intents and
+//  the default-group preference) and resolves it to a live `Contact`
+//  out of the shared model container.
+//
+//  Edits flow through the same `ContactStore` the main window uses, so
+//  changes appear in both places and join the main app's undo stack.
+//
+
+import SwiftData
+import SwiftUI
+
+struct ContactWindowView: View {
+    /// JSON-encoded `PersistentIdentifier`. Optional only because
+    /// `WindowGroup`'s binding hands us `String?` — an empty value is
+    /// treated the same as a missing contact below.
+    let encodedID: String?
+
+    @Query(sort: [SortDescriptor(\Contact.lastName), SortDescriptor(\Contact.firstName)])
+    private var contacts: [Contact]
+
+    private var contact: Contact? {
+        guard let encodedID,
+              let id = PersistentIdentifier.decode(stored: encodedID)
+        else { return nil }
+        return contacts.first { $0.persistentModelID == id }
+    }
+
+    var body: some View {
+        Group {
+            if let contact {
+                ContactDetailView(contact: contact)
+                    .navigationTitle(contact.fullName)
+            } else {
+                ContentUnavailableView(
+                    "Contact Not Found",
+                    systemImage: "person.crop.circle.badge.questionmark",
+                    description: Text(
+                        "This window's contact may have been deleted. " +
+                            "Close the window or open another contact from the main window."
+                    )
+                )
+            }
+        }
+        .frame(minWidth: 460, minHeight: 520)
+    }
+}


### PR DESCRIPTION
## Summary
Right-clicking a contact in the list now offers **Open in New Window**. The detached window shows just that contact's detail form; edits flow through the same `ContactStore`, so changes appear in both windows and join the main app's undo stack. This is the **I — Multi-window** item from the post-rewrite roadmap.

### Plumbing
- New `WindowGroup(id: "contact", for: String.self)` keyed on the encoded `PersistentIdentifier` (same scheme App Intents/Spotlight use), so the value round-trips through `OpenWindowAction` and SwiftUI's window-restoration store. `.defaultSize(520 × 640)`.
- `ContactWindowView` resolves the encoded id against the shared container's `@Query` and falls back to a "Contact Not Found" unavailable view when the target was deleted (or the restoration string is from a previous container).
- `ContactListView` reads `\.openWindow` from the environment and adds a row context menu with **Open in New Window** plus a destructive **Delete** for parity with the existing ⌫ shortcut.

### Not in this PR
- A Window menu command (e.g. `Window ▸ Open Contact in New Window`) with a keyboard shortcut. The context menu covers the discoverable path; a menu-bar command can be a follow-up if you want it bound to a chord.
- Per-window state persistence beyond what SwiftUI gives us for free.

## Test plan
- [ ] `make check` (format + lint + 93 tests) green
- [ ] App launches
- [ ] Right-click a contact in the list → "Open in New Window" opens a new window with that contact's detail
- [ ] Edit the contact in the detached window → the change appears in the main window
- [ ] Close the detached window → app stays running while the main window is open; ⌘W closes the detached window
- [ ] Delete the contact from the main window → the detached window shows "Contact Not Found"
- [ ] Right-click → Delete works the same as ⌫ on the selected row

🤖 Generated with [Claude Code](https://claude.com/claude-code)