### PR TITLE
Stream photo import via ImageIO instead of reading the whole file

### DIFF
--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -280,8 +280,11 @@ struct ContactDetailView: View {
                 let avatar: Data? = await Task.detached {
                     let didAccess = url.startAccessingSecurityScopedResource()
                     defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
-                    guard let fileData = try? Data(contentsOf: url) else { return nil }
-                    return ImageProcessing.avatarData(from: fileData)
+                    // Decode straight from the file via ImageIO so a huge image
+                    // is downsampled to a thumbnail without ever loading its
+                    // full raw bytes into memory (dropping a 300 MB file no
+                    // longer allocates 300 MB).
+                    return ImageProcessing.avatarData(from: url)
                 }.value
 
                 guard let avatar else {

--- a/ContactManagerTests/ImageProcessingTests.swift
+++ b/ContactManagerTests/ImageProcessingTests.swift
@@ -54,4 +54,26 @@ struct ImageProcessingTests {
         let garbage = Data("not an image".utf8)
         #expect(ImageProcessing.avatarData(from: garbage) == nil)
     }
+
+    @Test func downscalesFromAFileURLWithoutLoadingItWhole() throws {
+        // The URL overload streams via ImageIO (used by photo import) so a
+        // huge file isn't read into memory before downscaling.
+        let png = try makePNG(width: 1024, height: 768)
+        let url = FileManager.default.temporaryDirectory
+            .appending(path: "avatar-test-\(png.count).png")
+        try png.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let avatar = try #require(ImageProcessing.avatarData(from: url))
+        let size = try pixelSize(of: avatar)
+        #expect(max(size.width, size.height) <= Int(ImageProcessing.maxPixelSize))
+        #expect(size.width == 512)
+        #expect(size.height == 384)
+    }
+
+    @Test func returnsNilForAMissingFileURL() {
+        let missing = FileManager.default.temporaryDirectory
+            .appending(path: "does-not-exist-\(UUID().uuidString).png")
+        #expect(ImageProcessing.avatarData(from: missing) == nil)
+    }
 }


### PR DESCRIPTION
## Summary
P1 from the ship-readiness audit. Picking a contact photo read the entire file into memory with `Data(contentsOf:)` before downscaling, so dropping a 300 MB image allocated 300 MB just to make a 512px thumbnail.

`ImageProcessing` already exposes a URL overload that decodes straight from the file via `CGImageSourceCreateWithURL` + a thumbnail pass — bounded memory regardless of the source's size. The import path now calls it directly. Security-scoped resource access and the off-main-actor hop are unchanged.

## Test plan
- [x] `make check` — lint/format clean; 119 unit tests pass (the 3 XCUITests flaked locally on app *activation* — `Failed to activate application … Running Background` — because this machine's foreground is occupied; CI runs only swiftformat/swiftlint, and the change doesn't touch launch/activation)
- [x] `ImageProcessingTests` now covers the URL overload: downscales a file written to a temp dir (1024×768 → 512×384) and returns nil for a missing URL
- [ ] Manual: import a large image as an avatar and confirm it's downscaled without a memory spike

🤖 Generated with [Claude Code](https://claude.com/claude-code)