### PR TITLE
Drop contacts onto a sidebar group to add them

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */; };
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
 		4EC36757044377406665E53B /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */; };
+		4F1E1A097740ECE3D42E55B8 /* GroupDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964ACD67CC8CB35694497A10 /* GroupDropTests.swift */; };
 		52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */; };
 		552E226D873AE11781A7F97A /* ContactDetailView+Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */; };
 		61F22EEDEE6075BD602203D5 /* VCardDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */; };
@@ -109,6 +110,7 @@
 		90E3C45DEC115A2BF7DE83DF /* ContactLink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactLink.swift; sourceTree = "<group>"; };
 		915AF700C971510D0B642590 /* ContactEntity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntity.swift; sourceTree = "<group>"; };
 		93C12246003379D5966F0210 /* ContactEntityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityTests.swift; sourceTree = "<group>"; };
+		964ACD67CC8CB35694497A10 /* GroupDropTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroupDropTests.swift; sourceTree = "<group>"; };
 		A7276D515CA167FBF4C47299 /* VCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCard.swift; sourceTree = "<group>"; };
 		ABDED82FFB4B5F039052FFB5 /* Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Birthday.swift; sourceTree = "<group>"; };
 		AC2AA1D7BB15FC01B9CBA3B3 /* EntityModelContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityModelContainer.swift; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 				BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */,
 				604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */,
 				6EE79F02FFFD9820269D3725 /* ContactLinkTests.swift */,
+				964ACD67CC8CB35694497A10 /* GroupDropTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -465,6 +468,7 @@
 				623A5F4AE958EAD5C2757F83 /* CSVTests.swift in Sources */,
 				52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */,
 				21EF2DF533DFA347DCF69BD0 /* ContactLinkTests.swift in Sources */,
