### PR TITLE
Round out UI smoke tests for the newer menu commands

### DIFF
--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -62,6 +62,18 @@ final class ContactManagerUITests: XCTestCase {
         XCTAssertTrue(app.menuItems["Import vCard…"].exists)
         XCTAssertTrue(app.menuItems["Import CSV…"].exists)
         XCTAssertTrue(app.menuItems["Export vCard…"].exists)
+        XCTAssertTrue(app.menuItems["Export as PDF…"].exists)
+        XCTAssertTrue(app.menuItems["Print…"].exists)
+    }
+
+    /// Verifies the Edit menu wires the search / dedup commands. The behaviors
+    /// (⌘F focus, merge) are covered at the unit/interaction layer; this just
+    /// guards the menu wiring so a dropped command is caught.
+    func test_editMenuExposesFindCommands() {
+        let app = bootSeededApp()
+        app.menuBars.menuBarItems["Edit"].click()
+        XCTAssertTrue(app.menuItems["Find"].exists)
+        XCTAssertTrue(app.menuItems["Find Duplicates…"].exists)
     }
 
     /// Verifies Edit ▸ Find Duplicates… opens the sheet. Sheet content
@@ -74,6 +86,14 @@ final class ContactManagerUITests: XCTestCase {
             "Duplicates sheet's Done button should appear after ⌘⇧D"
         )
     }
+
+    // Row-level and detail-field assertions (seeded contacts rendering, ⌘N
+    // opening the editor) need stable accessibilityIdentifiers to be reliable
+    // on macOS — the rows are single combined a11y elements and TextFields
+    // expose their prompt as a placeholder, not a queryable label. That's a
+    // deliberately deferred step (it'd mean adding identifiers across the
+    // views); these journeys are covered at the data layer by ContactStore /
+    // ContactQuery unit tests.
 
     // MARK: - Helpers
 


### PR DESCRIPTION
## Summary
The menu smoke test predated several features. This rounds it out:

- **File menu** test now also asserts **Export as PDF…** and **Print…**.
- New **Edit menu** test asserts **Find** (⌘F) and **Find Duplicates…**.

So a dropped/renamed command is caught.

### Scope note
Kept the suite **smoke-only and robust** (the agreed scope). I tried row-level ("seeded contacts render") and detail-field ("⌘N opens the editor") assertions, but on macOS those need stable `accessibilityIdentifier`s to be reliable — list rows are single *combined* accessibility elements and a `TextField`'s prompt is a *placeholder*, not a queryable label, so the queries failed against the real element tree. Rather than thread identifiers through the views (a larger, separate change), I left a comment documenting that; those create/edit/delete journeys remain covered at the data layer by `ContactStore` / `ContactQuery` unit tests.

## Test plan
- [x] `xcodebuild test -only-testing:ContactManagerUITests` — **4 UI tests pass** (launch, File menu, Edit menu, Find Duplicates sheet)
- [x] `make lint` / format-check clean
- [x] (UI tests aren't part of CI — CI runs swiftformat/swiftlint — so this is Xcode/local coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)