### PR TITLE
Auto-bump version/build, tag, and release on each successful merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,20 +21,33 @@ jobs:
     name: Bump, tag, and release
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    env:
+      XCCONFIG: ContactManager/Config/SharedSettings.xcconfig
     steps:
+      # Check out the exact commit CI tested (not a moving `main`), so the
+      # release is tied to that commit; if `main` has since advanced, the push
+      # below fails safely and that newer merge runs its own release.
       - uses: actions/checkout@v4
         with:
-          ref: main
-          fetch-depth: 0 # full history for the build number + tag lookups
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0 # full history for the build number
+
+      - name: Skip if this commit is already a release bump
+        id: guard
+        run: |
+          set -euo pipefail
+          if git log -1 --pretty=%s | grep -q '^Release v'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Compute next version and build
+        if: ${{ steps.guard.outputs.skip == 'false' }}
         id: ver
         run: |
           set -euo pipefail
-          pbx=ContactManager.xcodeproj/project.pbxproj
-          # Highest MARKETING_VERSION currently in the project (major.minor are
-          # yours to bump by hand; the patch auto-increments each merge).
-          current=$(grep -oE 'MARKETING_VERSION = [0-9.]+' "$pbx" | sed 's/.*= //' | sort -V | tail -1)
+          current=$(grep -E '^MARKETING_VERSION' "$XCCONFIG" | sed -E 's/.*= *//')
           IFS=. read -r major minor patch <<< "$current"
           patch=${patch:-0}
           version="${major}.${minor}.$((patch + 1))"
@@ -46,24 +59,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Next release: v$version (build $build)"
 
-      - name: Skip if HEAD is already a release commit
-        id: guard
-        run: |
-          set -euo pipefail
-          if git log -1 --pretty=%s | grep -q '^Release v'; then
-            echo "HEAD is already a release bump — nothing to do."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Stamp version + build into the project
+      - name: Stamp version + build into the xcconfig
         if: ${{ steps.guard.outputs.skip == 'false' }}
         run: |
           set -euo pipefail
-          pbx=ContactManager.xcodeproj/project.pbxproj
-          sed -i -E "s/MARKETING_VERSION = [^;]+;/MARKETING_VERSION = ${{ steps.ver.outputs.version }};/g" "$pbx"
-          sed -i -E "s/CURRENT_PROJECT_VERSION = [^;]+;/CURRENT_PROJECT_VERSION = ${{ steps.ver.outputs.build }};/g" "$pbx"
+          sed -i -E "s|^MARKETING_VERSION = .*|MARKETING_VERSION = ${{ steps.ver.outputs.version }}|" "$XCCONFIG"
+          sed -i -E "s|^CURRENT_PROJECT_VERSION = .*|CURRENT_PROJECT_VERSION = ${{ steps.ver.outputs.build }}|" "$XCCONFIG"
 
       - name: Commit, tag, and create the release
         if: ${{ steps.guard.outputs.skip == 'false' }}
@@ -75,7 +76,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # Pushing with the default GITHUB_TOKEN does not re-trigger CI, so this
-          # version-bump commit can't kick off another release run.
+          # version-bump commit can't kick off another release run. If main has
+          # advanced past the tested commit, this push fails (fail-safe).
           git commit -am "Release $tag (build ${{ steps.ver.outputs.build }}) [skip ci]"
           git tag -a "$tag" -m "$tag (build ${{ steps.ver.outputs.build }})"
           git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+# Runs after CI finishes on main. Gated on success below, so only a merge that
