### PR TITLE
Respect Reduce Motion for selection and avatar animations

### DIFF
--- a/ContactManager/Views/AvatarView.swift
+++ b/ContactManager/Views/AvatarView.swift
@@ -17,6 +17,8 @@ struct AvatarView: View {
     /// (important for list rows that re-render frequently).
     @State private var photo: NSImage?
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         Group {
             if let photo {
@@ -44,8 +46,9 @@ struct AvatarView: View {
         .accessibilityHidden(true)
         .task(id: contact.photoData) {
             let decoded = contact.photoData.flatMap { NSImage(data: $0) }
-            // Animate the actual swap, which happens when `photo` updates.
-            withAnimation(.smooth) { photo = decoded }
+            // Animate the actual swap, which happens when `photo` updates —
+            // unless the user has asked to reduce motion.
+            withAnimation(reduceMotion ? nil : .smooth) { photo = decoded }
         }
     }
 

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -25,6 +25,8 @@ struct ContactListView: View {
     /// Drives the search field's focus so the Find command (⌘F) can jump to it.
     @FocusState private var searchFocused: Bool
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         List(selection: $selection) {
             ForEach(sections) { section in
@@ -45,7 +47,7 @@ struct ContactListView: View {
             ideal: LayoutMetrics.listIdealWidth,
             max: LayoutMetrics.listMaxWidth
         )
-        .animation(.smooth, value: sortOrder)
+        .animation(reduceMotion ? nil : .smooth, value: sortOrder)
         .searchable(text: $searchText, prompt: "Search Contacts")
         .searchFocused($searchFocused)
         // The Find menu command (⌘F) routes here to focus the search field.

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -14,6 +14,7 @@ import SwiftUI
 struct ContentView: View {
     @Environment(\.modelContext) private var context
     @Environment(\.undoManager) private var undoManager
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @Query(sort: [SortDescriptor(\Contact.lastName), SortDescriptor(\Contact.firstName)])
     private var contacts: [Contact]
@@ -177,7 +178,7 @@ struct ContentView: View {
         do {
             let contact = try store.createContact(in: groupForNewContact)
             contactPendingNameFocus = contact.persistentModelID
-            withAnimation(.snappy) { selectedContact = contact }
+            withAnimation(reduceMotion ? nil : .snappy) { selectedContact = contact }
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -198,7 +199,7 @@ struct ContentView: View {
     private func addGroup() {
         do {
             let group = try store.createGroup()
-            withAnimation(.snappy) { sidebarSelection = .group(group.persistentModelID) }
+            withAnimation(reduceMotion ? nil : .snappy) { sidebarSelection = .group(group.persistentModelID) }
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -241,7 +242,7 @@ struct ContentView: View {
         // middle column even if the user arrived via Spotlight while a
         // narrower group was active.
         if case .group = sidebarSelection { sidebarSelection = .allContacts }
-        withAnimation(.snappy) { selectedContact = contact }
+        withAnimation(reduceMotion ? nil : .snappy) { selectedContact = contact }
     }
 }
 


### PR DESCRIPTION
## Summary
Accessibility pass — the one notable gap I found. The app's animations ran unconditionally and ignored the system **Reduce Motion** setting:

- the list's sort-reorder — `.animation(.smooth, value: sortOrder)`
- contact/group selection — `withAnimation(.snappy)` (×3)
- the avatar photo cross-fade — `withAnimation(.smooth)`

Each now reads `@Environment(\.accessibilityReduceMotion)` and passes a `nil` animation when it's on, so motion-sensitive users get instant state changes while everyone else keeps the polish. **No change with Reduce Motion off.**

### Rest of the audit (already in good shape)
While going through every view I confirmed the existing accessibility is solid, so this is the only code change:
- Icon-only buttons are labeled (camera / envelope / phone / copy in the detail view).
- List + duplicate rows are single combined elements (`accessibilityElement(children: .combine)`); the merge button has a label.
- Decorative avatars are `accessibilityHidden`; the identity header has the `.isHeader` trait.
- Pickers/toggles carry labels (incl. the labels-hidden field-label and birthday month/day pickers).
- No body-text fixed font sizes → Dynamic Type scales (the only `system(size:)` uses are decorative initials/badge).
- Color isn't the sole signal (e.g., the green "Add Email/Phone" buttons have text).

## Test plan
- [x] `make check` — build/lint/format clean; 146 unit tests pass
- [ ] Manual: System Settings ▸ Accessibility ▸ Display ▸ **Reduce Motion** on → switching contacts/groups, changing sort, and photo changes apply instantly; off → animated as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)