### PR TITLE
Advertise the open contact for Handoff

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -21,9 +21,11 @@
 		2EB13805320DA225F70D08F3 /* VCardTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */; };
 		3076738411F8C3FA073D1BE0 /* ContactsBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */; };
 		322103E6FBEAD59C6A2405E6 /* Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDED82FFB4B5F039052FFB5 /* Birthday.swift */; };
+		442122E49889F5A9CA174B12 /* ContactActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */; };
 		4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */; };
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
 		488CA0C339AD3218073A02E8 /* PrintableContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37DB6CC43A76261CFF3987D /* PrintableContactView.swift */; };
+		4B9EAE3500BB10401AEB3746 /* ContactActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CF4C47C670B0A8C3B6B384 /* ContactActivity.swift */; };
 		4EC36757044377406665E53B /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */; };
 		4F1E1A097740ECE3D42E55B8 /* GroupDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964ACD67CC8CB35694497A10 /* GroupDropTests.swift */; };
 		52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */; };
@@ -135,6 +137,7 @@
 		AC2AA1D7BB15FC01B9CBA3B3 /* EntityModelContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityModelContainer.swift; sourceTree = "<group>"; };
 		B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTransfer.swift; sourceTree = "<group>"; };
 		B040B21B7E2002E00885A9BA /* BirthdayTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BirthdayTests.swift; sourceTree = "<group>"; };
+		B0CF4C47C670B0A8C3B6B384 /* ContactActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactActivity.swift; sourceTree = "<group>"; };
 		B25751DDEC1515E341AF67F5 /* ContactField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactField.swift; sourceTree = "<group>"; };
 		B75D02267D3BC6C014143329 /* ContactModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactModelTests.swift; sourceTree = "<group>"; };
 		BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSVTests.swift; sourceTree = "<group>"; };
@@ -142,6 +145,7 @@
 		C0255C29CC874D2BA1C064CF /* ContactPDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactPDF.swift; sourceTree = "<group>"; };
 		C0F303B7AE5B9202CDA6D9DA /* ContactPDFTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactPDFTests.swift; sourceTree = "<group>"; };
 		C7DCAF444714BC3726B212C4 /* UndoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UndoTests.swift; sourceTree = "<group>"; };
+		DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactActivityTests.swift; sourceTree = "<group>"; };
 		DC69A4C348D4BBEF0D8F1330 /* PDFExportDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFExportDocument.swift; sourceTree = "<group>"; };
 		DEAB729518FA2A6600E3570B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		DED8178913A452A900EC3234 /* ContactManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ContactManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -229,6 +233,7 @@
 				436B4115937E4350EB9A7EF7 /* Chunking.swift */,
 				C0255C29CC874D2BA1C064CF /* ContactPDF.swift */,
 				DC69A4C348D4BBEF0D8F1330 /* PDFExportDocument.swift */,
+				B0CF4C47C670B0A8C3B6B384 /* ContactActivity.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -323,6 +328,7 @@
 				B040B21B7E2002E00885A9BA /* BirthdayTests.swift */,
 				2623DCD281C3DDAA29BB6B99 /* DefaultGroupPreferenceTests.swift */,
 				279FCAC10E829D7DAC9D8385 /* OpenContactIntentTests.swift */,
+				DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -492,6 +498,7 @@
 				488CA0C339AD3218073A02E8 /* PrintableContactView.swift in Sources */,
 				8397B67D483997505B17269E /* ContactDetailView+Birthday.swift in Sources */,
 				AA43BCF64B0DC3F571E4A813 /* DefaultGroupPreference.swift in Sources */,
+				4B9EAE3500BB10401AEB3746 /* ContactActivity.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -517,6 +524,7 @@
 				BC3D0CE8272648D0ACEF0C46 /* BirthdayTests.swift in Sources */,
 				8279EF938E1BAA17ACAB8D94 /* DefaultGroupPreferenceTests.swift in Sources */,
 				01001E025DB1348D36342E1C /* OpenContactIntentTests.swift in Sources */,
