### PR TITLE
Chunk imports and show progress

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		61F22EEDEE6075BD602203D5 /* VCardDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */; };
 		623A5F4AE958EAD5C2757F83 /* CSVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */; };
 		63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C12246003379D5966F0210 /* ContactEntityTests.swift */; };
+		644397DD275B65E0F3A7C1DB /* ImportProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29335D93B2E97B9038F1481A /* ImportProgressView.swift */; };
 		64A0899508308C671981B72F /* ContactWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B17AADA860AEDB87017DF0B /* ContactWindowView.swift */; };
 		6BF479700A4101F1353CBF78 /* ContactQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B27567532AC1A51FF4CC13A /* ContactQuery.swift */; };
 		6DDC44CAA558E1DB276460CF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833F1AF82CACF7B9E89BADCA /* ContentView.swift */; };
@@ -39,12 +40,14 @@
 		81F488BB8E6D53268C607C68 /* DuplicatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C373BD237429970D6A7C86 /* DuplicatesView.swift */; };
 		827CF451F0B38B89C4469595 /* DuplicateFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */; };
 		8C6AC6410FA2258ADB2BF640 /* ContactManagerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001F8DF120EBA372663EC888 /* ContactManagerUITests.swift */; };
+		8DF0A36CE542853FF12BEF1A /* Chunking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436B4115937E4350EB9A7EF7 /* Chunking.swift */; };
 		9506DFC07D9490AEDFB096EC /* ImageProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */; };
 		97E98BCB6784672DCB8C1625 /* VCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7276D515CA167FBF4C47299 /* VCard.swift */; };
 		A486AAFFBF01C05775A7BB38 /* ContactEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915AF700C971510D0B642590 /* ContactEntity.swift */; };
 		A94AB327927F2F1FBBD81119 /* ContactGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFE362455F20C848F729EEE /* ContactGroup.swift */; };
 		ABE65AD0BD5B666CD7272802 /* EntityModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2AA1D7BB15FC01B9CBA3B3 /* EntityModelContainer.swift */; };
 		AC7E1126C65C59B15141CB79 /* ContentView+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F852CE2356ADE83460064B /* ContentView+Import.swift */; };
+		AF36C8E991E2B6C96634FBA0 /* ChunkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30CD9D085E7424A79159879 /* ChunkingTests.swift */; };
 		B1393B1344A7D64B52C4B3D4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9795992CBF553603FD37928 /* SettingsView.swift */; };
 		BBD79E7FD90E021417B527A9 /* FindContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F6260FE20C27094AFB327A /* FindContactIntent.swift */; };
 		C2A11D686722C70868435ACE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303A7F66E428BF3662142C0 /* SidebarView.swift */; };
@@ -87,9 +90,11 @@
 		10E7338673D65A6FAB4F9AF3 /* ContactManagerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContactManagerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotlightIndexer.swift; sourceTree = "<group>"; };
 		2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactsBridge.swift; sourceTree = "<group>"; };
+		29335D93B2E97B9038F1481A /* ImportProgressView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportProgressView.swift; sourceTree = "<group>"; };
 		2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardDocument.swift; sourceTree = "<group>"; };
 		3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinderTests.swift; sourceTree = "<group>"; };
+		436B4115937E4350EB9A7EF7 /* Chunking.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Chunking.swift; sourceTree = "<group>"; };
 		4E2F2242E59F2C42DDD0736B /* CSV.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSV.swift; sourceTree = "<group>"; };
 		54C373BD237429970D6A7C86 /* DuplicatesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicatesView.swift; sourceTree = "<group>"; };
 		5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingTests.swift; sourceTree = "<group>"; };
@@ -111,6 +116,7 @@
 		915AF700C971510D0B642590 /* ContactEntity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntity.swift; sourceTree = "<group>"; };
 		93C12246003379D5966F0210 /* ContactEntityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityTests.swift; sourceTree = "<group>"; };
 		964ACD67CC8CB35694497A10 /* GroupDropTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroupDropTests.swift; sourceTree = "<group>"; };
+		A30CD9D085E7424A79159879 /* ChunkingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChunkingTests.swift; sourceTree = "<group>"; };
 		A7276D515CA167FBF4C47299 /* VCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCard.swift; sourceTree = "<group>"; };
 		ABDED82FFB4B5F039052FFB5 /* Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Birthday.swift; sourceTree = "<group>"; };
 		AC2AA1D7BB15FC01B9CBA3B3 /* EntityModelContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityModelContainer.swift; sourceTree = "<group>"; };
@@ -201,6 +207,7 @@
 				4E2F2242E59F2C42DDD0736B /* CSV.swift */,
 				90E3C45DEC115A2BF7DE83DF /* ContactLink.swift */,
 				ABDED82FFB4B5F039052FFB5 /* Birthday.swift */,
