### PR TITLE
Focus the search field with the Find command (⌘F)

### DIFF
--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -236,7 +236,9 @@ private struct StoreErrorView: View {
 }
 
 extension Notification.Name {
-    /// Posted by menu commands; observed by `ContentView`.
+    /// Posted by menu commands and observed by the relevant view — most by
+    /// `ContentView`, except `.focusSearchRequested`, handled by
+    /// `ContactListView` where the search field lives.
     static let newContactRequested = Notification.Name("ContactManager.newContactRequested")
     static let importVCardRequested = Notification.Name("ContactManager.importVCardRequested")
     static let importCSVRequested = Notification.Name("ContactManager.importCSVRequested")

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -67,6 +67,12 @@ struct ContactManagerApp: App {
                 }
                 .keyboardShortcut("n", modifiers: .command)
             }
+            CommandGroup(after: .textEditing) {
+                Button("Find") {
+                    NotificationCenter.default.post(name: .focusSearchRequested, object: nil)
+                }
+                .keyboardShortcut("f", modifiers: .command)
+            }
             CommandGroup(after: .pasteboard) {
                 Button("Find Duplicates…") {
                     NotificationCenter.default.post(name: .findDuplicatesRequested, object: nil)
@@ -237,6 +243,8 @@ extension Notification.Name {
     static let importSystemContactsRequested = Notification.Name("ContactManager.importSystemContactsRequested")
     static let exportVCardRequested = Notification.Name("ContactManager.exportVCardRequested")
     static let findDuplicatesRequested = Notification.Name("ContactManager.findDuplicatesRequested")
+    /// Posted by the Find menu command (⌘F); focuses the contact search field.
+    static let focusSearchRequested = Notification.Name("ContactManager.focusSearchRequested")
     /// Posted by App Intents (and `Spotlight` taps via `ContentView`'s
     /// `onContinueUserActivity`). UserInfo carries `id: String` — the
     /// encoded `PersistentIdentifier` of the contact to select.

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -22,6 +22,9 @@ struct ContactListView: View {
     /// SwiftUI's `OpenWindowAction` for the detached-contact window.
     @Environment(\.openWindow) private var openWindow
 
+    /// Drives the search field's focus so the Find command (⌘F) can jump to it.
+    @FocusState private var searchFocused: Bool
+
     var body: some View {
         List(selection: $selection) {
             ForEach(sections) { section in
@@ -44,6 +47,11 @@ struct ContactListView: View {
         )
         .animation(.smooth, value: sortOrder)
         .searchable(text: $searchText, prompt: "Search Contacts")
+        .searchFocused($searchFocused)
+        // The Find menu command (⌘F) routes here to focus the search field.
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchRequested)) { _ in
+            searchFocused = true
+        }
         .overlay { emptyState }
         // Accept `.vcf` drops from Finder. Filtering on extension keeps
         // arbitrary file drops from triggering a no-op import.


### PR DESCRIPTION
## Summary
P1 from the audit. The searchable contact list had no keyboard path to the search field — ⌘F did nothing. Added a standard **Find** menu item (⌘F, placed after the Edit menu's text-editing group) that posts a notification; `ContactListView` binds a `@FocusState` to the search field via `.searchFocused` and focuses it on receipt.

Reuses the app's existing menu-command → `NotificationCenter` pattern, since a menu command can't set a view's focus state directly.

## Test plan
- [x] `make check` — build/lint/format clean; 119 unit tests pass (3 XCUITests flaked locally on app activation only; CI runs swiftformat/swiftlint)
- [x] No new tests: pure focus/menu wiring with no extractable logic
- [ ] Manual: press ⌘F and confirm the search field takes focus and accepts typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)