+				442122E49889F5A9CA174B12 /* ContactActivityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -698,6 +706,7 @@
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ContactManager/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSContactsUsageDescription = "ContactManager imports contacts from your system Contacts when you choose Import from Contacts…";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Scott Densmore. All rights reserved.";
@@ -736,6 +745,7 @@
 				GCC_GENERATE_TEST_COVERAGE_FILES = NO;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ContactManager/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSContactsUsageDescription = "ContactManager imports contacts from your system Contacts when you choose Import from Contacts…";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Scott Densmore. All rights reserved.";

--- a/ContactManager/Info.plist
+++ b/ContactManager/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>com.scottdensmore.ContactManager.viewContact</string>
+	</array>
+</dict>
+</plist>

--- a/ContactManager/Support/ContactActivity.swift
+++ b/ContactManager/Support/ContactActivity.swift
@@ -5,7 +5,8 @@
 //  The `NSUserActivity` for "viewing a contact" — advertised for Handoff so
 //  the contact open on one device can be continued on another, and consumed
 //  on the receiving side. The activity type is also declared in the app's
-//  Info.plist (INFOPLIST_KEY_NSUserActivityTypes) so the system advertises it.
+//  Info.plist under `NSUserActivityTypes` (a partial Info.plist merged into
+//  the generated one) so the system advertises it.
 //
 
 import Foundation
@@ -14,7 +15,8 @@ enum ContactActivity {
     /// Handoff activity type for the currently open contact.
     static let viewContactType = "com.scottdensmore.ContactManager.viewContact"
     /// `userInfo` key holding the contact's encoded `PersistentIdentifier`.
-    static let idKey = "id"
+    /// Reverse-DNS namespaced so it can't collide with system or other keys.
+    static let idKey = "com.scottdensmore.ContactManager.contactID"
 
     /// Populates an activity (e.g. the one SwiftUI's `.userActivity` hands us)
     /// to advertise the given contact for Handoff. Kept separate from the view

--- a/ContactManager/Support/ContactActivity.swift
+++ b/ContactManager/Support/ContactActivity.swift
@@ -1,0 +1,35 @@
+//
+//  ContactActivity.swift
+//  ContactManager
+//
+//  The `NSUserActivity` for "viewing a contact" — advertised for Handoff so
+//  the contact open on one device can be continued on another, and consumed
+//  on the receiving side. The activity type is also declared in the app's
+//  Info.plist (INFOPLIST_KEY_NSUserActivityTypes) so the system advertises it.
+//
+
+import Foundation
+
+enum ContactActivity {
+    /// Handoff activity type for the currently open contact.
+    static let viewContactType = "com.scottdensmore.ContactManager.viewContact"
+    /// `userInfo` key holding the contact's encoded `PersistentIdentifier`.
+    static let idKey = "id"
+
+    /// Populates an activity (e.g. the one SwiftUI's `.userActivity` hands us)
+    /// to advertise the given contact for Handoff. Kept separate from the view
+    /// so the payload is unit-tested.
+    static func configure(_ activity: NSUserActivity, contactID: String, displayName: String) {
+        activity.title = displayName
+        activity.userInfo = [idKey: contactID]
+        activity.targetContentIdentifier = contactID
+        activity.isEligibleForHandoff = true
+        // Spotlight indexing is handled separately by `SpotlightIndexer`.
+        activity.isEligibleForSearch = false
+    }
+
+    /// The encoded contact id carried by a continued activity, if any.
+    static func contactID(from activity: NSUserActivity) -> String? {
+        activity.userInfo?[idKey] as? String
+    }
+}

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -295,6 +295,15 @@ private extension ContentView {
                 let id = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String
                 selectContact(byEncodedID: id)
             }
+            // Advertise the open contact for Handoff, and accept it back.
+            .userActivity(ContactActivity.viewContactType, isActive: selectedContact != nil) { activity in
+                if let contact = selectedContact, let id = contact.persistentModelID.storedString {
+                    ContactActivity.configure(activity, contactID: id, displayName: contact.fullName)
+                }
+            }
+            .onContinueUserActivity(ContactActivity.viewContactType) { activity in
+                selectContact(byEncodedID: ContactActivity.contactID(from: activity))
+            }
     }
 
     /// The sheets, importers, exporters, and the error alert.

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -117,7 +117,7 @@ struct ContentView: View {
             }
         // Split into helpers so the modifier chain stays within the SwiftUI
         // type-checker's budget (and the type-body length limit).
-        return handlingFileDialogs(handlingMenuCommands(scene))
+        return handlingFileDialogs(handlingHandoff(handlingMenuCommands(scene)))
     }
 
     /// The three-column split view, window frame, and the import overlay.
@@ -295,8 +295,17 @@ private extension ContentView {
                 let id = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String
                 selectContact(byEncodedID: id)
             }
-            // Advertise the open contact for Handoff, and accept it back.
-            .userActivity(ContactActivity.viewContactType, isActive: selectedContact != nil) { activity in
+    }
+
+    /// Advertises the open contact for Handoff, and accepts it back. The
+    /// activity is only active once we have an encoded id, so the system never
+    /// holds an activity without a valid contact identifier.
+    func handlingHandoff(_ content: some View) -> some View {
+        content
+            .userActivity(
+                ContactActivity.viewContactType,
+                isActive: selectedContact?.persistentModelID.storedString != nil
+            ) { activity in
                 if let contact = selectedContact, let id = contact.persistentModelID.storedString {
                     ContactActivity.configure(activity, contactID: id, displayName: contact.fullName)
                 }

--- a/ContactManagerTests/ContactActivityTests.swift
+++ b/ContactManagerTests/ContactActivityTests.swift
@@ -1,0 +1,33 @@
+//
+//  ContactActivityTests.swift
+//  ContactManagerTests
+//
+//  Covers the Handoff NSUserActivity payload for the open contact.
+//
+
+@testable import ContactManager
+import Foundation
+import Testing
+
+struct ContactActivityTests {
+    @Test func configurePopulatesHandoffPayload() {
+        let activity = NSUserActivity(activityType: ContactActivity.viewContactType)
+        ContactActivity.configure(activity, contactID: "encoded-id-1", displayName: "Ada Lovelace")
+
+        #expect(activity.title == "Ada Lovelace")
+        #expect(activity.targetContentIdentifier == "encoded-id-1")
+        #expect(activity.isEligibleForHandoff)
+        #expect(activity.userInfo?[ContactActivity.idKey] as? String == "encoded-id-1")
+    }
+
+    @Test func contactIDRoundTripsThroughActivity() {
+        let activity = NSUserActivity(activityType: ContactActivity.viewContactType)
+        ContactActivity.configure(activity, contactID: "encoded-id-2", displayName: "Alan Turing")
+        #expect(ContactActivity.contactID(from: activity) == "encoded-id-2")
+    }
+
+    @Test func contactIDIsNilWhenAbsent() {
+        let activity = NSUserActivity(activityType: ContactActivity.viewContactType)
+        #expect(ContactActivity.contactID(from: activity) == nil)
+    }
+}


### PR DESCRIPTION
## Summary
P2 from the audit. Inbound continuity (Spotlight tap) was wired, but the app never published an `NSUserActivity` for the contact you're viewing — so there was nothing to hand off to another device.

- `ContentView` now advertises a **"viewContact" activity** via SwiftUI's `.userActivity` (active whenever a contact is selected), populated by a tested **`ContactActivity`** helper (title, encoded id in `userInfo`, `targetContentIdentifier`, `isEligibleForHandoff`), and accepts it back via `.onContinueUserActivity` to select the contact — the same path as the Spotlight handler.
- For the system to actually advertise it, the activity type must be in Info.plist's `NSUserActivityTypes`. The target uses `GENERATE_INFOPLIST_FILE`, and `INFOPLIST_KEY_*` doesn't support that array key, so this adds a minimal `ContactManager/Info.plist` (just `NSUserActivityTypes`) and points `INFOPLIST_FILE` at it — Xcode **merges** it on top of the generated keys.

**Verified** the built `Info.plist` contains `NSUserActivityTypes` *and* the generated keys (`CFBundleIdentifier`, `NSContactsUsageDescription`, …) via PlistBuddy.

## Test plan
- [x] `make check` — build/lint/format clean; 146 unit tests pass (3 XCUITests flake locally on app activation only; CI runs swiftformat/swiftlint)
- [x] New `ContactActivityTests`: payload fields + id round-trip + nil-when-absent
- [x] Built Info.plist inspected: `NSUserActivityTypes = [com.scottdensmore.ContactManager.viewContact]`, generated keys preserved
- [ ] Manual (needs two signed-in devices): open a contact, confirm a Handoff banner appears on a nearby device and continues to the same contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)