### PR TITLE
Refresh the README to match the current app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,6 @@ pattern), then build to confirm it compiles.
 
 ## Workflow
 
-- Ship focused, single-purpose PRs. Keep the README roadmap and this file in sync.
+- Ship focused, single-purpose PRs. Keep the README and this file in sync.
 - Use the GitHub CLI (`gh`) for all GitHub operations, and address Copilot review comments
   before merging.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Contact Manager
 
-**ContactManager** is a native macOS contact manager built with **SwiftUI** and **SwiftData**, targeting the modern macOS Tahoe (macOS 26) look and feel. It is **100% self-contained** with zero third-party dependencies.
+**ContactManager** is a native macOS contact manager built with **SwiftUI** and **SwiftData**, targeting the modern macOS Tahoe (macOS 26) look and feel. It has **zero third-party runtime dependencies**.
 
 The app was originally an Objective-C / AppKit / Core Data demo and was rebuilt, in focused increments, into a polished native Tahoe application.
 
@@ -9,73 +9,89 @@ The app was originally an Objective-C / AppKit / Core Data demo and was rebuilt,
 ## Architecture
 
 - **Platform**: macOS 26.0+ (Tahoe)
-- **UI**: SwiftUI — a three-column `NavigationSplitView` (sidebar / contact list / detail) that automatically adopts the Liquid Glass appearance when built against the macOS 26 SDK.
-- **Persistence**: SwiftData (`@Model`, `ModelContainer`, `@Query`), replacing the legacy Core Data stack.
-- **Language**: Swift
-- **Testing**: Swift Testing, backed by an in-memory `ModelContainer`.
+- **UI**: SwiftUI — a three-column `NavigationSplitView` (groups sidebar / contact list / detail) that automatically adopts the Liquid Glass appearance when built against the macOS 26 SDK.
+- **Persistence**: SwiftData (`@Model`, `ModelContainer`, `@Query`), replacing the legacy Core Data stack. The container is **CloudKit-ready** (`cloudKitDatabase: .automatic`) and falls back to a local-only store when no iCloud capability is present.
+- **System integration**: App Intents (Shortcuts / Siri), Core Spotlight indexing, the macOS Contacts framework, and drag-and-drop.
+- **Language**: Swift (language mode 5; full Swift 6 concurrency is a future migration).
+- **Testing**: Swift Testing (unit) backed by an in-memory `ModelContainer`, plus a small XCUITest smoke suite.
 
 ### Source layout
 
 ```
 ContactManager/
-├── App/      ContactManagerApp.swift   – @main entry point, model container, menu commands
-├── Models/   Contact.swift             – the @Model contact entity + derived values
-│             ContactField.swift        – labeled, repeatable email/phone child entity
-│             ContactGroup.swift        – user group/tag (many-to-many with Contact)
-│             ContactQuery.swift        – pure, testable filter/sort/section helpers
-│             SampleData.swift          – first-launch seed data
-├── Support/  ImageProcessing.swift     – downscales picked images into avatar JPEGs
-│             VCard.swift               – pure vCard 3.0 reader/writer
-│             VCardDocument.swift       – FileDocument for the export dialog
-└── Views/    ContentView.swift         – NavigationSplitView shell, group + import/export logic
-              SidebarView.swift         – groups sidebar with create/rename/delete
-              ContactListView.swift     – searchable, sectioned contact list + toolbar
-              ContactDetailView.swift   – editable detail form + photo well + group toggles
-              AvatarView.swift          – photo or initials avatar with a per-contact tint
+├── App/      ContactManagerApp.swift     – @main entry, ModelContainer, menu commands, scenes
+├── Models/   Contact.swift               – the @Model contact entity + derived values
+│             ContactField.swift          – labeled, repeatable email/phone child entity
+│             ContactGroup.swift          – user group/tag (many-to-many with Contact)
+│             ContactStore.swift          – data layer: every mutation, saved + undoable
+│             ContactQuery.swift          – pure filter/sort/section helpers
+│             DuplicateFinder.swift       – groups likely-duplicate contacts
+│             DefaultGroupPreference.swift – resolves the "new contacts join" preference
+│             SampleData.swift            – first-launch seed data
+├── Support/  VCard / VCardDocument / VCardTransfer – vCard 3.0 read/write, export, drag
+│             CSV.swift                   – Google/Outlook/Apple CSV reader
+│             ContactsBridge.swift        – import from the macOS Contacts app
+│             ImageProcessing.swift       – downscales picked images into avatar JPEGs
+│             Birthday.swift              – UTC-anchored date-only birthday handling
+│             ContactLink.swift           – mailto:/tel: URL construction
+│             ContactPDF / PDFExportDocument – contact-card PDF render + export
+│             Chunking.swift              – batches large imports
+│             SpotlightIndexer.swift      – incremental Core Spotlight indexing
+│             PersistentIdentifierEncoding.swift – stable encoded model ids
+├── Intents/  ContactEntity / ContactEntityQuery – App Intents identity + Spotlight attributes
+│             FindContactIntent / OpenContactIntent – Shortcuts/Siri actions
+│             EntityModelContainer.swift  – process-wide container handle for intents
+└── Views/    ContentView (+Import)       – split-view shell, selection, import/export, progress
+              SidebarView                 – groups sidebar (create/rename/delete, drop target)
+              ContactListView             – searchable, sectioned list + toolbar + drag
+              ContactDetailView (+Photo, +Birthday) – editable detail, photo well, share, actions
+              ContactWindowView           – single-contact detached window
+              PrintableContactView        – print/PDF card layout
+              SettingsView · DuplicatesView · ImportProgressView · AvatarView · LayoutMetrics
 ```
 
 ---
 
 ## Features
 
