### PR TITLE
Index Spotlight incrementally from a per-mutation delta

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */; };
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
 		4EC36757044377406665E53B /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */; };
+		52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */; };
 		61F22EEDEE6075BD602203D5 /* VCardDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */; };
 		623A5F4AE958EAD5C2757F83 /* CSVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */; };
 		63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C12246003379D5966F0210 /* ContactEntityTests.swift */; };
@@ -86,6 +87,7 @@
 		4E2F2242E59F2C42DDD0736B /* CSV.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSV.swift; sourceTree = "<group>"; };
 		54C373BD237429970D6A7C86 /* DuplicatesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicatesView.swift; sourceTree = "<group>"; };
 		5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingTests.swift; sourceTree = "<group>"; };
+		604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotlightDeltaTests.swift; sourceTree = "<group>"; };
 		61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PersistentIdentifierEncoding.swift; sourceTree = "<group>"; };
 		617D7B082A403094284FBD38 /* ContactStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStore.swift; sourceTree = "<group>"; };
 		6303A7F66E428BF3662142C0 /* SidebarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 				F9F733D535CFC76FA07FB61E /* VCardTransferTests.swift */,
 				93C12246003379D5966F0210 /* ContactEntityTests.swift */,
 				BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */,
+				604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -445,6 +448,7 @@
 				1BE87CA3661CF6390FF9EEC4 /* VCardTransferTests.swift in Sources */,
 				63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */,
 				623A5F4AE958EAD5C2757F83 /* CSVTests.swift in Sources */,
