### PR TITLE
Wire CloudKit sync as a non-blocking, opt-in capability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,11 +67,16 @@ pattern), then build to confirm it compiles.
   (e.g. `var city: String = ""`), or in-place migration fails (`NSCocoaError 134110`).
   Optional attributes and relationships migrate cleanly. Verify by launching against an
   existing store.
-- **CloudKit-ready:** the container is built with `ModelConfiguration(cloudKitDatabase:
-  .automatic)` and falls back to `.none` (local-only) on failure, so the app runs with or
-  without an iCloud entitlement. To keep the schema sync-compatible, every non-optional
-  attribute needs an inline default (already covered by the migration rule), every to-many
-  relationship needs `= []`, and we avoid `@Attribute(.unique)` and `.deny` delete rules.
+- **CloudKit (opt-in, non-blocking):** `loadContainer` checks the running binary's
+  entitlements (`hasCloudKitEntitlement()` via `SecTask`) for an iCloud container. If one
+  is configured it opens the store with `cloudKitDatabase: .automatic` (sync); otherwise
+  `.none` (local) and it seeds sample data. A try/catch falls back to local on failure.
+  **Do not commit an iCloud entitlement / container** — it would break signing for anyone
+  who clones without that team/container; enabling iCloud is a documented local opt-in
+  (README ▸ "iCloud sync"). Seed only when local-only, so samples never sync into a real
+  iCloud account. To keep the schema sync-compatible, every non-optional attribute needs an
+  inline default (already covered by the migration rule), every to-many relationship needs
+  `= []`, and we avoid `@Attribute(.unique)` and `.deny` delete rules.
 - **Tests:** use an in-memory `ModelContainer`; the suite is `@MainActor @Suite(.serialized)`
   and holds the container as a stored property. The app skips creating its own container
   under tests (`XCTestConfigurationFilePath`) so the test owns the only one — keep that guard.

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -6,6 +6,7 @@
 //  AppKit launch path.
 //
 
+import Security
 import SwiftData
 import SwiftUI
 
@@ -145,33 +146,38 @@ struct ContactManagerApp: App {
             return loadUITestContainer(schema: schema)
         }
 
-        // Build a CloudKit-backed container when the iCloud capability is
-        // present, and fall back to a local-only container otherwise so the
-        // app still runs without iCloud.
+        // Use CloudKit only when the iCloud capability is actually configured
+        // (an iCloud container in the entitlements). A fresh clone has none, so
+        // it runs fully local and works out of the box; enabling iCloud in
+        // Signing & Capabilities (see README) switches on sync with no code
+        // change — `.automatic` then resolves the configured container.
+        let cloudKitEnabled = hasCloudKitEntitlement()
         let container: ModelContainer
-        var isLocalOnlyFallback = false
+        var didFallBackToLocal = false
         do {
-            // `.automatic` uses the project's iCloud container when an iCloud
-            // entitlement is present; without one it still loads successfully
-            // and behaves as a local-only store.
-            let cloudConfiguration = ModelConfiguration(schema: schema, cloudKitDatabase: .automatic)
-            container = try ModelContainer(for: schema, configurations: cloudConfiguration)
+            let configuration = ModelConfiguration(
+                schema: schema,
+                cloudKitDatabase: cloudKitEnabled ? .automatic : .none
+            )
+            container = try ModelContainer(for: schema, configurations: configuration)
         } catch {
-            print("ContactManager: CloudKit container failed (\(error.localizedDescription)); using local.")
+            let mode = cloudKitEnabled ? "CloudKit" : "local"
+            print("ContactManager: \(mode) container failed (\(error.localizedDescription)); retrying local-only.")
             do {
                 let localConfiguration = ModelConfiguration(schema: schema, cloudKitDatabase: .none)
                 container = try ModelContainer(for: schema, configurations: localConfiguration)
-                isLocalOnlyFallback = true
+                didFallBackToLocal = true
             } catch {
                 return .failed(error.localizedDescription)
             }
         }
 