-- Three-column native layout with a Liquid Glass toolbar and a toggleable trailing inspector pane.
-- Create, edit (inline, autosaving), and delete contacts.
-- Multiple labeled emails and phone numbers per contact (add/remove inline).
-- Company, job title, postal address, birthday, and free-form notes.
-- Live search across name, company, title, notes, and field values.
-- Alphabetical sections with a first-name / last-name sort toggle.
-- Contact photos (downscaled on import) with an initials avatar fallback.
-- User-defined groups (sidebar create/rename/delete) with per-contact membership.
-- vCard 3.0 import and export (File ▸ Import/Export vCard…), including embedded **PHOTO** round-tripping.
-- Duplicate detection & merge (Edit ▸ Find Duplicates…) — review and combine contacts that share an email, phone, or name.
-- iCloud sync (when the iCloud capability is enabled in Xcode) with a graceful local-only fallback when it isn't.
-- Liquid Glass styling, glass-prominent actions, and smooth list/selection animations.
-
-### Roadmap
-
-Shipped as small, single-purpose PRs:
-
-1. ✅ **Foundation** — SwiftUI + SwiftData rewrite, CRUD, project modernized to macOS 26.
-2. ✅ **Richer fields** — multiple emails/phones, company/title, address, birthday, notes.
-3. ✅ **Search & sections** — live search and alphabetical sectioning.
-4. ✅ **Contact photos** — photo import with initials fallback.
-5. ✅ **Groups & vCard** — user groups/tags and `.vcf` import/export.
-6. ✅ **Tahoe polish** — Liquid Glass refinements, animations, and richer empty states.
+- Three-column native layout with a Liquid Glass toolbar and smooth list/selection animations.
+- Create, edit (inline, autosaving), and delete contacts, with full **Undo/Redo** (⌘Z / ⇧⌘Z).
+- Multiple labeled emails and phone numbers, company, job title, postal address, birthday (year optional), and notes.
+- Click-to-mail / click-to-call (`mailto:` / `tel:`) on the contact's primary email and phone.
+- Live, debounced search across name, company, title, notes, and field values, with alphabetical sections and a first-name / last-name sort toggle. **⌘F** focuses the search field.
+- Contact photos (downscaled on import, streamed via ImageIO) with an initials avatar fallback.
+- User-defined groups (sidebar create/rename/delete); drag contacts onto a group to add them.
+- Duplicate detection & merge (Edit ▸ Find Duplicates…).
+- **Import**: vCard `.vcf`, CSV (Google / Outlook / Apple exports), and the macOS **Contacts** app — chunked with a progress overlay. **Export / share**: vCard via File ▸ Export or the detail Share button.
+- **Print** a contact card and **Export as PDF** (⌘P / ⇧⌘P).
+- **Drag and drop**: drag a contact to Finder as a `.vcf`, drop a `.vcf` onto the list to import, drop an image onto the avatar.
+- **Open in New Window** for a single contact (the window closes itself if that contact is deleted).
+- **Shortcuts & Siri** via App Intents (Find / Open Contact) and **Spotlight** indexing with tap-to-open.
+- **iCloud sync** when the capability is enabled in Xcode, with a graceful local-only fallback.
+- Runs under the **App Sandbox** with the hardened runtime.
 
 ---
 