+				52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Models/ContactStore.swift
+++ b/ContactManager/Models/ContactStore.swift
@@ -254,12 +254,46 @@ struct ContactStore {
         undoManager?.beginUndoGrouping()
         do {
             let result = try body()
+
+            // Snapshot the context's pending changes *before* the save clears
+            // them, so the notification can carry a precise delta and the
+            // Spotlight index updates incrementally rather than rebuilding the
+            // whole thing on every edit.
+            let touched = context.insertedModelsArray + context.changedModelsArray
+            let deletedModels = context.deletedModelsArray
+            // Deleted contacts already hold permanent ids (they were saved
+            // before), so read them now — after the save the objects are gone.
+            let deletedIDs = Set(
+                deletedModels.compactMap { ($0 as? Contact)?.persistentModelID.storedString }
+            )
+            // A field can be deleted while its owning contact survives (Delete
+            // Field, or merge folding duplicates). Capture those owners now,
+            // while the inverse relationship is still intact, so the contact's
+            // emails/phones get refreshed.
+            let survivingFieldOwnerIDs = Set(
+                deletedModels.compactMap { ($0 as? ContactField)?.contact?.persistentModelID.storedString }
+            )
+
             try context.save()
             undoManager?.endUndoGrouping()
             undoManager?.setActionName(actionName)
+
+            // Read updated ids *after* the save: a freshly inserted contact's
+            // pre-save id is temporary and wouldn't match a later fetch-by-id;
+            // the save promotes it to the permanent identifier in place.
+            var updatedIDs = Set(touched.compactMap(Self.affectedContactID))
+            updatedIDs.formUnion(survivingFieldOwnerIDs)
+            updatedIDs.subtract(deletedIDs) // never re-index a contact we just deleted
+            let change = ContactChange(updatedIDs: updatedIDs, deletedIDs: deletedIDs)
+
             // Observed by ContentView to refresh the Spotlight index. Fired
-            // after the save commits so observers see the post-mutation state.
-            NotificationCenter.default.post(name: .contactsDidChange, object: nil)
+            // after the save commits so observers see the post-mutation state,
+            // and carries the delta so the refresh stays incremental.
+            NotificationCenter.default.post(
+                name: .contactsDidChange,
+                object: nil,
+                userInfo: [ContactChange.userInfoKey: change]
+            )
             return result
         } catch {
             context.rollback()
@@ -267,6 +301,38 @@ struct ContactStore {
             throw error
         }
     }
+
+    /// Maps a touched model to the contact whose Spotlight entry it affects: a
+    /// `Contact` directly, or a `ContactField` via its owner. Other models
+    /// (e.g. `ContactGroup`) don't appear in the index and map to `nil`.
+    private static func affectedContactID(of model: any PersistentModel) -> String? {
+        switch model {
+        case let contact as Contact:
+            contact.persistentModelID.storedString
+        case let field as ContactField:
+            field.contact?.persistentModelID.storedString
+        default:
+            nil
+        }
+    }
+}
+
+/// The set of contacts a `ContactStore` mutation touched, delivered in the
+/// `.contactsDidChange` notification so observers (the Spotlight indexer) can
+/// update incrementally. Ids are encoded `PersistentIdentifier`s — the same
+/// scheme `ContactEntity.id` uses, so they round-trip through a fetch-by-id.
+struct ContactChange {
+    /// Contacts created or edited — their Spotlight entry needs refreshing.
+    var updatedIDs: Set<String>
+    /// Contacts deleted — their Spotlight entry must be removed.
+    var deletedIDs: Set<String>
+
+    /// True when the mutation touched no indexable contact (e.g. renaming a
+    /// group), letting observers skip work entirely.
+    var isEmpty: Bool { updatedIDs.isEmpty && deletedIDs.isEmpty }
+
+    /// `userInfo` key the change rides under in `.contactsDidChange`.
+    static let userInfoKey = "ContactManager.contactChange"
 }
 
 enum ContactStoreError: LocalizedError {

--- a/ContactManager/Support/PersistentIdentifierEncoding.swift
+++ b/ContactManager/Support/PersistentIdentifierEncoding.swift
@@ -15,8 +15,16 @@ import SwiftData
 extension PersistentIdentifier {
     /// JSON-encoded string suitable for `@AppStorage`. Returns `nil` only
     /// if encoding unexpectedly fails (shouldn't in practice).
+    ///
+    /// Keys are sorted so the *same* identifier always encodes to the *same*
+    /// string. Without this, `PersistentIdentifier`'s Codable output reorders
+    /// keys between encodings (even within one process), and any code that
+    /// compares two separately-encoded ids by string — Spotlight's
+    /// `entities(for:)` lookup, incremental re-index matching — would miss.
     var storedString: String? {
-        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        guard let data = try? encoder.encode(self) else { return nil }
         return String(data: data, encoding: .utf8)
     }
 

--- a/ContactManager/Support/SpotlightIndexer.swift
+++ b/ContactManager/Support/SpotlightIndexer.swift
@@ -23,18 +23,14 @@ actor SpotlightIndexer {
     static let domainIdentifier = "com.scottdensmore.ContactManager.contacts"
 
     /// Replaces our entire indexed set with a freshly-fetched snapshot.
+    /// Used at launch and as a fallback; per-mutation refreshes should go
+    /// through `apply(_:)` so they don't rebuild the whole index.
     /// Errors are logged but not surfaced — a Spotlight indexing failure
     /// is a quality-of-life regression, not a user-visible error.
     func reindex() async {
         let entities = await (try? ContactEntityQuery().allEntities()) ?? []
         let index = CSSearchableIndex.default()
-        let items = entities.map { entity in
-            CSSearchableItem(
-                uniqueIdentifier: entity.id,
-                domainIdentifier: Self.domainIdentifier,
-                attributeSet: entity.attributeSet
-            )
-        }
+        let items = entities.map(Self.makeItem)
         do {
             try await index.deleteSearchableItems(withDomainIdentifiers: [Self.domainIdentifier])
             if !items.isEmpty {
@@ -43,5 +39,38 @@ actor SpotlightIndexer {
         } catch {
             print("Spotlight reindex failed: \(error)")
         }
+    }
+
+    /// Applies a single mutation's delta: re-indexes the updated contacts
+    /// (fetched fresh by id) and removes the deleted ones. O(changed) instead
+    /// of `reindex()`'s O(all contacts), so a one-contact edit no longer
+    /// rebuilds the entire index. Like `reindex()`, errors are logged only.
+    func apply(_ change: ContactChange) async {
+        guard !change.isEmpty else { return }
+        let index = CSSearchableIndex.default()
+        do {
+            if !change.deletedIDs.isEmpty {
+                try await index.deleteSearchableItems(withIdentifiers: Array(change.deletedIDs))
+            }
+            if !change.updatedIDs.isEmpty {
+                // Fetch only the touched contacts. An id with no match (created
+                // and removed before we got here) simply yields no item.
+                let entities = await (try? ContactEntityQuery().entities(for: Array(change.updatedIDs))) ?? []
+                let items = entities.map(Self.makeItem)
+                if !items.isEmpty {
+                    try await index.indexSearchableItems(items)
+                }
+            }
+        } catch {
+            print("Spotlight incremental update failed: \(error)")
+        }
+    }
+
+    private static func makeItem(for entity: ContactEntity) -> CSSearchableItem {
+        CSSearchableItem(
+            uniqueIdentifier: entity.id,
+            domainIdentifier: domainIdentifier,
+            attributeSet: entity.attributeSet
+        )
     }
 }

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -166,11 +166,17 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .openContactRequested)) { note in
             selectContact(byEncodedID: note.userInfo?["id"] as? String)
         }
-        .onReceive(NotificationCenter.default.publisher(for: .contactsDidChange)) { _ in
-            // The indexer fetches its own snapshot — `@Query`'s post-save
+        .onReceive(NotificationCenter.default.publisher(for: .contactsDidChange)) { note in
+            // Apply just the mutation's delta — the indexer fetches the
+            // affected contacts fresh by id, since `@Query`'s post-save
             // refresh is asynchronous and can still reflect pre-save state
-            // when this notification fires.
-            Task { await SpotlightIndexer.shared.reindex() }
+            // when this notification fires. A post without a payload falls
+            // back to a full reindex.
+            if let change = note.userInfo?[ContactChange.userInfoKey] as? ContactChange {
+                Task { await SpotlightIndexer.shared.apply(change) }
+            } else {
+                Task { await SpotlightIndexer.shared.reindex() }
+            }
         }
         .onContinueUserActivity(CSSearchableItemActionType) { activity in
             let id = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String

--- a/ContactManager/Views/SettingsView.swift
+++ b/ContactManager/Views/SettingsView.swift
@@ -65,8 +65,16 @@ struct SettingsView: View {
             if !defaultGroupID.isEmpty { defaultGroupID = "" }
             return
         }
-        if !groups.contains(where: { $0.persistentModelID == id }) {
+        guard groups.contains(where: { $0.persistentModelID == id }) else {
             defaultGroupID = ""
+            return
+        }
+        // Re-store in the canonical (sorted-key) encoding. A value written by
+        // an older build used a non-deterministic key order, so its string
+        // wouldn't match the freshly-encoded picker tags; normalizing here
+        // keeps the selection highlighted without a separate migration.
+        if let canonical = id.storedString, canonical != defaultGroupID {
+            defaultGroupID = canonical
         }
     }
 }

--- a/ContactManagerTests/ContactEntityTests.swift
+++ b/ContactManagerTests/ContactEntityTests.swift
@@ -89,11 +89,14 @@ struct ContactEntityTests {
         #expect(decoded == contact.persistentModelID)
     }
 
-    @Test func encodedIdIsStableAcrossEncodings() {
+    @Test func encodedIdIsStableAcrossEncodings() throws {
         // Spotlight's incremental re-index and `entities(for:)` lookup match
         // contacts by comparing two separately-encoded ids as strings, so the
-        // same identifier must always encode to the same string.
+        // same identifier must always encode to the same string. Unwrap both
+        // so a `nil` encoding fails the test instead of trivially matching.
         let id = sampleContact().persistentModelID
-        #expect(id.storedString == id.storedString)
+        let first = try #require(id.storedString)
+        let second = try #require(id.storedString)
+        #expect(first == second)
     }
 }

--- a/ContactManagerTests/ContactEntityTests.swift
+++ b/ContactManagerTests/ContactEntityTests.swift
@@ -88,4 +88,12 @@ struct ContactEntityTests {
         let decoded = try #require(PersistentIdentifier.decode(stored: entity.id))
         #expect(decoded == contact.persistentModelID)
     }
+
+    @Test func encodedIdIsStableAcrossEncodings() {
+        // Spotlight's incremental re-index and `entities(for:)` lookup match
+        // contacts by comparing two separately-encoded ids as strings, so the
+        // same identifier must always encode to the same string.
+        let id = sampleContact().persistentModelID
+        #expect(id.storedString == id.storedString)
+    }
 }

--- a/ContactManagerTests/SpotlightDeltaTests.swift
+++ b/ContactManagerTests/SpotlightDeltaTests.swift
@@ -1,0 +1,106 @@
+//
+//  SpotlightDeltaTests.swift
+//  ContactManagerTests
+//
+//  Verifies the `ContactChange` delta that `ContactStore` broadcasts in the
+//  `.contactsDidChange` notification. `SpotlightIndexer` consumes this delta
+//  to update the index incrementally, so getting the affected-contact set
+//  right is what keeps a single edit from rebuilding the entire index.
+//
+
+@testable import ContactManager
+import Foundation
+import SwiftData
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct SpotlightDeltaTests {
+    let container: ModelContainer
+    let store: ContactStore
+    var context: ModelContext { container.mainContext }
+
+    init() throws {
+        container = try ModelContainer(
+            for: Contact.self, ContactField.self, ContactGroup.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        store = ContactStore(container.mainContext)
+    }
+
+    /// Captures the `ContactChange` posted by the mutation `body` runs.
+    /// `.contactsDidChange` is posted synchronously on the main actor, so the
+    /// observer fires before `body` returns.
+    private func change(during body: () throws -> Void) rethrows -> ContactChange? {
+        var captured: ContactChange?
+        let token = NotificationCenter.default.addObserver(
+            forName: .contactsDidChange, object: nil, queue: nil
+        ) { note in
+            captured = note.userInfo?[ContactChange.userInfoKey] as? ContactChange
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+        try body()
+        return captured
+    }
+
+    @Test func createEmitsUpdateForTheNewContact() throws {
+        var contact: Contact?
+        let change = try #require(try change { contact = try store.createContact() })
+        let id = try #require(contact?.persistentModelID.storedString)
+        #expect(change.updatedIDs == [id])
+        #expect(change.deletedIDs.isEmpty)
+    }
+
+    @Test func deleteEmitsRemovalAndNoUpdate() throws {
+        let contact = try store.createContact()
+        let id = try #require(contact.persistentModelID.storedString)
+
+        let change = try #require(try change { try store.delete(contact) })
+        #expect(change.deletedIDs == [id])
+        #expect(change.updatedIDs.isEmpty)
+    }
+
+    @Test func addFieldEmitsUpdateForOwningContact() throws {
+        let contact = try store.createContact()
+        let id = try #require(contact.persistentModelID.storedString)
+
+        let change = try #require(try change { try store.addField(.email, to: contact) })
+        #expect(change.updatedIDs.contains(id))
+        #expect(change.deletedIDs.isEmpty)
+    }
+
+    @Test func deleteFieldEmitsUpdateForSurvivingOwner() throws {
+        let contact = try store.createContact()
+        let field = try store.addField(.phone, value: "555", to: contact)
+        let id = try #require(contact.persistentModelID.storedString)
+
+        let change = try #require(try change { try store.delete([field]) })
+        #expect(change.updatedIDs == [id]) // owner refreshed, not deleted
+        #expect(change.deletedIDs.isEmpty)
+    }
+
+    @Test func renamingGroupTouchesNoContact() throws {
+        let group = try store.createGroup(named: "Work")
+
+        let change = try #require(try change { try store.rename(group, to: "Clients") })
+        #expect(change.isEmpty)
+    }
+
+    @Test func mergeUpdatesPrimaryAndDeletesTheRest() throws {
+        let primary = try store.createContact()
+        primary.firstName = "Ada"
+        let duplicate = try store.createContact()
+        duplicate.firstName = "Ada"
+        // Give the duplicate an email so the merge reassigns it to the primary
+        // — that reassignment is what marks the primary as touched.
+        try store.addField(.email, value: "ada@home.test", to: duplicate)
+        try context.save()
+
+        let primaryID = try #require(primary.persistentModelID.storedString)
+        let duplicateID = try #require(duplicate.persistentModelID.storedString)
+
+        let change = try #require(try change { _ = try store.merge([primary, duplicate]) })
+        #expect(change.updatedIDs == [primaryID]) // surviving contact re-indexed
+        #expect(change.deletedIDs == [duplicateID]) // duplicate removed
+    }
+}


### PR DESCRIPTION
## Summary
Audit P0 #4. Every `ContactStore` mutation posted a payload-less `.contactsDidChange`, and `ContentView` answered it by rebuilding the **entire** Spotlight index — delete-the-whole-domain + re-index every contact. That's O(all contacts) per single edit, with a brief window where the index is empty.

- **Per-mutation delta.** `mutate` now snapshots the context's pending changes around the save and broadcasts a `ContactChange { updatedIDs, deletedIDs }`:
  - `updatedIDs` = inserted/changed `Contact`s, plus the owning contact of any inserted/changed/deleted `ContactField` (a contact's emails/phones feed its Spotlight entry), minus anything being deleted.
  - `deletedIDs` = removed `Contact`s.
  - Ids are read **after** the save so a freshly inserted contact carries its permanent `PersistentIdentifier` (the temporary pre-save id wouldn't match a later fetch). Owners of deleted fields are captured **before** the save, while the inverse relationship is still intact.
- **Incremental apply.** `SpotlightIndexer.apply(_:)` deletes the removed ids, fetches only the updated contacts by id, and re-indexes those — O(changed) instead of O(all). `reindex()` stays for launch and as a fallback when a post arrives without a payload. Group-only changes (e.g. rename) map to no contact and are a no-op.
- **Determinism fix (latent bug).** `PersistentIdentifier.storedString` now encodes with `.sortedKeys`. Its `Codable` output otherwise reorders keys between encodings — even within one process — so the id captured at save time could differ *as a string* from the same id re-encoded at fetch time, making the by-id lookup (and the pre-existing Spotlight-**open** path in `entities(for:)`) silently miss. A flaky equality assertion in the new tests surfaced it.

## Test plan
- [x] `make check` — 101 unit tests + 3 UI tests pass; ran the unit suite 3× to confirm the determinism fix removed the flake
- [x] New `SpotlightDeltaTests` suite asserts the emitted delta for create / delete / add-field / delete-field / group-rename / merge
- [x] `ContactEntityTests` gains an id-encoding stability check
- [ ] Manual: edit a single contact in a large store and confirm its Spotlight entry updates without the whole index churning; delete a contact and confirm it drops out of Spotlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)