### PR TITLE
CI: build and run the unit tests, not just lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,21 @@ jobs:
 
       - name: Lint (SwiftLint)
         run: swiftlint lint --strict
+
+  build-test:
+    name: Build & Test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select latest Xcode
+        run: |
+          latest=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          if [ -n "$latest" ]; then sudo xcode-select -s "$latest/Contents/Developer"; fi
+          xcodebuild -version
+
+      - name: Build
+        run: make build
+
+      - name: Test (unit)
+        run: make test-unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ jobs:
 
   build-test:
     name: Build & Test
-    runs-on: macos-latest
+    # Must be macOS 26: the app's deployment target is macOS 26, so the tests
+    # can only *run* on a 26 runner (macos-latest is still 15 — it can build
+    # against the 26 SDK but not launch a 26-target app).
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select latest Xcode
+      - name: Select Xcode 26
         run: |
-          latest=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
-          if [ -n "$latest" ]; then sudo xcode-select -s "$latest/Contents/Developer"; fi
+          # Glob the 26.x Xcodes and take the lexically-last (highest patch) —
+          # avoids GNU-only `sort -V`. Falls back to the runner default if none.
+          xcode=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | tail -1)
+          if [ -n "$xcode" ]; then sudo xcode-select -s "$xcode/Contents/Developer"; fi
           xcodebuild -version
 
       - name: Build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,13 +9,18 @@ agents — keep it readable and idiomatic.
 | Task | Command |
 | --- | --- |
 | Build | `make build` |
-| Test | `make test` |
+| Test | `make test` (unit + UI) / `make test-unit` (unit only) |
 | Lint | `make lint` (autofix: `make lint-fix`) |
 | Format | `make format` (check only: `make format-check`) |
-| Pre-PR gate | `make check` (format-check + lint + test) |
+| Pre-PR gate | `make check` (format-check + lint + unit tests) |
 | Install tooling | `make bootstrap` (runs `brew bundle`) |
 
 Tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`) — not XCTest.
+`make build`/`make test` pass `CODE_SIGNING_ALLOWED=NO` (compile + test gates; a signed
+build for distribution is done from Xcode), so they run identically locally and in CI.
+`check` runs the **unit** tests (`ContactManagerTests`) — fast and deterministic; the
+XCUITest smoke suite (`make test`) is run from Xcode, since it flakes on app activation
+when the foreground is busy and isn't part of CI.
 
 ## Layout
 
@@ -33,8 +38,10 @@ Run `make format` and `make lint` before committing; both must pass (or `make ch
 Configs: `.swiftformat`, `.swiftlint.yml`. Linting is intentionally **not** an Xcode
 build phase: the project enables `ENABLE_USER_SCRIPT_SANDBOXING`, which blocks a
 whole-tree SwiftLint run script from reading sources. Instead, CI
-(`.github/workflows/ci.yml`) runs `swiftformat --lint` + `swiftlint --strict` on every
-PR, so enforcement happens with zero local build/commit friction.
+(`.github/workflows/ci.yml`) enforces it on every PR: a **Lint & Format** job
+(`swiftformat --lint` + `swiftlint --strict`) and a **Build & Test** job
+(`make build` + `make test-unit`, code signing disabled), so enforcement happens with
+zero local build/commit friction.
 
 - 4-space indent; opening braces on the same line; trailing commas in multiline
   literals (SwiftFormat owns comma style — SwiftLint's `trailing_comma` is disabled

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 PROJECT := ContactManager.xcodeproj
 SCHEME := ContactManager
 DESTINATION := platform=macOS
+# Code signing is off for build/test: these are compile + test gates (CI has no
+# Apple account, and a signed build for distribution is done from Xcode). Keeps
+# the local and CI invocations identical.
+XCODEBUILD := xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DESTINATION)' CODE_SIGNING_ALLOWED=NO
 
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap build test lint lint-fix format format-check check
+.PHONY: help bootstrap build test test-unit lint lint-fix format format-check check
 
 help: ## List available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -14,10 +18,13 @@ bootstrap: ## Install developer tooling (SwiftLint, SwiftFormat) via Homebrew
 	./scripts/bootstrap.sh
 
 build: ## Build the app
-	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DESTINATION)' build
+	$(XCODEBUILD) build
 
-test: ## Run the test suite
-	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -destination '$(DESTINATION)' test
+test: ## Run the full test suite (unit + UI)
+	$(XCODEBUILD) test
+
+test-unit: ## Run the unit tests only (deterministic; used by CI and `check`)
+	$(XCODEBUILD) test -only-testing:ContactManagerTests
 
 lint: ## Lint sources with SwiftLint (strict — matches CI; warnings fail)
 	swiftlint lint --quiet --strict
@@ -31,4 +38,4 @@ format: ## Format sources in place with SwiftFormat
 format-check: ## Verify formatting without modifying files
 	swiftformat --lint .
 
-check: format-check lint test ## Run format check, lint, and tests (CI gate)
+check: format-check lint test-unit ## Run format check, lint, and unit tests (CI gate)

--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ A `Makefile` wraps the common tasks (install tooling once with `make bootstrap`,
 | Task | Command |
 | --- | --- |
 | Build | `make build` |
-| Test | `make test` |
+| Test | `make test` (unit + UI) · `make test-unit` (unit only) |
 | Lint | `make lint` (autofix: `make lint-fix`) |
 | Format | `make format` (check only: `make format-check`) |
-| Pre-PR gate | `make check` (format-check + lint + test) |
+| Pre-PR gate | `make check` (format-check + lint + unit tests) |
 
-Tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`). Linting and formatting are **SwiftLint** + **SwiftFormat**; CI (`.github/workflows/ci.yml`) runs `swiftformat --lint` and `swiftlint --strict` on every PR. Contributor and agent conventions live in `CLAUDE.md`.
+Tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`); `make build`/`make test` disable code signing (compile + test gates — a signed build for distribution is done from Xcode), so they run identically locally and in CI. Linting and formatting are **SwiftLint** + **SwiftFormat**. CI (`.github/workflows/ci.yml`) runs two jobs on every PR: **Lint & Format** (`swiftformat --lint` + `swiftlint --strict`) and **Build & Test** (`make build` + `make test-unit` on a macOS 26 runner). The XCUITest smoke suite (`make test`) is run from Xcode, not CI. Contributor and agent conventions live in `CLAUDE.md`.
 
 ### Building & Running
 


### PR DESCRIPTION
## Summary
CI previously ran only `swiftformat --lint` + `swiftlint --strict` — the **build** and the **146 unit tests** were never validated on GitHub. This adds a **Build & Test** job and keeps local↔CI parity.

- **`.github/workflows/ci.yml`**: new `build-test` job (parallel to lint) — selects the latest installed Xcode, `make build`, `make test-unit`.
- **Makefile**: `build`/`test` now pass `CODE_SIGNING_ALLOWED=NO` (compile + test gates; CI has no Apple account, and a signed/distributable build is done from Xcode), so the same targets run locally and in CI. Added **`test-unit`** (`-only-testing:ContactManagerTests`) and pointed **`check`** at it — fast and deterministic.
- The **XCUITest** smoke suite stays out of CI (run via `make test` / Xcode) because it flakes on app activation when the foreground is busy.
- `CLAUDE.md` documents the two CI jobs + new targets.

## Test plan
- [x] Local: `make build` and `make test-unit` pass with signing off — 146 unit tests, ~3s, UI target skipped
- [ ] **Watching the GitHub Actions run** on this PR to confirm the runner has the right Xcode/SDK and the build+test job goes green (will iterate if the runner image needs a tweak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)