### PR TITLE
Add mailto:/tel: actions to contact detail quick rows

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		14E0C9EBEF8212F3F9B2777D /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51E6728EF90B1D2BF8EA5AE /* Contact.swift */; };
 		15AD8E34CC4EF4BC81F8A159 /* ContactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */; };
 		1BE87CA3661CF6390FF9EEC4 /* VCardTransferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F733D535CFC76FA07FB61E /* VCardTransferTests.swift */; };
+		21EF2DF533DFA347DCF69BD0 /* ContactLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE79F02FFFD9820269D3725 /* ContactLinkTests.swift */; };
 		23BF1F338E4C813308B5DEE2 /* ContactField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25751DDEC1515E341AF67F5 /* ContactField.swift */; };
 		2B9D4C628CAAECD10F00F5E2 /* LayoutMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734D363DD0CB0BAA7AE9460B /* LayoutMetrics.swift */; };
 		2EB13805320DA225F70D08F3 /* VCardTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */; };
@@ -31,6 +32,7 @@
 		7755029B0E36200BB139ECFA /* VCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7D5B554122CF852B0D825C /* VCardTests.swift */; };
 		7CD9C3EBF737E415B2561168 /* CSV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2F2242E59F2C42DDD0736B /* CSV.swift */; };
 		7F3D3F509379FD171AEC3606 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DEAB729518FA2A6600E3570B /* Images.xcassets */; };
+		8108F2C0C987CDC1258A3E7C /* ContactLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E3C45DEC115A2BF7DE83DF /* ContactLink.swift */; };
 		81F488BB8E6D53268C607C68 /* DuplicatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C373BD237429970D6A7C86 /* DuplicatesView.swift */; };
 		827CF451F0B38B89C4469595 /* DuplicateFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */; };
 		8C6AC6410FA2258ADB2BF640 /* ContactManagerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001F8DF120EBA372663EC888 /* ContactManagerUITests.swift */; };
@@ -92,6 +94,7 @@
 		617D7B082A403094284FBD38 /* ContactStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStore.swift; sourceTree = "<group>"; };
 		6303A7F66E428BF3662142C0 /* SidebarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		66F852CE2356ADE83460064B /* ContentView+Import.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+Import.swift"; sourceTree = "<group>"; };
+		6EE79F02FFFD9820269D3725 /* ContactLinkTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactLinkTests.swift; sourceTree = "<group>"; };
 		734D363DD0CB0BAA7AE9460B /* LayoutMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LayoutMetrics.swift; sourceTree = "<group>"; };
 		73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactDetailView.swift; sourceTree = "<group>"; };
 		7B17AADA860AEDB87017DF0B /* ContactWindowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactWindowView.swift; sourceTree = "<group>"; };
@@ -100,6 +103,7 @@
 		7E7D5B554122CF852B0D825C /* VCardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTests.swift; sourceTree = "<group>"; };
 		833F1AF82CACF7B9E89BADCA /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		874742D7DC5E9C20D3A88459 /* ContactEntityQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityQuery.swift; sourceTree = "<group>"; };
+		90E3C45DEC115A2BF7DE83DF /* ContactLink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactLink.swift; sourceTree = "<group>"; };
 		915AF700C971510D0B642590 /* ContactEntity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntity.swift; sourceTree = "<group>"; };
 		93C12246003379D5966F0210 /* ContactEntityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityTests.swift; sourceTree = "<group>"; };
 		A7276D515CA167FBF4C47299 /* VCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCard.swift; sourceTree = "<group>"; };
@@ -189,6 +193,7 @@
 				B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */,
 				1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */,
 				4E2F2242E59F2C42DDD0736B /* CSV.swift */,
+				90E3C45DEC115A2BF7DE83DF /* ContactLink.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -272,6 +277,7 @@
 				93C12246003379D5966F0210 /* ContactEntityTests.swift */,
 				BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */,
 				604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */,
+				6EE79F02FFFD9820269D3725 /* ContactLinkTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -431,6 +437,7 @@
 				AC7E1126C65C59B15141CB79 /* ContentView+Import.swift in Sources */,
 				7CD9C3EBF737E415B2561168 /* CSV.swift in Sources */,
 				64A0899508308C671981B72F /* ContactWindowView.swift in Sources */,
+				8108F2C0C987CDC1258A3E7C /* ContactLink.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -449,6 +456,7 @@
 				63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */,
 				623A5F4AE958EAD5C2757F83 /* CSVTests.swift in Sources */,
 				52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */,
