### PR TITLE
Add a ShareLink to share a contact as a vCard

### DIFF
--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -80,6 +80,12 @@ struct ContactDetailView: View {
         }
         .formStyle(.grouped)
         .navigationTitle(contact.fullName)
+        .toolbar {
+            ToolbarItem {
+                ShareLink(item: vcardTransfer, preview: SharePreview(shareTitle))
+                    .help("Share this contact as a vCard")
+            }
+        }
         .alert(
             "Couldn't Save Changes",
             isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } }),
@@ -307,17 +313,38 @@ struct ContactDetailView: View {
             errorMessage = error.localizedDescription
         }
     }
+}
+
+/// Non-view helpers, kept in an extension so the main view body stays focused
+/// on layout.
+private extension ContactDetailView {
+    // MARK: - Sharing
+
+    /// The contact rendered as a shareable vCard file (same payload as a
+    /// drag-to-Finder), built fresh so edits are reflected when shared.
+    var vcardTransfer: VCardTransfer {
+        VCardTransfer(
+            suggestedName: VCardTransfer.suggestedFilename(for: contact.fullName),
+            text: VCard.card(for: contact)
+        )
+    }
+
+    /// Share-sheet title; falls back to "Contact" for an unnamed contact.
+    var shareTitle: String {
+        let name = contact.fullName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? "Contact" : name
+    }
 
     // MARK: - Birthday bindings
 
-    private var birthdayEnabled: Binding<Bool> {
+    var birthdayEnabled: Binding<Bool> {
         Binding(
             get: { contact.birthday != nil },
             set: { contact.birthday = $0 ? (contact.birthday ?? .now) : nil }
         )
     }
 
-    private var birthdayValue: Binding<Date> {
+    var birthdayValue: Binding<Date> {
         Binding(
             get: { contact.birthday ?? .now },
             set: { contact.birthday = $0 }


### PR DESCRIPTION
## Summary
P1 from the audit. The detail view could only export a contact by dragging its row to Finder. Added a **Share** button to the detail toolbar via SwiftUI's `ShareLink`, reusing the existing `VCardTransfer` (already `Transferable`) — so the macOS share sheet offers Mail, Messages, AirDrop, Save to Files, etc., with the same `.vcf` payload as a drag, built fresh so in-progress edits are included.

Also moved the view's non-layout helpers (the new sharing helpers + the birthday bindings) into a `private extension` so the main struct body stays within the type-body length limit and reads as pure layout.

## Test plan
- [x] `make check` — format/lint clean; 119 unit tests pass (3 XCUITests flaked locally on app *activation* only — foreground occupied on this machine; CI runs swiftformat/swiftlint only)
- [x] No new tests: the shared payload (`VCardTransfer` / `VCard.card`) is already covered by `VCardTransferTests`; this is view-only wiring
- [ ] Manual: select a contact, click Share in the toolbar, confirm the sheet offers a `<name>.vcf` to Mail/AirDrop/Files

🤖 Generated with [Claude Code](https://claude.com/claude-code)