### PR TITLE
Fix Release workflow: install xcodeproj gem with sudo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         id: ver
         run: |
           set -euo pipefail
-          gem install xcodeproj --no-document
+          sudo gem install xcodeproj --no-document
           build=$(git rev-list --count HEAD)
           # Patch-bump MARKETING_VERSION and set CURRENT_PROJECT_VERSION on the
           # app target (major/minor stay manual). xcodeproj edits the target


### PR DESCRIPTION
## Summary
The Release run for the previous merge failed at `gem install xcodeproj` — `Gem::FilePermissionError: You don't have write permissions for /var/lib/gems/3.2.0` on the ubuntu runner. Use **`sudo gem install`** (passwordless on GitHub runners); the system-installed gem is on Ruby's default load path so the non-sudo `require "xcodeproj"` in the bump step still finds it.

The failure happened *before* any commit/tag/release step, so `main` was untouched — no partial release. After this merges, the Release workflow should produce `v2.0.2`.

## Test plan
- [x] CI green on this PR
- [ ] After merge: Release workflow succeeds and publishes `v2.0.2` (build N), stamping the `.pbxproj` app target