### PR TITLE
Edit year-less birthdays without exposing the sentinel year

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		8108F2C0C987CDC1258A3E7C /* ContactLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E3C45DEC115A2BF7DE83DF /* ContactLink.swift */; };
 		81F488BB8E6D53268C607C68 /* DuplicatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C373BD237429970D6A7C86 /* DuplicatesView.swift */; };
 		827CF451F0B38B89C4469595 /* DuplicateFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */; };
+		8397B67D483997505B17269E /* ContactDetailView+Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */; };
 		8C6AC6410FA2258ADB2BF640 /* ContactManagerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001F8DF120EBA372663EC888 /* ContactManagerUITests.swift */; };
 		8DF0A36CE542853FF12BEF1A /* Chunking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436B4115937E4350EB9A7EF7 /* Chunking.swift */; };
 		9506DFC07D9490AEDFB096EC /* ImageProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */; };
@@ -54,6 +55,7 @@
 		AF36C8E991E2B6C96634FBA0 /* ChunkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30CD9D085E7424A79159879 /* ChunkingTests.swift */; };
 		B1393B1344A7D64B52C4B3D4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9795992CBF553603FD37928 /* SettingsView.swift */; };
 		BBD79E7FD90E021417B527A9 /* FindContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F6260FE20C27094AFB327A /* FindContactIntent.swift */; };
+		BC3D0CE8272648D0ACEF0C46 /* BirthdayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B040B21B7E2002E00885A9BA /* BirthdayTests.swift */; };
 		C2A11D686722C70868435ACE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303A7F66E428BF3662142C0 /* SidebarView.swift */; };
 		CD70772ECD6A854C66159FFD /* OpenContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B27494A51645ACA6BED8EA8 /* OpenContactIntent.swift */; };
 		CE55AD882E6631A9541B6106 /* ContactsBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */; };
@@ -102,6 +104,7 @@
 		4E2F2242E59F2C42DDD0736B /* CSV.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSV.swift; sourceTree = "<group>"; };
 		54C373BD237429970D6A7C86 /* DuplicatesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicatesView.swift; sourceTree = "<group>"; };
 		5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingTests.swift; sourceTree = "<group>"; };
+		570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Birthday.swift"; sourceTree = "<group>"; };
 		604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotlightDeltaTests.swift; sourceTree = "<group>"; };
 		61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PersistentIdentifierEncoding.swift; sourceTree = "<group>"; };
 		617D7B082A403094284FBD38 /* ContactStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStore.swift; sourceTree = "<group>"; };
@@ -126,6 +129,7 @@
 		ABDED82FFB4B5F039052FFB5 /* Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Birthday.swift; sourceTree = "<group>"; };
 		AC2AA1D7BB15FC01B9CBA3B3 /* EntityModelContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityModelContainer.swift; sourceTree = "<group>"; };
 		B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTransfer.swift; sourceTree = "<group>"; };
+		B040B21B7E2002E00885A9BA /* BirthdayTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BirthdayTests.swift; sourceTree = "<group>"; };
 		B25751DDEC1515E341AF67F5 /* ContactField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactField.swift; sourceTree = "<group>"; };
 		B75D02267D3BC6C014143329 /* ContactModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactModelTests.swift; sourceTree = "<group>"; };
 		BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSVTests.swift; sourceTree = "<group>"; };
@@ -251,6 +255,7 @@
 				05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */,
 				29335D93B2E97B9038F1481A /* ImportProgressView.swift */,
 				A37DB6CC43A76261CFF3987D /* PrintableContactView.swift */,
+				570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -308,6 +313,7 @@
 				964ACD67CC8CB35694497A10 /* GroupDropTests.swift */,
 				A30CD9D085E7424A79159879 /* ChunkingTests.swift */,
 				C0F303B7AE5B9202CDA6D9DA /* ContactPDFTests.swift */,
+				B040B21B7E2002E00885A9BA /* BirthdayTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -475,6 +481,7 @@
 				6BD515E7E488C1261839AC60 /* ContactPDF.swift in Sources */,
 				6DF39989CF5CF55F228DA933 /* PDFExportDocument.swift in Sources */,
 				488CA0C339AD3218073A02E8 /* PrintableContactView.swift in Sources */,
+				8397B67D483997505B17269E /* ContactDetailView+Birthday.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -497,6 +504,7 @@
 				4F1E1A097740ECE3D42E55B8 /* GroupDropTests.swift in Sources */,
 				AF36C8E991E2B6C96634FBA0 /* ChunkingTests.swift in Sources */,
 				65E6B33886CF04648BEDF442 /* ContactPDFTests.swift in Sources */,