+				21EF2DF533DFA347DCF69BD0 /* ContactLinkTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Support/ContactLink.swift
+++ b/ContactManager/Support/ContactLink.swift
@@ -12,20 +12,24 @@ import Foundation
 
 enum ContactLink {
     /// A `mailto:` URL for an email address, or `nil` if it's blank.
-    /// The address is percent-encoded so an odd value can't produce a
-    /// malformed URL (`@` and `+` are left intact — both are legal here).
+    /// Built through `URLComponents` so reserved delimiters (`?`, `#`) in an
+    /// odd value are percent-encoded into the address rather than becoming
+    /// mailto headers or a fragment; `@` and `+` are legal in the path and
+    /// pass through untouched.
     static func mailto(_ email: String) -> URL? {
         let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty,
-              let encoded = trimmed.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-        else { return nil }
-        return URL(string: "mailto:\(encoded)")
+        guard !trimmed.isEmpty else { return nil }
+        var components = URLComponents()
+        components.scheme = "mailto"
+        components.path = trimmed
+        return components.url
     }
 
     /// A `tel:` URL for a phone number, or `nil` if it carries no digits.
     /// Keeps only the dialable digits plus a leading `+` (country code),
     /// dropping the spaces, parentheses, and dashes people type for
-    /// readability — matching how `ContactStore` normalizes phone values.
+    /// readability. (`ContactStore`'s phone normalization strips the `+`
+    /// too; here it's kept because a country code is dialable.)
     static func tel(_ phone: String) -> URL? {
         let trimmed = phone.trimmingCharacters(in: .whitespacesAndNewlines)
         let digits = String(trimmed.filter(\.isNumber))

--- a/ContactManager/Support/ContactLink.swift
+++ b/ContactManager/Support/ContactLink.swift
@@ -1,0 +1,36 @@
+//
+//  ContactLink.swift
+//  ContactManager
+//
+//  Builds the `mailto:` / `tel:` URLs behind the contact detail's
+//  click-to-mail and click-to-call actions. Kept here (not in the view) so
+//  the value normalization — which is the part that actually has edge cases
+//  — is unit-tested directly.
+//
+
+import Foundation
+
+enum ContactLink {
+    /// A `mailto:` URL for an email address, or `nil` if it's blank.
+    /// The address is percent-encoded so an odd value can't produce a
+    /// malformed URL (`@` and `+` are left intact — both are legal here).
+    static func mailto(_ email: String) -> URL? {
+        let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let encoded = trimmed.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        else { return nil }
+        return URL(string: "mailto:\(encoded)")
+    }
+
+    /// A `tel:` URL for a phone number, or `nil` if it carries no digits.
+    /// Keeps only the dialable digits plus a leading `+` (country code),
+    /// dropping the spaces, parentheses, and dashes people type for
+    /// readability — matching how `ContactStore` normalizes phone values.
+    static func tel(_ phone: String) -> URL? {
+        let trimmed = phone.trimmingCharacters(in: .whitespacesAndNewlines)
+        let digits = String(trimmed.filter(\.isNumber))
+        guard !digits.isEmpty else { return nil }
+        let prefix = trimmed.hasPrefix("+") ? "+" : ""
+        return URL(string: "tel:\(prefix)\(digits)")
+    }
+}

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -148,20 +148,21 @@ struct ContactDetailView: View {
         if contact.primaryEmail != nil || contact.primaryPhone != nil {
             Section {
                 if let email = contact.primaryEmail {
-                    quickRow(label: "Email", value: email)
+                    quickRow(kind: .email, value: email)
                 }
                 if let phone = contact.primaryPhone {
-                    quickRow(label: "Phone", value: phone)
+                    quickRow(kind: .phone, value: phone)
                 }
             }
         }
     }
 
-    private func quickRow(label: String, value: String) -> some View {
-        HStack {
+    private func quickRow(kind: FieldKind, value: String) -> some View {
+        let label = kind == .email ? "Email" : "Phone"
+        return HStack {
             // Combined so VoiceOver reads "Email, name@example.com" as a
             // single element, instead of "Email" and "name@example.com"
-            // separately. The copy button stays its own focusable element.
+            // separately. The action buttons stay their own focusable elements.
             HStack {
                 Text(label)
                     .foregroundStyle(.secondary)
@@ -173,6 +174,17 @@ struct ContactDetailView: View {
             }
             .accessibilityElement(children: .combine)
 
+            // Click-to-mail / click-to-call. Only shown when the value yields
+            // a usable URL, so a junk entry doesn't offer a dead action.
+            if let url = actionURL(for: kind, value: value) {
+                Link(destination: url) {
+                    Image(systemName: kind == .email ? "envelope" : "phone")
+                }
+                .buttonStyle(.borderless)
+                .help(kind == .email ? "Send Email" : "Call")
+                .accessibilityLabel(kind == .email ? "Send Email" : "Call")
+            }
+
             Button {
                 copyToPasteboard(value)
             } label: {
@@ -181,6 +193,13 @@ struct ContactDetailView: View {
             .buttonStyle(.borderless)
             .help("Copy \(label)")
             .accessibilityLabel("Copy \(label)")
+        }
+    }
+
+    private func actionURL(for kind: FieldKind, value: String) -> URL? {
+        switch kind {
+        case .email: ContactLink.mailto(value)
+        case .phone: ContactLink.tel(value)
         }
     }
 

--- a/ContactManagerTests/ContactLinkTests.swift
+++ b/ContactManagerTests/ContactLinkTests.swift
@@ -34,6 +34,15 @@ struct ContactLinkTests {
         #expect(url.absoluteString == "mailto:ada%20lovelace@example.com")
     }
 
+    @Test func mailtoEncodesReservedDelimitersInsteadOfInjectingHeaders() throws {
+        // A value carrying `?`/`#` must fold into the address, not turn into
+        // mailto query headers or a fragment.
+        let url = try #require(ContactLink.mailto("ada@example.com?subject=hi#x"))
+        #expect(url.query == nil)
+        #expect(url.fragment == nil)
+        #expect(url.absoluteString.hasPrefix("mailto:ada@example.com"))
+    }
+
     @Test func mailtoIsNilForBlank() {
         #expect(ContactLink.mailto("") == nil)
         #expect(ContactLink.mailto("   ") == nil)

--- a/ContactManagerTests/ContactLinkTests.swift
+++ b/ContactManagerTests/ContactLinkTests.swift
@@ -1,0 +1,66 @@
+//
+//  ContactLinkTests.swift
+//  ContactManagerTests
+//
+//  Covers the `mailto:` / `tel:` URL construction behind the detail view's
+//  click-to-mail and click-to-call actions — the value normalization is the
+//  part with edge cases (formatting characters, blanks, country codes).
+//
+
+@testable import ContactManager
+import Foundation
+import Testing
+
+struct ContactLinkTests {
+    // MARK: - mailto
+
+    @Test func mailtoWrapsAPlainAddress() throws {
+        let url = try #require(ContactLink.mailto("ada@example.com"))
+        #expect(url.absoluteString == "mailto:ada@example.com")
+    }
+
+    @Test func mailtoTrimsSurroundingWhitespace() throws {
+        let url = try #require(ContactLink.mailto("  ada@example.com \n"))
+        #expect(url.absoluteString == "mailto:ada@example.com")
+    }
+
+    @Test func mailtoKeepsPlusAddressing() throws {
+        let url = try #require(ContactLink.mailto("ada+news@example.com"))
+        #expect(url.absoluteString == "mailto:ada+news@example.com")
+    }
+
+    @Test func mailtoPercentEncodesSpaces() throws {
+        let url = try #require(ContactLink.mailto("ada lovelace@example.com"))
+        #expect(url.absoluteString == "mailto:ada%20lovelace@example.com")
+    }
+
+    @Test func mailtoIsNilForBlank() {
+        #expect(ContactLink.mailto("") == nil)
+        #expect(ContactLink.mailto("   ") == nil)
+    }
+
+    // MARK: - tel
+
+    @Test func telStripsFormattingCharacters() throws {
+        let url = try #require(ContactLink.tel("(555) 010-0199"))
+        #expect(url.absoluteString == "tel:5550100199")
+    }
+
+    @Test func telKeepsLeadingCountryCodePlus() throws {
+        let url = try #require(ContactLink.tel("+1 (555) 010-0199"))
+        #expect(url.absoluteString == "tel:+15550100199")
+    }
+
+    @Test func telDropsAPlusThatIsNotLeading() throws {
+        // A stray "+" mid-string isn't a country-code marker; only a leading
+        // one is kept.
+        let url = try #require(ContactLink.tel("555+0100"))
+        #expect(url.absoluteString == "tel:5550100")
+    }
+
+    @Test func telIsNilWhenNoDigits() {
+        #expect(ContactLink.tel("") == nil)
+        #expect(ContactLink.tel("call me") == nil)
+        #expect(ContactLink.tel("+") == nil)
+    }
+}


### PR DESCRIPTION
## Summary
First P1 item from the ship-readiness audit. The Email/Phone quick-info rows in the contact detail only offered **Copy** — no native click-to-mail or click-to-call, which a Mac contact app is expected to have.

- Each quick row now shows an **envelope** (email) / **phone** (phone) button beside Copy that opens the system handler via a SwiftUI `Link`.
- URL construction lives in a new **`ContactLink`** helper in `Support/` (not the view), because the value normalization is the part with edge cases and is worth unit-testing directly:
  - `mailto:` trims and percent-encodes the address (keeping `@` and `+`), so an odd value can't yield a malformed URL.
  - `tel:` keeps only dialable digits plus a leading `+` country code, dropping the spaces/parens/dashes people type — matching how `ContactStore` already normalizes phone values.
- Both return `nil` for blank / no-digit input, and the button is only rendered when a usable URL exists, so a junk entry never offers a dead action.
- Opening these URLs works under the App Sandbox (delegated LaunchServices open; no network entitlement needed).

Scope is intentionally the read-only quick rows (the editable field rows stay plain `TextField`s).

## Test plan
- [x] `make check` — 110 unit tests + 3 UI tests pass
- [x] New `ContactLinkTests`: mailto (plain / whitespace / plus-addressing / space-encoding / blank) and tel (formatting-strip / leading-`+` country code / non-leading `+` / no-digits)
- [ ] Manual: select a contact with an email + phone, click the envelope (opens Mail compose) and the phone (offers FaceTime/handoff call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)