### PR TITLE
Focus First Name when a new contact is created

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
 		4EC36757044377406665E53B /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */; };
 		52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */; };
+		552E226D873AE11781A7F97A /* ContactDetailView+Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */; };
 		61F22EEDEE6075BD602203D5 /* VCardDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */; };
 		623A5F4AE958EAD5C2757F83 /* CSVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */; };
 		63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C12246003379D5966F0210 /* ContactEntityTests.swift */; };
@@ -76,6 +77,7 @@
 /* Begin PBXFileReference section */
 		001F8DF120EBA372663EC888 /* ContactManagerUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactManagerUITests.swift; sourceTree = "<group>"; };
 		03763AB80D45F026EC585490 /* ContactStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStoreTests.swift; sourceTree = "<group>"; };
+		05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Photo.swift"; sourceTree = "<group>"; };
 		05F6260FE20C27094AFB327A /* FindContactIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FindContactIntent.swift; sourceTree = "<group>"; };
 		08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactListView.swift; sourceTree = "<group>"; };
 		0B27567532AC1A51FF4CC13A /* ContactQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactQuery.swift; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 				F9795992CBF553603FD37928 /* SettingsView.swift */,
 				66F852CE2356ADE83460064B /* ContentView+Import.swift */,
 				7B17AADA860AEDB87017DF0B /* ContactWindowView.swift */,
+				05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -442,6 +445,7 @@
 				64A0899508308C671981B72F /* ContactWindowView.swift in Sources */,
 				8108F2C0C987CDC1258A3E7C /* ContactLink.swift in Sources */,
 				322103E6FBEAD59C6A2405E6 /* Birthday.swift in Sources */,
