### PR TITLE
Add Print and Export as PDF for the selected contact

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		322103E6FBEAD59C6A2405E6 /* Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDED82FFB4B5F039052FFB5 /* Birthday.swift */; };
 		4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */; };
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
+		488CA0C339AD3218073A02E8 /* PrintableContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37DB6CC43A76261CFF3987D /* PrintableContactView.swift */; };
 		4EC36757044377406665E53B /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */; };
 		4F1E1A097740ECE3D42E55B8 /* GroupDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964ACD67CC8CB35694497A10 /* GroupDropTests.swift */; };
 		52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */; };
@@ -31,8 +32,11 @@
 		63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C12246003379D5966F0210 /* ContactEntityTests.swift */; };
 		644397DD275B65E0F3A7C1DB /* ImportProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29335D93B2E97B9038F1481A /* ImportProgressView.swift */; };
 		64A0899508308C671981B72F /* ContactWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B17AADA860AEDB87017DF0B /* ContactWindowView.swift */; };
+		65E6B33886CF04648BEDF442 /* ContactPDFTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F303B7AE5B9202CDA6D9DA /* ContactPDFTests.swift */; };
+		6BD515E7E488C1261839AC60 /* ContactPDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0255C29CC874D2BA1C064CF /* ContactPDF.swift */; };
 		6BF479700A4101F1353CBF78 /* ContactQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B27567532AC1A51FF4CC13A /* ContactQuery.swift */; };
 		6DDC44CAA558E1DB276460CF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833F1AF82CACF7B9E89BADCA /* ContentView.swift */; };
+		6DF39989CF5CF55F228DA933 /* PDFExportDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC69A4C348D4BBEF0D8F1330 /* PDFExportDocument.swift */; };
 		7755029B0E36200BB139ECFA /* VCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7D5B554122CF852B0D825C /* VCardTests.swift */; };
 		7CD9C3EBF737E415B2561168 /* CSV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2F2242E59F2C42DDD0736B /* CSV.swift */; };
 		7F3D3F509379FD171AEC3606 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DEAB729518FA2A6600E3570B /* Images.xcassets */; };
@@ -117,6 +121,7 @@
 		93C12246003379D5966F0210 /* ContactEntityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityTests.swift; sourceTree = "<group>"; };
 		964ACD67CC8CB35694497A10 /* GroupDropTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroupDropTests.swift; sourceTree = "<group>"; };
 		A30CD9D085E7424A79159879 /* ChunkingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChunkingTests.swift; sourceTree = "<group>"; };
+		A37DB6CC43A76261CFF3987D /* PrintableContactView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrintableContactView.swift; sourceTree = "<group>"; };
 		A7276D515CA167FBF4C47299 /* VCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCard.swift; sourceTree = "<group>"; };
 		ABDED82FFB4B5F039052FFB5 /* Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Birthday.swift; sourceTree = "<group>"; };
 		AC2AA1D7BB15FC01B9CBA3B3 /* EntityModelContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityModelContainer.swift; sourceTree = "<group>"; };
@@ -124,7 +129,10 @@
 		B25751DDEC1515E341AF67F5 /* ContactField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactField.swift; sourceTree = "<group>"; };
 		B75D02267D3BC6C014143329 /* ContactModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactModelTests.swift; sourceTree = "<group>"; };
 		BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSVTests.swift; sourceTree = "<group>"; };
+		C0255C29CC874D2BA1C064CF /* ContactPDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactPDF.swift; sourceTree = "<group>"; };
+		C0F303B7AE5B9202CDA6D9DA /* ContactPDFTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactPDFTests.swift; sourceTree = "<group>"; };
 		C7DCAF444714BC3726B212C4 /* UndoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UndoTests.swift; sourceTree = "<group>"; };
+		DC69A4C348D4BBEF0D8F1330 /* PDFExportDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFExportDocument.swift; sourceTree = "<group>"; };
 		DEAB729518FA2A6600E3570B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		DED8178913A452A900EC3234 /* ContactManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ContactManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DED817AA13A452AA00EC3234 /* ContactManagerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContactManagerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -208,6 +216,8 @@
 				90E3C45DEC115A2BF7DE83DF /* ContactLink.swift */,
 				ABDED82FFB4B5F039052FFB5 /* Birthday.swift */,
 				436B4115937E4350EB9A7EF7 /* Chunking.swift */,