+				436B4115937E4350EB9A7EF7 /* Chunking.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -232,6 +239,7 @@
 				66F852CE2356ADE83460064B /* ContentView+Import.swift */,
 				7B17AADA860AEDB87017DF0B /* ContactWindowView.swift */,
 				05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */,
+				29335D93B2E97B9038F1481A /* ImportProgressView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -287,6 +295,7 @@
 				604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */,
 				6EE79F02FFFD9820269D3725 /* ContactLinkTests.swift */,
 				964ACD67CC8CB35694497A10 /* GroupDropTests.swift */,
+				A30CD9D085E7424A79159879 /* ChunkingTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -449,6 +458,8 @@
 				8108F2C0C987CDC1258A3E7C /* ContactLink.swift in Sources */,
 				322103E6FBEAD59C6A2405E6 /* Birthday.swift in Sources */,
 				552E226D873AE11781A7F97A /* ContactDetailView+Photo.swift in Sources */,
+				8DF0A36CE542853FF12BEF1A /* Chunking.swift in Sources */,
+				644397DD275B65E0F3A7C1DB /* ImportProgressView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -469,6 +480,7 @@
 				52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */,
 				21EF2DF533DFA347DCF69BD0 /* ContactLinkTests.swift in Sources */,
 				4F1E1A097740ECE3D42E55B8 /* GroupDropTests.swift in Sources */,
