### PR TITLE
Codify project workflow: TDD, review-before-commit, merge-on-green

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,12 @@ pattern), then build to confirm it compiles.
 
 ## Workflow
 
-- Ship focused, single-purpose PRs. Keep the README and this file in sync.
-- Use the GitHub CLI (`gh`) for all GitHub operations, and address Copilot review comments
-  before merging.
+- **Write code TDD-style.** Add the failing Swift Testing test first, then the code to
+  make it pass, then refactor. Keep logic in `Models/`/`Support/` so it's unit-testable
+  without the UI (see "Code style").
+- **Review before every commit.** Run a code review over the staged diff and fix what it
+  finds *before* committing — don't commit unreviewed code.
+- Ship focused, single-purpose PRs via the GitHub CLI (`gh`). Open the PR, let CI run, and
+  **merge once all required checks pass.** Copilot review is no longer a gate — you don't
+  need to request it or wait on it before merging.
+- Keep the README and this file in sync.


### PR DESCRIPTION
## Summary
Encode the project's working agreement in `CLAUDE.md` so contributors and agents follow it consistently:

- **TDD** — failing Swift Testing test first, then the code to pass it, then refactor (logic stays in `Models/`/`Support/` so it's unit-testable without the UI).
- **Review before every commit** — run a code review over the staged diff and fix findings *before* committing.
- **PRs merge on green** — open focused PRs via `gh`, let CI run, merge once all required checks pass. **Copilot review is no longer a gate** — no need to request it or wait on it.

Docs-only change.

## Test plan
- [x] Renders correctly; covers all four workflow rules
- [x] No code touched