### PR TITLE
Enable App Sandbox with required entitlements

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactListView.swift; sourceTree = "<group>"; };
 		0B27567532AC1A51FF4CC13A /* ContactQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactQuery.swift; sourceTree = "<group>"; };
 		0F82C8A388E97CC4F1106176 /* SampleData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SampleData.swift; sourceTree = "<group>"; };
+		10E14CB9E9A2442DFE7B0E0B /* ContactManager.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = ContactManager.entitlements; sourceTree = "<group>"; };
 		10E7338673D65A6FAB4F9AF3 /* ContactManagerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContactManagerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotlightIndexer.swift; sourceTree = "<group>"; };
 		2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactsBridge.swift; sourceTree = "<group>"; };
@@ -250,6 +251,7 @@
 				A34742F5CC5340B2EE610BF4 /* Support */,
 				C876089F42640D0818FE333F /* Views */,
 				C80F354FEBD80D33AEC2F590 /* Intents */,
+				10E14CB9E9A2442DFE7B0E0B /* ContactManager.entitlements */,
 			);
 			path = ContactManager;
 			sourceTree = "<group>";
@@ -612,9 +614,11 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = ContactManager/ContactManager.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -649,10 +653,12 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = ContactManager/ContactManager.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_GENERATE_TEST_COVERAGE_FILES = NO;

--- a/ContactManager/ContactManager.entitlements
+++ b/ContactManager/ContactManager.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds `ContactManager.entitlements` and turns on `ENABLE_APP_SANDBOX = YES` for the app target so the app can be notarized cleanly and submitted to the Mac App Store. Previously the project shipped hardened-runtime only with no entitlements wired.
- Declares only the three capabilities the app actually exercises today: `app-sandbox`, `files.user-selected.read-write` (file pickers + the existing drag-and-drop import/export flows), `personal-information.addressbook` (for the Import from Contacts… path via `ContactsBridge`).
- pbxproj edits done via the `xcodeproj` Ruby gem per CLAUDE.md; sandbox stays off on the test targets.

## Test plan
- [x] `make check` — format-check + lint + 21 unit tests + 3 UI tests all green against the sandboxed build
- [x] UI tests boot the actual sandboxed app (the in-memory test container + ⌘⇧D Find Duplicates flow still work)
- [ ] Manual: run the production launch path with an existing on-disk store to confirm the SwiftData container auto-redirects to the sandbox container (`~/Library/Containers/com.scottdensmore.ContactManager/Data/Library/Application Support/`)
- [ ] Manual: vCard / CSV import + export sheets, drag-image-onto-avatar, drag-contact-to-Finder, Import from Contacts… all still work

## Notes
- CloudKit (audit P0 #2) is **not** addressed here. The code still passes `cloudKitDatabase: .automatic` and silently degrades to local-only since no iCloud capability is wired. Decided to keep that as a separate PR so the scope stays small and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)