### PR TITLE
Close the detached contact window when its contact is deleted

### DIFF
--- a/ContactManager/Views/ContactWindowView.swift
+++ b/ContactManager/Views/ContactWindowView.swift
@@ -24,6 +24,12 @@ struct ContactWindowView: View {
     @Query(sort: [SortDescriptor(\Contact.lastName), SortDescriptor(\Contact.firstName)])
     private var contacts: [Contact]
 
+    @Environment(\.dismiss) private var dismiss
+    /// Whether this window ever showed its contact. Lets us tell "deleted
+    /// while open" (auto-close) from "never resolved" — a stale id at launch /
+    /// window restoration — where we keep the explanatory unavailable view.
+    @State private var hadContact = false
+
     private var contact: Contact? {
         guard let encodedID,
               let id = PersistentIdentifier.decode(stored: encodedID)
@@ -36,6 +42,7 @@ struct ContactWindowView: View {
             if let contact {
                 ContactDetailView(contact: contact)
                     .navigationTitle(contact.fullName)
+                    .onAppear { hadContact = true }
             } else {
                 ContentUnavailableView(
                     "Contact Not Found",
@@ -45,6 +52,9 @@ struct ContactWindowView: View {
                             "Close the window or open another contact from the main window."
                     )
                 )
+                // If we'd previously shown the contact, it was just deleted —
+                // close the now-orphaned window instead of stranding it.
+                .onAppear { if hadContact { dismiss() } }
             }
         }
         .frame(minWidth: 460, minHeight: 520)


### PR DESCRIPTION
## Summary
P2 from the audit. A contact opened in its own window (row ▸ Open in New Window) showed "Contact Not Found" forever once the contact was deleted from the main window. The window now dismisses itself when its contact disappears **after having been shown** — tracked via a `hadContact` flag so a window that never resolved its contact (a stale id at launch / window restoration) still keeps the explanatory unavailable view instead of vanishing on open.

## Test plan
- [x] `make check` — build/lint/format clean; 138 unit tests pass (3 XCUITests flake locally on app activation only; CI runs swiftformat/swiftlint)
- [x] No new unit test: window dismissal is view behavior with no extractable logic (window-restoration coverage is tracked under the P2 test-gap item)
- [ ] Manual: open a contact in a new window, delete it from the main window, confirm the detached window closes; relaunch with a window restored to a since-deleted contact and confirm it shows the unavailable view (doesn't insta-close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)