+# passes Lint & Format + Build & Test produces a release.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+# Never let two releases run at once (they'd race on the version bump).
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Bump, tag, and release
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0 # full history for the build number + tag lookups
+
+      - name: Compute next version and build
+        id: ver
+        run: |
+          set -euo pipefail
+          pbx=ContactManager.xcodeproj/project.pbxproj
+          # Highest MARKETING_VERSION currently in the project (major.minor are
+          # yours to bump by hand; the patch auto-increments each merge).
+          current=$(grep -oE 'MARKETING_VERSION = [0-9.]+' "$pbx" | sed 's/.*= //' | sort -V | tail -1)
+          IFS=. read -r major minor patch <<< "$current"
+          patch=${patch:-0}
+          version="${major}.${minor}.$((patch + 1))"
+          build=$(git rev-list --count HEAD)
+          {
+            echo "version=$version"
+            echo "build=$build"
+            echo "tag=v$version"
+          } >> "$GITHUB_OUTPUT"
+          echo "Next release: v$version (build $build)"
+
+      - name: Skip if HEAD is already a release commit
+        id: guard
+        run: |
+          set -euo pipefail
+          if git log -1 --pretty=%s | grep -q '^Release v'; then
+            echo "HEAD is already a release bump — nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Stamp version + build into the project
+        if: ${{ steps.guard.outputs.skip == 'false' }}
+        run: |
+          set -euo pipefail
+          pbx=ContactManager.xcodeproj/project.pbxproj
+          sed -i -E "s/MARKETING_VERSION = [^;]+;/MARKETING_VERSION = ${{ steps.ver.outputs.version }};/g" "$pbx"
+          sed -i -E "s/CURRENT_PROJECT_VERSION = [^;]+;/CURRENT_PROJECT_VERSION = ${{ steps.ver.outputs.build }};/g" "$pbx"
+
+      - name: Commit, tag, and create the release
+        if: ${{ steps.guard.outputs.skip == 'false' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.ver.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Pushing with the default GITHUB_TOKEN does not re-trigger CI, so this
+          # version-bump commit can't kick off another release run.
+          git commit -am "Release $tag (build ${{ steps.ver.outputs.build }}) [skip ci]"
+          git tag -a "$tag" -m "$tag (build ${{ steps.ver.outputs.build }})"
+          git push origin HEAD:main
+          git push origin "$tag"
+          gh release create "$tag" \
+            --title "$tag (build ${{ steps.ver.outputs.build }})" \
+            --generate-notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,14 @@ whole-tree SwiftLint run script from reading sources. Instead, CI
 (`make build` + `make test-unit`, code signing disabled), so enforcement happens with
 zero local build/commit friction.
 
+A separate **Release** workflow (`.github/workflows/release.yml`) runs after CI succeeds
+on `main` (`workflow_run`): it bumps the patch of `MARKETING_VERSION` and sets
+`CURRENT_PROJECT_VERSION` to the commit count, commits that back (via `GITHUB_TOKEN`, which
+doesn't re-trigger CI — no loop), tags `v{version}`, and creates a GitHub release with
+auto-generated notes. So every successful merge ships a tagged, notes-only release. Bump
+`MARKETING_VERSION`'s major/minor by hand when a release warrants it; the patch is
+automatic. Releases carry no binary (a runnable app needs signing/notarization).
+
 - 4-space indent; opening braces on the same line; trailing commas in multiline
   literals (SwiftFormat owns comma style — SwiftLint's `trailing_comma` is disabled
   so they don't fight).

--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -719,7 +719,6 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.0;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(ORGANIZATION_IDENTIFIER).${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -758,7 +757,6 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.0;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(ORGANIZATION_IDENTIFIER).${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ContactManager/Config/SharedSettings.xcconfig
+++ b/ContactManager/Config/SharedSettings.xcconfig
@@ -15,3 +15,8 @@ CODE_SIGN_STYLE = Automatic
 ORGANIZATION_IDENTIFIER = com.scottdensmore
 
 #include? "../DeveloperSettings.xcconfig"
+
+// App version + build. The patch and build auto-increment on each successful
+// merge (see .github/workflows/release.yml); bump major/minor by hand.
+MARKETING_VERSION = 2.0.0
+CURRENT_PROJECT_VERSION = 134

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ A `Makefile` wraps the common tasks (install tooling once with `make bootstrap`,
 | Format | `make format` (check only: `make format-check`) |
 | Pre-PR gate | `make check` (format-check + lint + unit tests) |
 
-Tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`); `make build`/`make test` disable code signing (compile + test gates — a signed build for distribution is done from Xcode), so they run identically locally and in CI. Linting and formatting are **SwiftLint** + **SwiftFormat**. CI (`.github/workflows/ci.yml`) runs two jobs on every PR: **Lint & Format** (`swiftformat --lint` + `swiftlint --strict`) and **Build & Test** (`make build` + `make test-unit` on a macOS 26 runner). The XCUITest smoke suite (`make test`) is run from Xcode, not CI. Contributor and agent conventions live in `CLAUDE.md`.
+Tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`); `make build`/`make test` disable code signing (compile + test gates — a signed build for distribution is done from Xcode), so they run identically locally and in CI. Linting and formatting are **SwiftLint** + **SwiftFormat**. CI (`.github/workflows/ci.yml`) runs two jobs on every PR: **Lint & Format** (`swiftformat --lint` + `swiftlint --strict`) and **Build & Test** (`make build` + `make test-unit` on a macOS 26 runner). The XCUITest smoke suite (`make test`) is run from Xcode, not CI. After CI passes on `main`, a **Release** workflow auto-bumps the version patch + build number, tags `v{version}`, and publishes a GitHub release with generated notes (bump the major/minor by hand when it's warranted). Contributor and agent conventions live in `CLAUDE.md`.
 
 ### Building & Running
 


### PR DESCRIPTION
## Summary
A **Release** workflow (`.github/workflows/release.yml`) that runs after CI on `main` and ships a tagged release for every successful merge.

- **Trigger:** `workflow_run` on the **CI** workflow completing, gated on `conclusion == 'success'` — so only a merge that passes **Lint & Format** + **Build & Test** releases.
- **Version/build:** bumps the **patch** of `MARKETING_VERSION` and sets `CURRENT_PROJECT_VERSION` to the commit count, stamped into the project. (Bump major/minor by hand when warranted; patch + build are automatic.)
- **No loop:** the bump is committed back with the default `GITHUB_TOKEN`, which by design doesn't re-trigger workflows.
- **Tag + release:** `v{version}` (e.g. `v2.0.1`) + a GitHub release with `--generate-notes`.
- **Notes-only:** no binary attached — a runnable macOS app needs signing + notarization (your Apple account), which CI can't do. That'd be a separate signed-build + notarize job.

First fire: merging this PR runs CI on `main`; on success the workflow (now present on `main`) produces **`v2.0.1` (build N)**. Old 2020 tags (`V1.2`, `v1.0.0`) are left untouched.

## Test plan
- [x] Validated the version/build compute against the real `project.pbxproj` locally (`2.0 → 2.0.1`, build = commit count)
- [x] CI (lint + build-test) green on this PR
- [ ] After merge: watch the Release workflow fire and confirm the `v2.0.1` tag + release appear with notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)