+				C0255C29CC874D2BA1C064CF /* ContactPDF.swift */,
+				DC69A4C348D4BBEF0D8F1330 /* PDFExportDocument.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -240,6 +250,7 @@
 				7B17AADA860AEDB87017DF0B /* ContactWindowView.swift */,
 				05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */,
 				29335D93B2E97B9038F1481A /* ImportProgressView.swift */,
+				A37DB6CC43A76261CFF3987D /* PrintableContactView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -296,6 +307,7 @@
 				6EE79F02FFFD9820269D3725 /* ContactLinkTests.swift */,
 				964ACD67CC8CB35694497A10 /* GroupDropTests.swift */,
 				A30CD9D085E7424A79159879 /* ChunkingTests.swift */,
+				C0F303B7AE5B9202CDA6D9DA /* ContactPDFTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -460,6 +472,9 @@
 				552E226D873AE11781A7F97A /* ContactDetailView+Photo.swift in Sources */,
 				8DF0A36CE542853FF12BEF1A /* Chunking.swift in Sources */,
 				644397DD275B65E0F3A7C1DB /* ImportProgressView.swift in Sources */,
+				6BD515E7E488C1261839AC60 /* ContactPDF.swift in Sources */,
+				6DF39989CF5CF55F228DA933 /* PDFExportDocument.swift in Sources */,
+				488CA0C339AD3218073A02E8 /* PrintableContactView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -481,6 +496,7 @@
 				21EF2DF533DFA347DCF69BD0 /* ContactLinkTests.swift in Sources */,
 				4F1E1A097740ECE3D42E55B8 /* GroupDropTests.swift in Sources */,
 				AF36C8E991E2B6C96634FBA0 /* ChunkingTests.swift in Sources */,
