### PR TITLE
Harden CI/release workflows: timeouts, least-priv token, brew cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,30 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: CI only reads the repo. (The Release workflow scopes its own
+# contents: write where it actually needs to push the bump/tag.)
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Format
     runs-on: macos-latest
+    timeout-minutes: 10
+    env:
+      # Skip Homebrew's slow metadata refresh + post-install cleanup; the cache
+      # below holds the bottles, so tool installs stay fast and deterministic.
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Cache Homebrew downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/Homebrew
+          key: brew-${{ runner.os }}-${{ hashFiles('Brewfile') }}
+          restore-keys: brew-${{ runner.os }}-
 
       - name: Install tooling
         run: brew bundle
@@ -31,6 +49,7 @@ jobs:
     # can only *run* on a 26 runner (macos-latest is still 15 — it can build
     # against the 26 SDK but not launch a 26-target app).
     runs-on: macos-26
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -38,6 +57,7 @@ jobs:
         run: |
           # Glob the 26.x Xcodes and take the lexically-last (highest patch) —
           # avoids GNU-only `sort -V`. Falls back to the runner default if none.
+          # shellcheck disable=SC2012  # paths are fixed/alphanumeric; ls is fine here
           xcode=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | tail -1)
           if [ -n "$xcode" ]; then sudo xcode-select -s "$xcode/Contents/Developer"; fi
           xcodebuild -version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     name: Bump, tag, and release
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # Check out the exact commit CI tested (not a moving `main`), so the
       # release is tied to that commit; if `main` has since advanced, the push


### PR DESCRIPTION
## Summary
Polish on the existing workflows (no behavior repair — CI was already solid):

- **Timeouts** — `timeout-minutes` on every job (lint `10`, build-test `30`, release `10`). The default GitHub timeout is **6 hours**; a hung `xcodebuild` would otherwise burn macOS runner minutes (billed 10×) until then.
- **Least privilege** — top-level `permissions: contents: read` on CI. The Release workflow keeps its own scoped `contents: write` where it actually pushes the bump/tag.
- **Faster lint job** — cache `~/Library/Caches/Homebrew` (keyed on `Brewfile`) and set `HOMEBREW_NO_AUTO_UPDATE` / `HOMEBREW_NO_INSTALL_CLEANUP` to skip the slow metadata refresh + cleanup.
- **Lint hygiene** — documented `shellcheck disable=SC2012` on the intentional `ls` Xcode glob so `actionlint` runs clean.

### Deliberately omitted
No SwiftPM/DerivedData build cache: the project has **zero third-party runtime deps** (nothing for SwiftPM to cache), and DerivedData caching across fresh checkouts is flaky for Swift — risk for little gain on a correctness gate.

## Test plan
- [x] `actionlint` clean on both workflows
- [x] YAML parses
- [ ] CI green on this PR (timeouts + permissions + cache exercised on the actual run)