-        // Only seed sample data on the confirmed local-only fallback. On a
-        // CloudKit-capable container the user's real contacts might be about
-        // to sync down (a fresh install on a second device); seeding then
-        // would race the sync and propagate the samples to every device.
-        if isLocalOnlyFallback {
+        // Seed sample data only for a genuinely local store. A CloudKit-backed
+        // store may be about to sync the user's real contacts down (a fresh
+        // install on a second device); seeding then would push the samples into
+        // their iCloud and propagate to every device.
+        let isLocalOnly = !cloudKitEnabled || didFallBackToLocal
+        if isLocalOnly {
             do {
                 try SampleData.seedIfNeeded(container.mainContext)
             } catch {
@@ -183,6 +189,20 @@ struct ContactManagerApp: App {
         EntityModelContainer.shared = container
         Task.detached { await SpotlightIndexer.shared.reindex() }
         return .ready(container)
+    }
+
+    /// Whether the app was built with an iCloud container in its entitlements
+    /// (i.e. someone enabled iCloud ▸ CloudKit in Signing & Capabilities). Read
+    /// from the running binary's own entitlements, so we can choose CloudKit vs
+    /// local without any build-time flag — a plain clone has none and runs
+    /// local-only.
+    private static func hasCloudKitEntitlement() -> Bool {
+        guard let task = SecTaskCreateFromSelf(nil),
+              let containers = SecTaskCopyValueForEntitlement(
+                  task, "com.apple.developer.icloud-container-identifiers" as CFString, nil
+              ) as? [String]
+        else { return false }
+        return !containers.isEmpty
     }
 
     private static func loadUITestContainer(schema: Schema) -> ContainerLoadState {

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -161,8 +161,10 @@ struct ContactManagerApp: App {
             )
             container = try ModelContainer(for: schema, configurations: configuration)
         } catch {
-            let mode = cloudKitEnabled ? "CloudKit" : "local"
-            print("ContactManager: \(mode) container failed (\(error.localizedDescription)); retrying local-only.")
+            // Only a CloudKit-backed attempt is worth retrying as local; if the
+            // local attempt itself failed there's nothing left to fall back to.
+            guard cloudKitEnabled else { return .failed(error.localizedDescription) }
+            print("ContactManager: CloudKit container failed (\(error.localizedDescription)); retrying local-only.")
             do {
                 let localConfiguration = ModelConfiguration(schema: schema, cloudKitDatabase: .none)
                 container = try ModelContainer(for: schema, configurations: localConfiguration)

--- a/README.md
+++ b/README.md
@@ -95,3 +95,29 @@ Open `ContactManager.xcodeproj` in Xcode (26 or later, macOS 26 SDK), select the
 ```shell
 make test            # unit + UI tests via xcodebuild
 ```
+
+### iCloud sync (optional)
+
+The app runs **local-only out of the box** — clone, build, and run with no
+account or extra setup (a fresh store is seeded with a few sample contacts).
+It's also **CloudKit-ready**: at launch it checks whether an iCloud container is
+configured in its entitlements and, if so, opens the SwiftData store with
+`cloudKitDatabase: .automatic` to sync across your devices; otherwise it stays
+local. Nothing about CloudKit is committed to the project, so a download is never
+blocked by a provisioning profile you don't own.
+
+To turn on sync for your own build:
+
+1. In Xcode, select the **ContactManager** target ▸ **Signing & Capabilities**.
+2. Set your **Team** (keep *Automatically manage signing*).
+3. Click **+ Capability** ▸ **iCloud**, check **CloudKit**, and add a container
+   (the default `iCloud.<your-bundle-id>` is fine — use your own bundle id).
+4. Click **+ Capability** ▸ **Background Modes** and enable **Remote
+   notifications** so the store receives sync pushes.
+5. Make sure the Mac is signed in to iCloud, then build and run. The store now
+   syncs; on an empty CloudKit account your existing local contacts upload, and
+   other devices using the same container pull them down.
+
+> These steps modify the target's entitlements and signing settings. If you
+> contribute back, **don't commit those changes** — leaving them out keeps the
+> project buildable by anyone who clones it without your team or container.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ To turn on sync for your own build:
 2. Set your **Team** (keep *Automatically manage signing*).
 3. Click **+ Capability** ▸ **iCloud**, check **CloudKit**, and add a container
    (the default `iCloud.<your-bundle-id>` is fine — use your own bundle id).
-4. Click **+ Capability** ▸ **Background Modes** and enable **Remote
-   notifications** so the store receives sync pushes.
+4. Click **+ Capability** ▸ **Push Notifications** so the store receives
+   CloudKit change pushes (this is the macOS capability; there's no
+   "Background Modes ▸ Remote notifications" toggle for a Mac app).
 5. Make sure the Mac is signed in to iCloud, then build and run. The store now
    syncs; on an empty CloudKit account your existing local contacts upload, and
    other devices using the same container pull them down.


### PR DESCRIPTION
## Summary
P0 #2 (the last open audit item). The store already used `cloudKitDatabase: .automatic`, but a fresh clone (no iCloud entitlement) hit a subtle gap: `.automatic` succeeds as a **local** store *without throwing*, so the catch-based `isLocalOnlyFallback` never tripped and **sample data was never seeded** — the app opened empty.

`loadContainer` now detects whether an iCloud container is configured in the running binary's entitlements (`hasCloudKitEntitlement()` via `SecTask`) and chooses explicitly:

- **entitlement present** → `cloudKitDatabase: .automatic` (sync), no auto-seed (real contacts may be about to sync down).
- **no entitlement** → `cloudKitDatabase: .none` (local), **seed** sample data.

A `try/catch` still falls back to local on any failure.

### Why this shape
You wanted CloudKit **available** but never **blocking** a download. No iCloud config is committed, so cloning never fails on a provisioning profile / container you don't own, and a local clone is seeded and usable immediately. Enabling sync is a documented opt-in:

- README gains an **"iCloud sync (optional)"** section: add the **iCloud ▸ CloudKit** capability + a container + **Background Modes ▸ Remote notifications**, sign in to iCloud — and *don't commit those entitlement/signing changes* so the project stays buildable by anyone.
- `CLAUDE.md`'s CloudKit note is updated to match.

The schema is already CloudKit-compatible (all non-optional attributes have defaults, to-many relationships default to `[]`, delete rules are cascade/nullify, no `.unique`).

## Test plan
- [x] `make check` — build/lint/format clean; 146 unit tests + UI smoke tests pass
- [x] Fresh-clone path verified by reasoning: no `icloud-container-identifiers` entitlement → `.none` + seed (app opens with sample contacts), builds with empty `DEVELOPMENT_TEAM` / sign-to-run-locally
- [ ] Manual (maintainer): enable iCloud ▸ CloudKit + a container + Remote notifications per the README, run on two devices signed into the same iCloud account, confirm contacts sync and samples are *not* seeded into the account

🤖 Generated with [Claude Code](https://claude.com/claude-code)