+				65E6B33886CF04648BEDF442 /* ContactPDFTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -95,6 +95,16 @@ struct ContactManagerApp: App {
                     NotificationCenter.default.post(name: .exportVCardRequested, object: nil)
                 }
                 .keyboardShortcut("e", modifiers: [.command, .shift])
+                Button("Export as PDF…") {
+                    NotificationCenter.default.post(name: .exportPDFRequested, object: nil)
+                }
+                .keyboardShortcut("p", modifiers: [.command, .shift])
+            }
+            CommandGroup(replacing: .printItem) {
+                Button("Print…") {
+                    NotificationCenter.default.post(name: .printContactRequested, object: nil)
+                }
+                .keyboardShortcut("p", modifiers: .command)
             }
         }
     }
@@ -244,6 +254,10 @@ extension Notification.Name {
     static let importCSVRequested = Notification.Name("ContactManager.importCSVRequested")
     static let importSystemContactsRequested = Notification.Name("ContactManager.importSystemContactsRequested")
     static let exportVCardRequested = Notification.Name("ContactManager.exportVCardRequested")
+    /// Posted by the Export as PDF / Print commands; handled by `ContentView`
+    /// for the selected contact.
+    static let exportPDFRequested = Notification.Name("ContactManager.exportPDFRequested")
+    static let printContactRequested = Notification.Name("ContactManager.printContactRequested")
     static let findDuplicatesRequested = Notification.Name("ContactManager.findDuplicatesRequested")
     /// Posted by the Find menu command (⌘F); focuses the contact search field.
     static let focusSearchRequested = Notification.Name("ContactManager.focusSearchRequested")

--- a/ContactManager/Support/ContactPDF.swift
+++ b/ContactManager/Support/ContactPDF.swift
@@ -1,0 +1,54 @@
+//
+//  ContactPDF.swift
+//  ContactManager
+//
+//  Renders a contact's printable card (PrintableContactView) to PDF data via
+//  ImageRenderer, and prints it through PDFKit. Kept out of the view so the
+//  PDF generation can be unit-tested.
+//
+
+import PDFKit
+import SwiftUI
+
+@MainActor
+enum ContactPDF {
+    /// PDF bytes for a single contact's card, or `nil` if rendering fails.
+    /// The page is sized to the rendered card.
+    static func data(for contact: Contact) -> Data? {
+        let renderer = ImageRenderer(content: PrintableContactView(contact: contact))
+        let pdfData = NSMutableData()
+        var result: Data?
+        // ImageRenderer.render runs its closure synchronously; we build a
+        // one-page PDF context the size of the rendered card.
+        renderer.render { size, renderInContext in
+            var mediaBox = CGRect(origin: .zero, size: size)
+            guard let consumer = CGDataConsumer(data: pdfData as CFMutableData),
+                  let context = CGContext(consumer: consumer, mediaBox: &mediaBox, nil)
+            else { return }
+            context.beginPDFPage(nil)
+            renderInContext(context)
+            context.endPDFPage()
+            context.closePDF()
+            result = pdfData as Data
+        }
+        return result
+    }
+
+    /// A file-system-safe filename stem (no extension) for the contact's PDF.
+    static func filename(for contact: Contact) -> String {
+        VCardTransfer.suggestedFilename(for: contact.fullName)
+    }
+
+    /// Presents the system print sheet for the contact's card.
+    static func print(_ contact: Contact) -> Bool {
+        guard let data = data(for: contact), let document = PDFDocument(data: data) else {
+            return false
+        }
+        let info = NSPrintInfo.shared
+        guard let operation = document.printOperation(
+            for: info, scalingMode: .pageScaleToFit, autoRotate: false
+        ) else { return false }
+        operation.run()
+        return true
+    }
+}

--- a/ContactManager/Support/ContactPDF.swift
+++ b/ContactManager/Support/ContactPDF.swift
@@ -39,16 +39,20 @@ enum ContactPDF {
         VCardTransfer.suggestedFilename(for: contact.fullName)
     }
 
-    /// Presents the system print sheet for the contact's card.
+    /// Presents the system print panel for the contact's card — as a
+    /// window-attached sheet when there's a key window, otherwise app-modal.
     static func print(_ contact: Contact) -> Bool {
         guard let data = data(for: contact), let document = PDFDocument(data: data) else {
             return false
         }
-        let info = NSPrintInfo.shared
         guard let operation = document.printOperation(
-            for: info, scalingMode: .pageScaleToFit, autoRotate: false
+            for: NSPrintInfo.shared, scalingMode: .pageScaleToFit, autoRotate: false
         ) else { return false }
-        operation.run()
+        if let window = NSApp.keyWindow {
+            operation.runModal(for: window, delegate: nil, didRun: nil, contextInfo: nil)
+        } else {
+            operation.run()
+        }
         return true
     }
 }

--- a/ContactManager/Support/PDFExportDocument.swift
+++ b/ContactManager/Support/PDFExportDocument.swift
@@ -1,0 +1,28 @@
+//
+//  PDFExportDocument.swift
+//  ContactManager
+//
+//  A tiny FileDocument wrapping PDF bytes, used by the "Export as PDF" dialog.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct PDFExportDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.pdf] }
+    static var writableContentTypes: [UTType] { [.pdf] }
+
+    var data: Data
+
+    init(data: Data) {
+        self.data = data
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        data = configuration.file.regularFileContents ?? Data()
+    }
+
+    func fileWrapper(configuration _: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: data)
+    }
+}

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -43,6 +43,9 @@ struct ContentView: View {
     @State private var isExportingVCard = false
     @State private var exportDocument = VCardDocument(text: "")
     @State private var showingDuplicates = false
+    @State private var isExportingPDF = false
+    @State private var pdfDocument = PDFExportDocument(data: Data())
+    @State private var pdfFilename = "Contact"
 
     /// Internal so the import handlers in `ContentView+Import.swift` can
     /// reach the same store the main view uses.
@@ -89,6 +92,37 @@ struct ContentView: View {
     }
 
     var body: some View {
+        let scene = splitView
+            .task(id: searchText) {
+                // Empty → clear immediately. Otherwise wait 150 ms before
+                // committing the new query so a burst of keystrokes only
+                // triggers one filter pass.
+                if searchText.isEmpty {
+                    debouncedSearchText = ""
+                    return
+                }
+                do {
+                    try await Task.sleep(for: .milliseconds(150))
+                    debouncedSearchText = searchText
+                } catch {
+                    // Task cancelled — a newer keystroke superseded this one.
+                }
+            }
+            .onAppear {
+                // Route every ContactStore mutation through the window's undo
+                // manager so Edit ▸ Undo/Redo (⌘Z / ⇧⌘Z) work.
+                context.undoManager = undoManager
+            }
+            .onChange(of: undoManager) { _, new in
+                context.undoManager = new
+            }
+        // Split into helpers so the modifier chain stays within the SwiftUI
+        // type-checker's budget (and the type-body length limit).
+        return handlingFileDialogs(handlingMenuCommands(scene))
+    }
+
+    /// The three-column split view, window frame, and the import overlay.
+    private var splitView: some View {
         NavigationSplitView {
             SidebarView(
                 selection: $sidebarSelection,
@@ -135,95 +169,6 @@ struct ContentView: View {
             if let importProgress {
                 ImportProgressView(progress: importProgress)
             }
-        }
-        .task(id: searchText) {
-            // Empty → clear immediately. Otherwise wait 150 ms before
-            // committing the new query so a burst of keystrokes only
-            // triggers one filter pass.
-            if searchText.isEmpty {
-                debouncedSearchText = ""
-                return
-            }
-            do {
-                try await Task.sleep(for: .milliseconds(150))
-                debouncedSearchText = searchText
-            } catch {
-                // Task cancelled — a newer keystroke superseded this one.
-            }
-        }
-        .onAppear {
-            // Route every ContactStore mutation through the window's undo
-            // manager so Edit ▸ Undo/Redo (⌘Z / ⇧⌘Z) work.
-            context.undoManager = undoManager
-        }
-        .onChange(of: undoManager) { _, new in
-            context.undoManager = new
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .newContactRequested)) { _ in
-            addContact()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .importVCardRequested)) { _ in
-            isImportingVCard = true
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .importCSVRequested)) { _ in
-            isImportingCSV = true
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .exportVCardRequested)) { _ in
-            exportDocument = VCardDocument(text: store.exportVCards(contacts))
-            isExportingVCard = true
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .findDuplicatesRequested)) { _ in
-            showingDuplicates = true
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .importSystemContactsRequested)) { _ in
-            importSystemContacts()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openContactRequested)) { note in
-            selectContact(byEncodedID: note.userInfo?["id"] as? String)
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .contactsDidChange)) { note in
-            // Apply just the mutation's delta — the indexer fetches the
-            // affected contacts fresh by id, since `@Query`'s post-save
-            // refresh is asynchronous and can still reflect pre-save state
-            // when this notification fires. A post without a payload falls
-            // back to a full reindex.
-            if let change = note.userInfo?[ContactChange.userInfoKey] as? ContactChange {
-                Task { await SpotlightIndexer.shared.apply(change) }
-            } else {
-                Task { await SpotlightIndexer.shared.reindex() }
-            }
-        }
-        .onContinueUserActivity(CSSearchableItemActionType) { activity in
-            let id = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String
-            selectContact(byEncodedID: id)
-        }
-        .sheet(isPresented: $showingDuplicates) {
-            DuplicatesView()
-        }
-        .fileImporter(isPresented: $isImportingVCard, allowedContentTypes: [.vCard]) { result in
-            handleImport(result)
-        }
-        .fileImporter(isPresented: $isImportingCSV, allowedContentTypes: [.commaSeparatedText]) { result in
-            handleCSVImport(result)
-        }
-        .fileExporter(
-            isPresented: $isExportingVCard,
-            document: exportDocument,
-            contentType: .vCard,
-            defaultFilename: "Contacts"
-        ) { result in
-            if case .failure(let error) = result {
-                errorMessage = error.localizedDescription
-            }
-        }
-        .alert(
-            "Something Went Wrong",
-            isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } }),
-            presenting: errorMessage
-        ) { _ in
-            Button("OK", role: .cancel) {}
-        } message: { message in
-            Text(message)
         }
     }
 
@@ -298,6 +243,128 @@ struct ContentView: View {
         // narrower group was active.
         if case .group = sidebarSelection { sidebarSelection = .allContacts }
         withAnimation(.snappy) { selectedContact = contact }
+    }
+}
+
+/// Body modifiers and command actions, split out of the main struct to keep
+/// the SwiftUI type-checker (and the type-body length) happy. Same-file, so
+/// these still see ContentView's private state.
+private extension ContentView {
+    /// Menu-command observers (New, imports/exports, Find Duplicates, Print/PDF,
+    /// Spotlight open, and the incremental re-index on every mutation).
+    func handlingMenuCommands(_ content: some View) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .newContactRequested)) { _ in
+                addContact()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .importVCardRequested)) { _ in
+                isImportingVCard = true
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .importCSVRequested)) { _ in
+                isImportingCSV = true
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .exportVCardRequested)) { _ in
+                exportDocument = VCardDocument(text: store.exportVCards(contacts))
+                isExportingVCard = true
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .findDuplicatesRequested)) { _ in
+                showingDuplicates = true
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .exportPDFRequested)) { _ in
+                exportSelectedContactAsPDF()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .printContactRequested)) { _ in
+                printSelectedContact()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .importSystemContactsRequested)) { _ in
+                importSystemContacts()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .openContactRequested)) { note in
+                selectContact(byEncodedID: note.userInfo?["id"] as? String)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .contactsDidChange)) { note in
+                // The indexer fetches the affected contacts fresh by id, since
+                // `@Query`'s post-save refresh can still reflect pre-save state
+                // here. A post without a payload falls back to a full reindex.
+                if let change = note.userInfo?[ContactChange.userInfoKey] as? ContactChange {
+                    Task { await SpotlightIndexer.shared.apply(change) }
+                } else {
+                    Task { await SpotlightIndexer.shared.reindex() }
+                }
+            }
+            .onContinueUserActivity(CSSearchableItemActionType) { activity in
+                let id = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String
+                selectContact(byEncodedID: id)
+            }
+    }
+
+    /// The sheets, importers, exporters, and the error alert.
+    func handlingFileDialogs(_ content: some View) -> some View {
+        content
+            .sheet(isPresented: $showingDuplicates) {
+                DuplicatesView()
+            }
+            .fileImporter(isPresented: $isImportingVCard, allowedContentTypes: [.vCard]) { result in
+                handleImport(result)
+            }
+            .fileImporter(isPresented: $isImportingCSV, allowedContentTypes: [.commaSeparatedText]) { result in
+                handleCSVImport(result)
+            }
+            .fileExporter(
+                isPresented: $isExportingVCard,
+                document: exportDocument,
+                contentType: .vCard,
+                defaultFilename: "Contacts"
+            ) { result in
+                if case .failure(let error) = result {
+                    errorMessage = error.localizedDescription
+                }
+            }
+            .fileExporter(
+                isPresented: $isExportingPDF,
+                document: pdfDocument,
+                contentType: .pdf,
+                defaultFilename: pdfFilename
+            ) { result in
+                if case .failure(let error) = result {
+                    errorMessage = error.localizedDescription
+                }
+            }
+            .alert(
+                "Something Went Wrong",
+                isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } }),
+                presenting: errorMessage
+            ) { _ in
+                Button("OK", role: .cancel) {}
+            } message: { message in
+                Text(message)
+            }
+    }
+
+    // MARK: - Print / PDF
+
+    func exportSelectedContactAsPDF() {
+        guard let contact = selectedContact else {
+            errorMessage = "Select a contact to export as PDF."
+            return
+        }
+        guard let data = ContactPDF.data(for: contact) else {
+            errorMessage = "Couldn't generate a PDF for that contact."
+            return
+        }
+        pdfDocument = PDFExportDocument(data: data)
+        pdfFilename = ContactPDF.filename(for: contact)
+        isExportingPDF = true
+    }
+
+    func printSelectedContact() {
+        guard let contact = selectedContact else {
+            errorMessage = "Select a contact to print."
+            return
+        }
+        if !ContactPDF.print(contact) {
+            errorMessage = "Couldn't prepare that contact for printing."
+        }
     }
 }
 

--- a/ContactManager/Views/PrintableContactView.swift
+++ b/ContactManager/Views/PrintableContactView.swift
@@ -1,0 +1,120 @@
+//
+//  PrintableContactView.swift
+//  ContactManager
+//
+//  A fixed-width card layout for a single contact, rendered to PDF (and the
+//  print sheet) by `ContactPDF`. Standalone — it reads only the contact, so
+//  it renders the same off-screen as it would on-screen.
+//
+
+import SwiftUI
+
+struct PrintableContactView: View {
+    let contact: Contact
+
+    private let width: CGFloat = 480
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            Divider()
+            fields(contact.emails, title: "Email")
+            fields(contact.phones, title: "Phone")
+            address
+            birthday
+            notes
+        }
+        .padding(32)
+        .frame(width: width, alignment: .leading)
+        .background(.white)
+        .foregroundStyle(.black)
+    }
+
+    private var header: some View {
+        HStack(spacing: 16) {
+            AvatarView(contact: contact, size: 64)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(contact.fullName)
+                    .font(.title.weight(.semibold))
+                let role = [contact.jobTitle, contact.company]
+                    .filter { !$0.isEmpty }
+                    .joined(separator: " · ")
+                if !role.isEmpty {
+                    Text(role).font(.headline).foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func fields(_ fields: [ContactField], title: String) -> some View {
+        let nonEmpty = fields.filter { !$0.value.trimmingCharacters(in: .whitespaces).isEmpty }
+        if !nonEmpty.isEmpty {
+            section(title) {
+                ForEach(nonEmpty) { field in
+                    labeledRow(field.label.title, field.value)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var address: some View {
+        let lines = [
+            contact.street,
+            [contact.city, contact.state, contact.postalCode]
+                .filter { !$0.isEmpty }.joined(separator: " "),
+            contact.country,
+        ].filter { !$0.isEmpty }
+        if !lines.isEmpty {
+            section("Address") {
+                ForEach(lines, id: \.self) { Text($0) }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var birthday: some View {
+        if let date = contact.birthday {
+            section("Birthday") {
+                Text(formattedBirthday(date))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var notes: some View {
+        if !contact.notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            section("Notes") {
+                Text(contact.notes)
+            }
+        }
+    }
+
+    private func section(_ title: String, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title.uppercased())
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            content()
+                .font(.body)
+        }
+    }
+
+    private func labeledRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label).foregroundStyle(.secondary).frame(width: 64, alignment: .leading)
+            Text(value)
+        }
+    }
+
+    private func formattedBirthday(_ date: Date) -> String {
+        let fields = Birthday.fields(of: date)
+        let months = Calendar(identifier: .gregorian).monthSymbols
+        let month = (1 ... 12).contains(fields.month) ? months[fields.month - 1] : ""
+        if let year = fields.year {
+            return "\(month) \(fields.day), \(year)"
+        }
+        return "\(month) \(fields.day)"
+    }
+}

--- a/ContactManager/Views/PrintableContactView.swift
+++ b/ContactManager/Views/PrintableContactView.swift
@@ -7,12 +7,14 @@
 //  it renders the same off-screen as it would on-screen.
 //
 
+import AppKit
 import SwiftUI
 
 struct PrintableContactView: View {
     let contact: Contact
 
     private let width: CGFloat = 480
+    private let avatarSize: CGFloat = 64
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -32,7 +34,7 @@ struct PrintableContactView: View {
 
     private var header: some View {
         HStack(spacing: 16) {
-            AvatarView(contact: contact, size: 64)
+            printableAvatar
             VStack(alignment: .leading, spacing: 2) {
                 Text(contact.fullName)
                     .font(.title.weight(.semibold))
@@ -44,6 +46,41 @@ struct PrintableContactView: View {
                 }
             }
         }
+    }
+
+    /// A synchronous avatar: `ImageRenderer` renders off-screen and never runs
+    /// `AvatarView`'s async `.task`, so the photo is decoded inline here (with
+    /// the same initials-over-gradient fallback) to ensure it's in the PDF.
+    private var printableAvatar: some View {
+        Group {
+            if let data = contact.photoData, let image = NSImage(data: data) {
+                Image(nsImage: image).resizable().scaledToFill()
+            } else {
+                Circle()
+                    .fill(avatarGradient)
+                    .overlay {
+                        Text(contact.initials)
+                            .font(.system(size: avatarSize * 0.4, weight: .semibold, design: .rounded))
+                            .foregroundStyle(.white)
+                            .minimumScaleFactor(0.5)
+                    }
+            }
+        }
+        .frame(width: avatarSize, height: avatarSize)
+        .clipShape(Circle())
+    }
+
+    /// Mirrors `AvatarView`'s stable per-contact gradient (kept in sync
+    /// deliberately; the print layout needs a synchronous variant).
+    private var avatarGradient: LinearGradient {
+        let palette: [Color] = [.blue, .indigo, .teal, .pink, .orange, .purple, .green, .red]
+        let index = ((contact.colorSeed % palette.count) + palette.count) % palette.count
+        let base = palette[index]
+        return LinearGradient(
+            colors: [base, base.opacity(0.65)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
     }
 
     @ViewBuilder

--- a/ContactManagerTests/ContactPDFTests.swift
+++ b/ContactManagerTests/ContactPDFTests.swift
@@ -1,0 +1,37 @@
+//
+//  ContactPDFTests.swift
+//  ContactManagerTests
+//
+//  Verifies the contact-card PDF renderer produces real PDF bytes and a
+//  sensible filename.
+//
+
+@testable import ContactManager
+import Foundation
+import Testing
+
+@MainActor
+struct ContactPDFTests {
+    @Test func rendersNonEmptyPDFData() throws {
+        let contact = Contact(firstName: "Ada", lastName: "Lovelace", company: "Analytical")
+        contact.fields = [
+            ContactField(kind: .email, label: .work, value: "ada@analytical.engine", sortIndex: 0),
+            ContactField(kind: .phone, label: .mobile, value: "+1 555 0100", sortIndex: 0),
+        ]
+        let data = try #require(ContactPDF.data(for: contact))
+        #expect(!data.isEmpty)
+        // Every PDF starts with the "%PDF" magic header.
+        #expect(data.prefix(4).elementsEqual(Data("%PDF".utf8)))
+    }
+
+    @Test func rendersAMinimalContact() throws {
+        // No fields/photo/notes — should still produce a valid one-page PDF.
+        let data = try #require(ContactPDF.data(for: Contact(firstName: "Solo", lastName: "Name")))
+        #expect(data.prefix(4).elementsEqual(Data("%PDF".utf8)))
+    }
+
+    @Test func filenameFollowsContactName() {
+        let contact = Contact(firstName: "Ada", lastName: "Lovelace")
+        #expect(ContactPDF.filename(for: contact) == "Ada Lovelace")
+    }
+}


### PR DESCRIPTION
## Summary
Final P1 item. macOS users expect File ▸ Print; the app had neither print nor PDF export. Added **File ▸ Print…** (⌘P) and **Export as PDF…** (⇧⌘P), both acting on the selected contact (a friendly message appears if nothing is selected).

- **`PrintableContactView`** lays out a contact as a card — photo/initials, name, role, labeled emails/phones, address, birthday, notes.
- **`ContactPDF`** renders it to PDF data via `ImageRenderer` (one page sized to the card) and prints it through PDFKit. The rendering is the testable core.
- Export uses a small **`PDFExportDocument`** via `.fileExporter`, named after the contact.

To keep the SwiftUI type-checker within budget (and `ContentView` under the type-body length limit) after adding the import overlay, new observers, and a second exporter, `body` now composes a `splitView` with two helper modifiers (`handlingMenuCommands` / `handlingFileDialogs`) in a same-file private extension — no behavior change.

Scope is the selected contact's card (single page); a paginated whole-list export is a possible follow-up.

## Test plan
- [x] `make check` — build/lint/format clean; 130 unit tests pass (3 XCUITests flaked locally on app activation only; CI runs swiftformat/swiftlint)
- [x] New `ContactPDFTests`: renders a full and a minimal contact (asserts the `%PDF` header) and checks the filename
- [ ] Manual: select a contact, ⌘P shows the print sheet; ⇧⌘P saves `<name>.pdf`; with no selection both show the prompt to select a contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)