+				AF36C8E991E2B6C96634FBA0 /* ChunkingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Support/Chunking.swift
+++ b/ContactManager/Support/Chunking.swift
@@ -1,0 +1,22 @@
+//
+//  Chunking.swift
+//  ContactManager
+//
+//  Splits a collection into fixed-size batches. Used to import contacts a
+//  chunk at a time (one save + progress tick per chunk) instead of building
+//  the whole set on the main actor in a single mega-undo step.
+//
+
+import Foundation
+
+extension Array {
+    /// Splits the array into consecutive sub-arrays of at most `size` elements.
+    /// A non-positive `size` returns the whole array as a single chunk (or no
+    /// chunks when empty), so callers can't accidentally spin forever.
+    func chunked(into size: Int) -> [[Element]] {
+        guard size > 0 else { return isEmpty ? [] : [self] }
+        return stride(from: 0, to: count, by: size).map {
+            Array(self[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
+}

--- a/ContactManager/Support/Chunking.swift
+++ b/ContactManager/Support/Chunking.swift
@@ -7,8 +7,6 @@
 //  the whole set on the main actor in a single mega-undo step.
 //
 
-import Foundation
-
 extension Array {
     /// Splits the array into consecutive sub-arrays of at most `size` elements.
     /// A non-positive `size` returns the whole array as a single chunk (or no

--- a/ContactManager/Views/ContentView+Import.swift
+++ b/ContactManager/Views/ContentView+Import.swift
@@ -23,6 +23,8 @@ extension ContentView {
 
     func importSystemContacts() {
         Task {
+            importProgress = ImportProgress()
+            defer { importProgress = nil }
             // Permission prompt + fetch + mapping all run off the main actor;
             // only the final insert hops back here.
             let parsed: [ParsedContact]
@@ -38,11 +40,25 @@ extension ContentView {
                 errorMessage = "No contacts were found in your system Contacts."
                 return
             }
-            do {
-                try store.importContacts(parsed)
-            } catch {
-                errorMessage = error.localizedDescription
+            await insert(parsed)
+        }
+    }
+
+    // MARK: - Chunked insert + progress
+
+    /// Inserts parsed contacts a chunk at a time — one save (and undo step) per
+    /// chunk instead of one giant transaction — updating `importProgress` and
+    /// yielding between chunks so the overlay animates rather than freezing.
+    func insert(_ parsed: [ParsedContact]) async {
+        importProgress = ImportProgress(done: 0, total: parsed.count)
+        do {
+            for chunk in parsed.chunked(into: 500) {
+                try store.importContacts(chunk)
+                importProgress?.done += chunk.count
+                await Task.yield()
             }
+        } catch {
+            errorMessage = error.localizedDescription
         }
     }
 
@@ -51,6 +67,8 @@ extension ContentView {
     /// Imports one or more vCard files dropped onto the contact list.
     func importVCardURLs(_ urls: [URL]) {
         Task {
+            importProgress = ImportProgress()
+            defer { importProgress = nil }
             let parsed: [ParsedContact] = await Task.detached {
                 var all: [ParsedContact] = []
                 for url in urls {
@@ -68,11 +86,7 @@ extension ContentView {
                 errorMessage = "No contacts were found in that file."
                 return
             }
-            do {
-                try store.importContacts(parsed)
-            } catch {
-                errorMessage = error.localizedDescription
-            }
+            await insert(parsed)
         }
     }
 
@@ -84,6 +98,8 @@ extension ContentView {
             errorMessage = error.localizedDescription
         case .success(let url):
             Task {
+                importProgress = ImportProgress()
+                defer { importProgress = nil }
                 let outcome: CSVImportOutcome = await Task.detached {
                     let didAccess = url.startAccessingSecurityScopedResource()
                     defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
@@ -112,11 +128,7 @@ extension ContentView {
                 case .parsed(let contacts) where contacts.isEmpty:
                     errorMessage = "No contacts were found in that file."
                 case .parsed(let contacts):
-                    do {
-                        try store.importContacts(contacts)
-                    } catch {
-                        errorMessage = error.localizedDescription
-                    }
+                    await insert(contacts)
                 }
             }
         }
@@ -128,6 +140,8 @@ extension ContentView {
             errorMessage = error.localizedDescription
         case .success(let url):
             Task {
+                importProgress = ImportProgress()
+                defer { importProgress = nil }
                 // Read and parse off the main actor so large files don't block UI.
                 let parsed: [ParsedContact]? = await Task.detached {
                     let didAccess = url.startAccessingSecurityScopedResource()
@@ -145,11 +159,7 @@ extension ContentView {
                     errorMessage = "No contacts were found in that file."
                     return
                 }
-                do {
-                    try store.importContacts(parsed)
-                } catch {
-                    errorMessage = error.localizedDescription
-                }
+                await insert(parsed)
             }
         }
     }

--- a/ContactManager/Views/ContentView+Import.swift
+++ b/ContactManager/Views/ContentView+Import.swift
@@ -49,6 +49,7 @@ extension ContentView {
     /// Inserts parsed contacts a chunk at a time — one save (and undo step) per
     /// chunk instead of one giant transaction — updating `importProgress` and
     /// yielding between chunks so the overlay animates rather than freezing.
+    @MainActor
     func insert(_ parsed: [ParsedContact]) async {
         importProgress = ImportProgress(done: 0, total: parsed.count)
         do {

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -25,9 +25,11 @@ struct ContentView: View {
     /// The contact just created via ⌘N/＋, so the detail form can open with
     /// the cursor in First Name. Cleared once the field takes focus.
     @State private var contactPendingNameFocus: PersistentIdentifier?
-    // Internal so the import handlers in `ContentView+Import.swift` can
-    // set this when a parse/insert fails.
+    /// Internal so the import handlers in `ContentView+Import.swift` can
+    /// set this when a parse/insert fails.
     @State var errorMessage: String?
+    // Drives the import progress overlay; set by the import handlers.
+    @State var importProgress: ImportProgress?
     @State private var searchText = ""
     /// Trails `searchText` by 150 ms so we don't re-filter the entire contact
     /// list on every keystroke. Cleared instantly when the user clears the
@@ -129,6 +131,11 @@ struct ContentView: View {
             minWidth: LayoutMetrics.windowMinWidth,
             minHeight: LayoutMetrics.windowMinHeight
         )
+        .overlay {
+            if let importProgress {
+                ImportProgressView(progress: importProgress)
+            }
+        }
         .task(id: searchText) {
             // Empty → clear immediately. Otherwise wait 150 ms before
             // committing the new query so a burst of keystrokes only

--- a/ContactManager/Views/ImportProgressView.swift
+++ b/ContactManager/Views/ImportProgressView.swift
@@ -1,0 +1,48 @@
+//
+//  ImportProgressView.swift
+//  ContactManager
+//
+//  A small modal-style overlay shown while a vCard/CSV/system-Contacts import
+//  is parsing and inserting, so a large file no longer looks like a frozen UI.
+//
+
+import SwiftUI
+
+/// State for the import overlay. `total == nil` means the parse phase is still
+/// running (indeterminate); once inserting begins, `total` is the contact count
+/// and `done` climbs per saved chunk.
+struct ImportProgress: Equatable {
+    var done = 0
+    var total: Int?
+}
+
+struct ImportProgressView: View {
+    let progress: ImportProgress
+
+    var body: some View {
+        VStack(spacing: 12) {
+            if let total = progress.total {
+                ProgressView(value: Double(progress.done), total: Double(max(total, 1))) {
+                    Text("Importing Contacts")
+                }
+                Text("\(progress.done) of \(total)")
+                    .font(.caption)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            } else {
+                ProgressView { Text("Preparing Import…") }
+            }
+        }
+        .padding(24)
+        .frame(width: 260)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .shadow(radius: 20)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        guard let total = progress.total else { return "Preparing import" }
+        return "Importing contacts, \(progress.done) of \(total)"
+    }
+}

--- a/ContactManagerTests/ChunkingTests.swift
+++ b/ContactManagerTests/ChunkingTests.swift
@@ -1,0 +1,35 @@
+//
+//  ChunkingTests.swift
+//  ContactManagerTests
+//
+//  Covers Array.chunked(into:), which batches contacts for chunked import.
+//
+
+@testable import ContactManager
+import Testing
+
+struct ChunkingTests {
+    @Test func splitsIntoFullAndRemainderChunks() {
+        let chunks = Array(1 ... 10).chunked(into: 4)
+        #expect(chunks == [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10]])
+    }
+
+    @Test func returnsOneChunkWhenSmallerThanSize() {
+        #expect([1, 2, 3].chunked(into: 10) == [[1, 2, 3]])
+    }
+
+    @Test func dividesEvenlyWithoutAnEmptyTrailingChunk() {
+        let chunks = Array(1 ... 6).chunked(into: 3)
+        #expect(chunks == [[1, 2, 3], [4, 5, 6]])
+    }
+
+    @Test func emptyArrayYieldsNoChunks() {
+        #expect([Int]().chunked(into: 5).isEmpty)
+    }
+
+    @Test func nonPositiveSizeDoesNotSpin() {
+        // Guard against an accidental 0/negative size looping forever.
+        #expect([1, 2, 3].chunked(into: 0) == [[1, 2, 3]])
+        #expect([Int]().chunked(into: 0).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
P1 audit items #7 (chunk the system Contacts import) and #8 (import progress UI) — one cohesive feature. All four import paths (vCard file, vCard drop, CSV, system Contacts) built the full set of contacts on the main actor and inserted them in a single save / mega-undo step, freezing the UI on a large file with no feedback.

- Each handler now inserts the parsed contacts in **chunks of 500** via a shared `insert(_:)` helper: one `ContactStore.importContacts` save (and undo step) per chunk, `await Task.yield()` between chunks so the window keeps painting, and `importProgress` updated as each chunk lands.
- A new **`ImportProgressView`** overlay shows an indeterminate "Preparing Import…" during the off-main parse and a determinate "N of M" bar during insert — covering every import path.
- Chunking is a small, tested `Array.chunked(into:)` helper (guards a non-positive size so it can't spin forever).

## Test plan
- [x] `make check` — build/lint/format clean; 127 unit tests pass (3 XCUITests flaked locally on app activation only; CI runs swiftformat/swiftlint)
- [x] New `ChunkingTests`: even split, remainder, smaller-than-size, empty, non-positive size
- [ ] Manual: import a large vCard/CSV and the system Contacts and confirm the overlay shows preparing → "N of M" and the window stays responsive; Edit ▸ Undo removes a chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)