### PR TITLE
Debounce search, optimize ContactQuery.filtered

### DIFF
--- a/ContactManager/Models/ContactQuery.swift
+++ b/ContactManager/Models/ContactQuery.swift
@@ -46,19 +46,20 @@ enum ContactQuery {
     /// Filters contacts whose name, company, job title, notes, or any email/
     /// phone field value contains the query. An empty query returns every
     /// contact unchanged.
+    ///
+    /// Uses `localizedCaseInsensitiveContains` (no per-string `.lowercased()`
+    /// allocation) and short-circuits on the cheap scalar attributes before
+    /// walking the to-many `fields` relationship.
     static func filtered(_ contacts: [Contact], matching query: String) -> [Contact] {
-        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty else { return contacts }
 
         return contacts.filter { contact in
-            let haystacks = [
-                contact.fullName,
-                contact.company,
-                contact.jobTitle,
-                contact.notes,
-            ] + contact.fields.map(\.value)
-
-            return haystacks.contains { $0.lowercased().contains(needle) }
+            if contact.fullName.localizedCaseInsensitiveContains(needle) { return true }
+            if contact.company.localizedCaseInsensitiveContains(needle) { return true }
+            if contact.jobTitle.localizedCaseInsensitiveContains(needle) { return true }
+            if contact.notes.localizedCaseInsensitiveContains(needle) { return true }
+            return contact.fields.contains { $0.value.localizedCaseInsensitiveContains(needle) }
         }
     }
 

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -26,6 +26,10 @@ struct ContentView: View {
     // set this when a parse/insert fails.
     @State var errorMessage: String?
     @State private var searchText = ""
+    /// Trails `searchText` by 150 ms so we don't re-filter the entire contact
+    /// list on every keystroke. Cleared instantly when the user clears the
+    /// search field — only typing-into-non-empty pays the debounce delay.
+    @State private var debouncedSearchText = ""
     @AppStorage("contactSortOrder") private var sortOrder: ContactSortOrder = .lastName
     @AppStorage("defaultGroupID") private var defaultGroupID: String = ""
 
@@ -74,7 +78,7 @@ struct ContentView: View {
 
     private var sections: [ContactSection] {
         ContactQuery.sections(
-            ContactQuery.filtered(scopedContacts, matching: searchText),
+            ContactQuery.filtered(scopedContacts, matching: debouncedSearchText),
             by: sortOrder
         )
     }
@@ -117,6 +121,21 @@ struct ContentView: View {
             minWidth: LayoutMetrics.windowMinWidth,
             minHeight: LayoutMetrics.windowMinHeight
         )
+        .task(id: searchText) {
+            // Empty → clear immediately. Otherwise wait 150 ms before
+            // committing the new query so a burst of keystrokes only
+            // triggers one filter pass.
+            if searchText.isEmpty {
+                debouncedSearchText = ""
+                return
+            }
+            do {
+                try await Task.sleep(for: .milliseconds(150))
+                debouncedSearchText = searchText
+            } catch {
+                // Task cancelled — a newer keystroke superseded this one.
+            }
+        }
         .onAppear {
             // Route every ContactStore mutation through the window's undo
             // manager so Edit ▸ Undo/Redo (⌘Z / ⇧⌘Z) work.


### PR DESCRIPTION
## Summary
Two fixes for the search hitch that gets visible past a few thousand contacts (audit P0 #3).

- **Debounce.** `ContentView.searchText` now feeds a `debouncedSearchText` that trails by 150 ms via `.task(id: searchText)`. A burst of keystrokes triggers one filter pass instead of one per character. Empty searches skip the delay so clearing the field returns the full list instantly.
- **Filter optimization.** `ContactQuery.filtered` no longer lowercases every field of every contact and folds them into a temporary array. It now uses `localizedCaseInsensitiveContains` on each candidate in turn, short-circuiting on the cheap scalar attributes (`fullName`, `company`, `jobTitle`, `notes`) before walking the to-many `fields` relationship. No more per-string allocation; the field walk only runs for contacts whose scalars didn't already hit.

Intentionally **not** in this PR: rewriting `@Query` as a child view with a SwiftData `#Predicate` `FetchDescriptor`. The debounce already eliminates the per-keystroke hitch; the predicate refactor is a structurally bigger change (child view with `@Query`, group-scope predicate construction) that's worth handling separately if the in-memory pass starts mattering at larger N.

## Test plan
- [x] `make check` — all 21 unit tests + 3 UI tests pass
- [x] Existing search-semantics coverage in `ContactModelTests` (name, company+email, notes, phone-field match, empty passes all through, no-match returns empty) is unchanged and green
- [ ] Manual: type quickly into the search field with the seeded sample and confirm the list updates after a brief pause rather than per-character
- [ ] Manual: clear the search field and confirm the list snaps back without delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)