+				BC3D0CE8272648D0ACEF0C46 /* BirthdayTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Support/Birthday.swift
+++ b/ContactManager/Support/Birthday.swift
@@ -59,6 +59,33 @@ enum Birthday {
         return Fields(year: year, month: parts.month ?? 1, day: parts.day ?? 1)
     }
 
+    /// Returns a copy of `date` with its year replaced — or cleared to the
+    /// year-less form when `year` is `nil` — keeping month and day. Backs the
+    /// editor's "include year" toggle so flipping it never touches the stored
+    /// month/day or escapes the UTC convention.
+    static func setting(year: Int?, of date: Date) -> Date? {
+        let parts = fields(of: date)
+        return self.date(year: year, month: parts.month, day: clampDay(parts.day, month: parts.month, year: year))
+    }
+
+    /// Number of days in `month`, honoring `year` for February (or the
+    /// omitted-year sentinel — itself a leap year — when `year` is `nil`, so a
+    /// year-less Feb 29 stays selectable). Falls back to 31 if the date can't be
+    /// built. Drives the day picker's range in the year-less birthday editor.
+    static func daysInMonth(_ month: Int, year: Int?) -> Int {
+        guard let anchor = date(year: year, month: month, day: 1),
+              let range = calendar.range(of: .day, in: .month, for: anchor)
+        else { return 31 }
+        return range.count
+    }
+
+    /// Clamps `day` to the valid range for the given month/year, so switching to
+    /// a shorter month (e.g. Jan 31 → Feb) lands on the last valid day instead
+    /// of rolling into the next month.
+    static func clampDay(_ day: Int, month: Int, year: Int?) -> Int {
+        min(max(day, 1), daysInMonth(month, year: year))
+    }
+
     /// Parses a date-only birthday string into a UTC-anchored `Date`. Accepts
     /// the year-less `--MMDD` / `--MM-DD` forms (storing the sentinel year) as
     /// well as `YYYY-MM-DD` / `YYYYMMDD`, ignoring any `T` time suffix.

--- a/ContactManager/Views/ContactDetailView+Birthday.swift
+++ b/ContactManager/Views/ContactDetailView+Birthday.swift
@@ -21,7 +21,10 @@ extension ContactDetailView {
             get: { contact.birthday.map { Birthday.fields(of: $0).year != nil } ?? false },
             set: { include in
                 guard let birthday = contact.birthday else { return }
-                let year = include ? Birthday.fields(of: .now).year : nil
+                // Derive "this year" from the user's local calendar, not the
+                // UTC birthday calendar: near New Year those disagree (Dec 31
+                // local can be Jan 1 UTC), and this is a user-facing choice.
+                let year = include ? Calendar(identifier: .gregorian).component(.year, from: .now) : nil
                 contact.birthday = Birthday.setting(year: year, of: birthday)
             }
         )

--- a/ContactManager/Views/ContactDetailView+Birthday.swift
+++ b/ContactManager/Views/ContactDetailView+Birthday.swift
@@ -1,0 +1,95 @@
+//
+//  ContactDetailView+Birthday.swift
+//  ContactManager
+//
+//  The birthday editor's year-aware bindings and the month/day-only control.
+//  Split out of ContactDetailView so the main file stays focused on layout.
+//  Year-less birthdays (a vCard `--MMDD` or a yearless Contacts card) store a
+//  sentinel year; everything here reads/writes through `Birthday` so that
+//  sentinel — and the UTC convention — never leaks into the UI.
+//
+
+import Foundation
+import SwiftUI
+
+extension ContactDetailView {
+    /// Whether the stored birthday carries a real year. Toggling on stamps the
+    /// current year; toggling off drops to the year-less form. Both go through
+    /// `Birthday.setting` so the month/day and UTC convention are preserved.
+    var birthdayIncludesYear: Binding<Bool> {
+        Binding(
+            get: { contact.birthday.map { Birthday.fields(of: $0).year != nil } ?? false },
+            set: { include in
+                guard let birthday = contact.birthday else { return }
+                let year = include ? Birthday.fields(of: .now).year : nil
+                contact.birthday = Birthday.setting(year: year, of: birthday)
+            }
+        )
+    }
+
+    /// Month (1–12) of a year-less birthday. The setter clamps the day so
+    /// switching to a shorter month doesn't roll the date into the next one.
+    var birthdayMonth: Binding<Int> {
+        Binding(
+            get: { contact.birthday.map { Birthday.fields(of: $0).month } ?? 1 },
+            set: { month in
+                guard let birthday = contact.birthday else { return }
+                let parts = Birthday.fields(of: birthday)
+                let day = Birthday.clampDay(parts.day, month: month, year: parts.year)
+                contact.birthday = Birthday.date(year: parts.year, month: month, day: day)
+            }
+        )
+    }
+
+    /// Day-of-month of a year-less birthday.
+    var birthdayDay: Binding<Int> {
+        Binding(
+            get: { contact.birthday.map { Birthday.fields(of: $0).day } ?? 1 },
+            set: { day in
+                guard let birthday = contact.birthday else { return }
+                let parts = Birthday.fields(of: birthday)
+                contact.birthday = Birthday.date(year: parts.year, month: parts.month, day: day)
+            }
+        )
+    }
+}
+
+/// Month + day pickers for a year-less birthday, so the editor never surfaces
+/// the omitted-year sentinel. The day range follows the selected month (using
+/// the UTC calendar birthdays are stored in, whose sentinel year is a leap year
+/// so Feb 29 stays available).
+struct MonthDayPicker: View {
+    @Binding var month: Int
+    @Binding var day: Int
+
+    /// Nominative month names ("January", not "of January") for the picker.
+    private static let monthNames: [String] = {
+        let formatter = DateFormatter()
+        formatter.calendar = Birthday.calendar
+        return formatter.standaloneMonthSymbols ?? formatter.monthSymbols
+    }()
+
+    var body: some View {
+        HStack {
+            Text("Date")
+            Spacer()
+            Picker("Month", selection: $month) {
+                ForEach(Array(Self.monthNames.enumerated()), id: \.offset) { index, name in
+                    Text(name).tag(index + 1)
+                }
+            }
+            .labelsHidden()
+            .fixedSize()
+            .accessibilityLabel("Birthday month")
+
+            Picker("Day", selection: $day) {
+                ForEach(1 ... Birthday.daysInMonth(month, year: nil), id: \.self) { value in
+                    Text(value.formatted()).tag(value)
+                }
+            }
+            .labelsHidden()
+            .fixedSize()
+            .accessibilityLabel("Birthday day")
+        }
+    }
+}

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -59,13 +59,21 @@ struct ContactDetailView: View {
 
             Section("Birthday") {
                 Toggle("Has Birthday", isOn: birthdayEnabled)
-                if contact.birthday != nil {
-                    DatePicker("Date", selection: birthdayValue, displayedComponents: .date)
-                        // Birthdays are stored anchored to UTC; show/edit them
-                        // in the same calendar (its time zone is UTC) so the
-                        // picked day matches what's saved and what other devices
-                        // see, regardless of the local time zone.
-                        .environment(\.calendar, Birthday.calendar)
+                if let birthday = contact.birthday {
+                    Toggle("Include Year", isOn: birthdayIncludesYear)
+                    if Birthday.fields(of: birthday).year == nil {
+                        // Year unknown (a vCard `--MMDD` or a yearless Contacts
+                        // card): edit month/day only so the sentinel year never
+                        // shows and can't be accidentally "confirmed".
+                        MonthDayPicker(month: birthdayMonth, day: birthdayDay)
+                    } else {
+                        DatePicker("Date", selection: birthdayValue, displayedComponents: .date)
+                            // Birthdays are stored anchored to UTC; show/edit them
+                            // in the same calendar (its time zone is UTC) so the
+                            // picked day matches what's saved and what other devices
+                            // see, regardless of the local time zone.
+                            .environment(\.calendar, Birthday.calendar)
+                    }
                 }
             }
 

--- a/ContactManagerTests/BirthdayTests.swift
+++ b/ContactManagerTests/BirthdayTests.swift
@@ -1,0 +1,78 @@
+//
+//  BirthdayTests.swift
+//  ContactManagerTests
+//
+//  Covers the pure field/year helpers behind the detail view's year-less
+//  birthday editor: clamping the day to a month, counting a month's days
+//  (including the leap-year sentinel), and adding/removing the year while
+//  preserving month and day on the shared UTC calendar.
+//
+
+@testable import ContactManager
+import Foundation
+import Testing
+
+struct BirthdayTests {
+    // MARK: - daysInMonth
+
+    @Test func countsDaysInLongAndShortMonths() {
+        #expect(Birthday.daysInMonth(1, year: 2025) == 31)
+        #expect(Birthday.daysInMonth(4, year: 2025) == 30)
+    }
+
+    @Test func februaryFollowsTheYearsLeapness() {
+        #expect(Birthday.daysInMonth(2, year: 2020) == 29)
+        #expect(Birthday.daysInMonth(2, year: 2021) == 28)
+    }
+
+    @Test func yearlessFebruaryAllowsTheTwentyNinth() {
+        // The omitted-year sentinel is a leap year so a year-less Feb 29 (a
+        // valid --0229 birthday) stays selectable.
+        #expect(Birthday.daysInMonth(2, year: nil) == 29)
+    }
+
+    // MARK: - clampDay
+
+    @Test func clampsDayDownToMonthLength() {
+        // Jan 31 → Feb should land on the last valid day, not roll forward.
+        #expect(Birthday.clampDay(31, month: 2, year: 2021) == 28)
+        #expect(Birthday.clampDay(31, month: 2, year: 2020) == 29)
+        #expect(Birthday.clampDay(31, month: 4, year: 2025) == 30)
+    }
+
+    @Test func leavesValidDayUntouched() {
+        #expect(Birthday.clampDay(15, month: 6, year: 2025) == 15)
+        #expect(Birthday.clampDay(0, month: 6, year: 2025) == 1)
+    }
+
+    // MARK: - setting(year:of:)
+
+    @Test func dropsTheYearWhilePreservingMonthAndDay() throws {
+        let dated = try #require(Birthday.date(year: 1990, month: 7, day: 4))
+        let yearless = try #require(Birthday.setting(year: nil, of: dated))
+        let fields = Birthday.fields(of: yearless)
+        #expect(fields.year == nil)
+        #expect(fields.month == 7)
+        #expect(fields.day == 4)
+    }
+
+    @Test func addsAYearWhilePreservingMonthAndDay() throws {
+        let yearless = try #require(Birthday.date(year: nil, month: 4, day: 15))
+        let dated = try #require(Birthday.setting(year: 2001, of: yearless))
+        let fields = Birthday.fields(of: dated)
+        #expect(fields.year == 2001)
+        #expect(fields.month == 4)
+        #expect(fields.day == 15)
+    }
+
+    @Test func clampsTheDayWhenAddingANonLeapYearToFeb29() throws {
+        // A year-less Feb 29 gaining a non-leap year must clamp to Feb 28
+        // rather than silently rolling into March.
+        let leapDay = try #require(Birthday.date(year: nil, month: 2, day: 29))
+        let dated = try #require(Birthday.setting(year: 2021, of: leapDay))
+        let fields = Birthday.fields(of: dated)
+        #expect(fields.year == 2021)
+        #expect(fields.month == 2)
+        #expect(fields.day == 28)
+    }
+}


### PR DESCRIPTION
## Summary

Year-less birthdays (imported from a vCard `--MMDD` or a Contacts card with no birth year) are stored as a `Date` anchored to a sentinel year (`Birthday.omittedYear`, currently `9996`). The contact detail editor's Birthday section showed a plain `DatePicker(displayedComponents: .date)`, which **surfaced that sentinel year to the user** — misleading, and easy to accidentally "confirm" a fabricated year.

This PR renders year-less birthdays without leaking the sentinel.

## Changes

- **Month/day-only control.** When the stored birthday has no year (`Birthday.fields(of:).year == nil`), the editor shows a new `MonthDayPicker` (month + day pickers) instead of the full `DatePicker`, so the sentinel year never appears.
- **"Include Year" toggle.** Adds a real year (current year) or drops back to the year-less form, preserving the month/day.
- **Day clamping.** Switching to a shorter month lands on the last valid day (Jan 31 → Feb 28/29) rather than rolling into the next month, and the year-less Feb 29 stays selectable (the sentinel year is a leap year).

All reads/writes route through `Birthday.fields(of:)` / `Birthday.date(year:month:day:)` plus three new pure helpers — `setting(year:of:)`, `daysInMonth(_:year:)`, `clampDay(_:month:year:)` — so the UTC convention and sentinel handling stay centralized.

The editor bindings and `MonthDayPicker` live in a new `ContactDetailView+Birthday.swift` (mirroring the existing `+Photo` split) to keep the main view under the 400-line lint limit.

## Tests

New `BirthdayTests` cover the pure helpers: month lengths, the leap-year sentinel allowing Feb 29, day clamping, and adding/removing the year while preserving month/day.

`make check` (format-check + lint + test) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)