+				552E226D873AE11781A7F97A /* ContactDetailView+Photo.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Views/ContactDetailView+Photo.swift
+++ b/ContactManager/Views/ContactDetailView+Photo.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftUI
 
 extension ContactDetailView {
+    @MainActor
     func handleImport(_ result: Result<URL, Error>) {
         switch result {
         case .failure(let error):
@@ -41,6 +42,7 @@ extension ContactDetailView {
         }
     }
 
+    @MainActor
     func removePhoto() {
         do {
             try store.setPhotoData(nil, on: contact)

--- a/ContactManager/Views/ContactDetailView+Photo.swift
+++ b/ContactManager/Views/ContactDetailView+Photo.swift
@@ -1,0 +1,51 @@
+//
+//  ContactDetailView+Photo.swift
+//  ContactManager
+//
+//  Avatar import/remove handlers for the detail view's photo well. Split
+//  out of ContactDetailView so the main file stays focused on layout.
+//
+
+import Foundation
+import SwiftUI
+
+extension ContactDetailView {
+    func handleImport(_ result: Result<URL, Error>) {
+        switch result {
+        case .failure(let error):
+            errorMessage = error.localizedDescription
+        case .success(let url):
+            Task {
+                // Read the file and run the avatar pipeline off the main actor
+                // so a multi-megabyte photo can't hitch the UI.
+                let avatar: Data? = await Task.detached {
+                    let didAccess = url.startAccessingSecurityScopedResource()
+                    defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+                    // Decode straight from the file via ImageIO so a huge image
+                    // is downsampled to a thumbnail without ever loading its
+                    // full raw bytes into memory (dropping a 300 MB file no
+                    // longer allocates 300 MB).
+                    return ImageProcessing.avatarData(from: url)
+                }.value
+
+                guard let avatar else {
+                    errorMessage = "That file couldn't be read as an image."
+                    return
+                }
+                do {
+                    try store.setPhotoData(avatar, on: contact)
+                } catch {
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    func removePhoto() {
+        do {
+            try store.setPhotoData(nil, on: contact)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -17,11 +17,17 @@ import UniformTypeIdentifiers
 struct ContactDetailView: View {
     @Environment(\.modelContext) private var context
     @Bindable var contact: Contact
+    /// Set for a just-created contact so the form opens with the cursor in
+    /// First Name; the view clears it via `onNameFieldFocused` after focusing.
+    var focusNameField = false
+    var onNameFieldFocused: () -> Void = {}
     @Query(sort: \ContactGroup.name) private var allGroups: [ContactGroup]
     @State private var isImportingPhoto = false
-    @State private var errorMessage: String?
+    // Not private: the photo handlers in ContactDetailView+Photo.swift read them.
+    @State var errorMessage: String?
+    @FocusState private var nameFieldFocused: Bool
 
-    private var store: ContactStore { ContactStore(context) }
+    var store: ContactStore { ContactStore(context) }
 
     var body: some View {
         Form {
@@ -31,6 +37,7 @@ struct ContactDetailView: View {
 
             Section("Name") {
                 TextField("First Name", text: $contact.firstName)
+                    .focused($nameFieldFocused)
                 TextField("Last Name", text: $contact.lastName)
             }
 
@@ -80,6 +87,14 @@ struct ContactDetailView: View {
         }
         .formStyle(.grouped)
         .navigationTitle(contact.fullName)
+        // A freshly created contact opens with the cursor in First Name so you
+        // can type a name immediately instead of reaching for the mouse.
+        .onAppear {
+            if focusNameField {
+                nameFieldFocused = true
+                onNameFieldFocused()
+            }
+        }
         .toolbar {
             ToolbarItem {
                 ShareLink(item: vcardTransfer, preview: SharePreview(shareTitle))
@@ -271,47 +286,6 @@ struct ContactDetailView: View {
                 }
             }
         )
-    }
-
-    // MARK: - Photo actions
-
-    private func handleImport(_ result: Result<URL, Error>) {
-        switch result {
-        case .failure(let error):
-            errorMessage = error.localizedDescription
-        case .success(let url):
-            Task {
-                // Read the file and run the avatar pipeline off the main actor
-                // so a multi-megabyte photo can't hitch the UI.
-                let avatar: Data? = await Task.detached {
-                    let didAccess = url.startAccessingSecurityScopedResource()
-                    defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
-                    // Decode straight from the file via ImageIO so a huge image
-                    // is downsampled to a thumbnail without ever loading its
-                    // full raw bytes into memory (dropping a 300 MB file no
-                    // longer allocates 300 MB).
-                    return ImageProcessing.avatarData(from: url)
-                }.value
-
-                guard let avatar else {
-                    errorMessage = "That file couldn't be read as an image."
-                    return
-                }
-                do {
-                    try store.setPhotoData(avatar, on: contact)
-                } catch {
-                    errorMessage = error.localizedDescription
-                }
-            }
-        }
-    }
-
-    private func removePhoto() {
-        do {
-            try store.setPhotoData(nil, on: contact)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
     }
 }
 

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -90,10 +90,12 @@ struct ContactDetailView: View {
         // A freshly created contact opens with the cursor in First Name so you
         // can type a name immediately instead of reaching for the mouse.
         .onAppear {
-            if focusNameField {
-                nameFieldFocused = true
-                onNameFieldFocused()
-            }
+            if focusNameField { nameFieldFocused = true }
+        }
+        // Clear the parent's one-shot flag only once focus has actually landed,
+        // so a missed/late focus application isn't dropped without a retry.
+        .onChange(of: nameFieldFocused) { _, focused in
+            if focused { onNameFieldFocused() }
         }
         .toolbar {
             ToolbarItem {

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -22,6 +22,9 @@ struct ContentView: View {
 
     @State private var sidebarSelection: SidebarItem? = .allContacts
     @State private var selectedContact: Contact?
+    /// The contact just created via ⌘N/＋, so the detail form can open with
+    /// the cursor in First Name. Cleared once the field takes focus.
+    @State private var contactPendingNameFocus: PersistentIdentifier?
     // Internal so the import handlers in `ContentView+Import.swift` can
     // set this when a parse/insert fails.
     @State var errorMessage: String?
@@ -107,8 +110,12 @@ struct ContentView: View {
         } detail: {
             Group {
                 if let selectedContact {
-                    ContactDetailView(contact: selectedContact)
-                        .id(selectedContact.persistentModelID)
+                    ContactDetailView(
+                        contact: selectedContact,
+                        focusNameField: selectedContact.persistentModelID == contactPendingNameFocus,
+                        onNameFieldFocused: { contactPendingNameFocus = nil }
+                    )
+                    .id(selectedContact.persistentModelID)
                 } else {
                     ContactPlaceholderView()
                 }
@@ -217,6 +224,7 @@ struct ContentView: View {
     private func addContact() {
         do {
             let contact = try store.createContact(in: groupForNewContact)
+            contactPendingNameFocus = contact.persistentModelID
             withAnimation(.snappy) { selectedContact = contact }
         } catch {
             errorMessage = error.localizedDescription


### PR DESCRIPTION
## Summary
P1 from the audit. ⌘N (and the ＋ button) created and selected a contact, but focus went nowhere — you had to click into First Name before typing. `ContentView` now records the new contact's id and passes a one-shot `focusNameField` flag to `ContactDetailView`, which focuses First Name on appear and clears the flag (so reselecting an existing contact never steals focus). The flag is keyed to the created id, and the detail view is already `.id`-recreated per contact, so only the new one focuses.

To stay under the file/type-body length limits, moved the photo import/remove handlers into a new `ContactDetailView+Photo.swift` extension (`errorMessage`/`store` relaxed from `private` to internal so the extension can reach them).

## Test plan
- [x] `make check` — build/lint/format clean; 119 unit tests pass (3 XCUITests flaked locally on app activation only; CI runs swiftformat/swiftlint)
- [x] No new tests: focus-on-appear is view behavior with no extractable logic
- [ ] Manual: press ⌘N and confirm the cursor lands in First Name ready to type; select an existing contact and confirm focus isn't grabbed

🤖 Generated with [Claude Code](https://claude.com/claude-code)