-## Getting Started
+## Development
 
-### Prerequisites
+A `Makefile` wraps the common tasks (install tooling once with `make bootstrap`, which runs `brew bundle`):
 
-Xcode 26 or later (macOS 26 SDK). No dependency managers required.
+| Task | Command |
+| --- | --- |
+| Build | `make build` |
+| Test | `make test` |
+| Lint | `make lint` (autofix: `make lint-fix`) |
+| Format | `make format` (check only: `make format-check`) |
+| Pre-PR gate | `make check` (format-check + lint + test) |
+
+Tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`). Linting and formatting are **SwiftLint** + **SwiftFormat**; CI (`.github/workflows/ci.yml`) runs `swiftformat --lint` and `swiftlint --strict` on every PR. Contributor and agent conventions live in `CLAUDE.md`.
 
 ### Building & Running
 
-Open `ContactManager.xcodeproj` in Xcode, select the **ContactManager** scheme, and press `Cmd + R`.
+Open `ContactManager.xcodeproj` in Xcode (26 or later, macOS 26 SDK), select the **ContactManager** scheme, and press `Cmd + R` — or run `make build`.
 
-### Running the Test Suite
+### Running the Tests
 
 ```shell
-xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' test
+make test            # unit + UI tests via xcodebuild
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ ContactManager/
 - Contact photos (downscaled on import, streamed via ImageIO) with an initials avatar fallback.
 - User-defined groups (sidebar create/rename/delete); drag contacts onto a group to add them.
 - Duplicate detection & merge (Edit ▸ Find Duplicates…).
-- **Import**: vCard `.vcf`, CSV (Google / Outlook / Apple exports), and the macOS **Contacts** app — chunked with a progress overlay. **Export / share**: vCard via File ▸ Export or the detail Share button.
+- **Import**: vCard `.vcf`, CSV (Google / Outlook / Apple exports), and the macOS **Contacts** app — chunked with a progress overlay. **Export / share**: vCard via File ▸ Export vCard… or the detail Share button.
 - **Print** a contact card and **Export as PDF** (⌘P / ⇧⌘P).
 - **Drag and drop**: drag a contact to Finder as a `.vcf`, drop a `.vcf` onto the list to import, drop an image onto the avatar.
 - **Open in New Window** for a single contact (the window closes itself if that contact is deleted).


### PR DESCRIPTION
## Summary
The README had drifted from the app. It described a trailing **inspector pane** that was removed (#30), stopped at the original 6-PR roadmap, and omitted most of what shipped since: App Intents/Shortcuts, Spotlight indexing, CSV import, macOS Contacts import, drag-and-drop, detached windows, `mailto:`/`tel:`, ShareLink, Print/Export PDF, import progress, the App Sandbox, and the Makefile/CI workflow.

Rewrote **Architecture** (CloudKit-ready note + system integration), the **source layout** (Models/Support/Intents/Views as they exist today), the **feature list**, and added a **Development** section documenting the `make` targets, Swift Testing, and the SwiftFormat/SwiftLint CI gate. Dropped the stale roadmap in favor of describing what the app does now.

Docs-only — no Swift changed.

## Test plan
- [x] Proofread against the current source tree and menu commands
- [x] No code touched; CI (swiftformat/swiftlint) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)