+				4F1E1A097740ECE3D42E55B8 /* GroupDropTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Models/ContactStore.swift
+++ b/ContactManager/Models/ContactStore.swift
@@ -113,11 +113,16 @@ struct ContactStore {
     /// returns how many were actually added (0 means no save/undo step).
     @discardableResult
     func addContacts(withEncodedIDs ids: [String], to group: ContactGroup) throws -> Int {
-        let wanted = Set(ids)
+        // Keep only well-formed encoded ids; unrelated text (an empty string, a
+        // stray drop) decodes to nothing and short-circuits the fetch. We match
+        // on the canonical encoded string rather than `PersistentIdentifier`
+        // equality, which doesn't hold for a decoded-vs-live persisted id.
+        let wanted = Set(ids.filter { PersistentIdentifier.decode(stored: $0) != nil })
         guard !wanted.isEmpty else { return 0 }
         let groupID = group.persistentModelID
         let toAdd = try context.fetch(FetchDescriptor<Contact>()).filter { contact in
-            wanted.contains(contact.persistentModelID.storedString ?? "")
+            guard let encoded = contact.persistentModelID.storedString else { return false }
+            return wanted.contains(encoded)
                 && !contact.groups.contains { $0.persistentModelID == groupID }
         }
         guard !toAdd.isEmpty else { return 0 }

--- a/ContactManager/Models/ContactStore.swift
+++ b/ContactManager/Models/ContactStore.swift
@@ -107,6 +107,26 @@ struct ContactStore {
         }
     }
 
+    /// Adds the contacts named by their encoded `PersistentIdentifier`s to
+    /// `group` — the data path behind dragging contacts onto a sidebar group.
+    /// Ids that don't resolve and contacts already in the group are skipped;
+    /// returns how many were actually added (0 means no save/undo step).
+    @discardableResult
+    func addContacts(withEncodedIDs ids: [String], to group: ContactGroup) throws -> Int {
+        let wanted = Set(ids)
+        guard !wanted.isEmpty else { return 0 }
+        let groupID = group.persistentModelID
+        let toAdd = try context.fetch(FetchDescriptor<Contact>()).filter { contact in
+            wanted.contains(contact.persistentModelID.storedString ?? "")
+                && !contact.groups.contains { $0.persistentModelID == groupID }
+        }
+        guard !toAdd.isEmpty else { return 0 }
+        return try mutate("Add to Group") {
+            toAdd.forEach { $0.groups.append(group) }
+            return toAdd.count
+        }
+    }
+
     // MARK: - Merge duplicates
 
     /// Merges several contacts into one canonical contact (the earliest

--- a/ContactManager/Support/VCardTransfer.swift
+++ b/ContactManager/Support/VCardTransfer.swift
@@ -12,6 +12,10 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct VCardTransfer: Transferable {
+    /// Encoded `PersistentIdentifier` of the source contact, so an in-app drop
+    /// (e.g. onto a sidebar group) can resolve which contact was dragged. Empty
+    /// when the identity isn't relevant (e.g. the detail Share button).
+    var contactID: String = ""
     /// File-system-safe stem, without the `.vcf` extension. Computed by
     /// `suggestedFilename(for:)` so the sanitization is testable.
     let suggestedName: String
@@ -19,6 +23,7 @@ struct VCardTransfer: Transferable {
     let text: String
 
     static var transferRepresentation: some TransferRepresentation {
+        // Dragging to Finder (or another app) writes a `.vcf` file.
         FileRepresentation(exportedContentType: .vCard) { transfer in
             // Write to a per-drag tempdir so multiple drags don't collide on
             // a shared filename. Finder copies the file out by the time the
@@ -32,6 +37,9 @@ struct VCardTransfer: Transferable {
             try Data(transfer.text.utf8).write(to: url)
             return SentTransferredFile(url, allowAccessingOriginalFile: false)
         }
+        // Dropping within the app exposes just the contact id as plain text, so
+        // a sidebar group can add the dragged contact without parsing a vCard.
+        ProxyRepresentation(exporting: \.contactID)
     }
 
     /// Pure helper: produces a filename stem ("Ada Lovelace") from the

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -91,6 +91,7 @@ struct ContactListView: View {
 
     private func transfer(for contact: Contact) -> VCardTransfer {
         VCardTransfer(
+            contactID: contact.persistentModelID.storedString ?? "",
             suggestedName: VCardTransfer.suggestedFilename(for: contact.fullName),
             text: VCard.card(for: contact)
         )

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -94,7 +94,8 @@ struct ContentView: View {
                 groups: groups,
                 addGroup: addGroup,
                 renameGroup: renameGroup,
-                deleteGroup: deleteGroup
+                deleteGroup: deleteGroup,
+                addContacts: addContacts(encodedIDs:to:)
             )
         } content: {
             ContactListView(
@@ -247,6 +248,14 @@ struct ContentView: View {
         do {
             let group = try store.createGroup()
             withAnimation(.snappy) { sidebarSelection = .group(group.persistentModelID) }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func addContacts(encodedIDs ids: [String], to group: ContactGroup) {
+        do {
+            try store.addContacts(withEncodedIDs: ids, to: group)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/ContactManager/Views/SidebarView.swift
+++ b/ContactManager/Views/SidebarView.swift
@@ -51,9 +51,12 @@ struct SidebarView: View {
                             }
                             // Drag contacts from the list onto a group to add
                             // them. The transfer exposes the contact id as text;
-                            // unrelated text drops resolve to nothing and no-op.
+                            // reject drops that carry no valid contact id (e.g.
+                            // unrelated selected text) so they aren't "accepted".
                             .dropDestination(for: String.self) { ids, _ in
-                                addContacts(ids, group)
+                                let valid = ids.filter { PersistentIdentifier.decode(stored: $0) != nil }
+                                guard !valid.isEmpty else { return false }
+                                addContacts(valid, group)
                                 return true
                             }
                     }

--- a/ContactManager/Views/SidebarView.swift
+++ b/ContactManager/Views/SidebarView.swift
@@ -21,6 +21,8 @@ struct SidebarView: View {
     var addGroup: () -> Void
     var renameGroup: (ContactGroup, String) -> Void
     var deleteGroup: (ContactGroup) -> Void
+    /// Adds the dropped contacts (by encoded id) to a group — sidebar drag target.
+    var addContacts: ([String], ContactGroup) -> Void
 
     @State private var renameTarget: ContactGroup?
     @State private var renameText = ""
@@ -46,6 +48,13 @@ struct SidebarView: View {
                             .contextMenu {
                                 Button("Rename…") { beginRename(group) }
                                 Button("Delete", role: .destructive) { deleteGroup(group) }
+                            }
+                            // Drag contacts from the list onto a group to add
+                            // them. The transfer exposes the contact id as text;
+                            // unrelated text drops resolve to nothing and no-op.
+                            .dropDestination(for: String.self) { ids, _ in
+                                addContacts(ids, group)
+                                return true
                             }
                     }
                 }

--- a/ContactManagerTests/GroupDropTests.swift
+++ b/ContactManagerTests/GroupDropTests.swift
@@ -1,0 +1,56 @@
+//
+//  GroupDropTests.swift
+//  ContactManagerTests
+//
+//  Covers `ContactStore.addContacts(withEncodedIDs:to:)` — the data path
+//  behind dragging contacts from the list onto a sidebar group.
+//
+
+@testable import ContactManager
+import Foundation
+import SwiftData
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct GroupDropTests {
+    let container: ModelContainer
+    let store: ContactStore
+
+    init() throws {
+        container = try ModelContainer(
+            for: Contact.self, ContactField.self, ContactGroup.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        store = ContactStore(container.mainContext)
+    }
+
+    @Test func addsDroppedContactsToTheGroup() throws {
+        let group = try store.createGroup(named: "Work")
+        let ada = try store.createContact()
+        let alan = try store.createContact()
+        let ids = try [ada, alan].map { try #require($0.persistentModelID.storedString) }
+
+        let added = try store.addContacts(withEncodedIDs: ids, to: group)
+        #expect(added == 2)
+        #expect(Set(group.contacts.map(\.persistentModelID)) == [ada.persistentModelID, alan.persistentModelID])
+    }
+
+    @Test func skipsExistingMembersAndUnknownIDs() throws {
+        let group = try store.createGroup(named: "Work")
+        let ada = try store.createContact(in: group) // already a member
+        let alan = try store.createContact()
+        let adaID = try #require(ada.persistentModelID.storedString)
+        let alanID = try #require(alan.persistentModelID.storedString)
+
+        // Ada is already in the group; "garbage" resolves to no contact.
+        let added = try store.addContacts(withEncodedIDs: [adaID, alanID, "garbage"], to: group)
+        #expect(added == 1)
+        #expect(group.contacts.count == 2)
+    }
+
+    @Test func isANoOpForEmptyInput() throws {
+        let group = try store.createGroup(named: "Work")
+        #expect(try store.addContacts(withEncodedIDs: [], to: group) == 0)
+    }
+}


### PR DESCRIPTION
## Summary
P1 from the audit. Contact rows were draggable (to Finder, as `.vcf`) but the sidebar groups weren't drop targets — dragging a contact onto a group did nothing.

- **`VCardTransfer`** now also carries the contact's encoded `PersistentIdentifier` and exposes it as a plain-text `ProxyRepresentation` alongside the existing `.vcf` `FileRepresentation`. A Finder drag still writes a file; an in-app drop can recover *which* contact moved — no custom UTType needed.
- Each **sidebar group row** gains `.dropDestination(for: String.self)` routing the dropped ids through a new **`ContactStore.addContacts(withEncodedIDs:to:)`**, which resolves them, skips ids that don't match a contact and contacts already in the group, and adds the rest in one undo step (“Add to Group”). Unrelated text drops resolve to nothing and no-op.

Routing through `ContactStore` keeps the membership logic in the data layer and unit-testable (per the repo conventions).

## Test plan
- [x] `make check` — build/lint/format clean; 122 unit tests pass (3 XCUITests flaked locally on app activation only; CI runs swiftformat/swiftlint)
- [x] New `GroupDropTests`: adds dropped contacts; skips existing members and unknown ids (returns the count actually added); empty input is a no-op
- [ ] Manual: drag a contact (or multi-selection) from the list onto a sidebar group and confirm the badge count increases and membership shows in the detail editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)