### PR TITLE
Tighten shared .claude allowlist: drop log show, widen entire deny

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,11 +87,10 @@
       "Bash(swift test *)",
       "Bash(swift build *)",
       "Bash(swiftlint lint *)",
-      "Bash(log show *)",
       "Bash(entire search *)"
     ],
     "deny": [
-      "Read(./.entire/metadata/**)"
+      "Read(./.entire/**)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #69, applying the code-review findings on the now-tracked `.claude/settings.json`:

- **Remove `Bash(log show *)`** from the shared allowlist — `log show` can dump arbitrary system logs, broader than the build/lint scope this file should grant. Contributors who need it grant it locally in `settings.local.json`.
- **Broaden the deny glob** `Read(./.entire/metadata/**)` → `Read(./.entire/**)` so the whole local Entire checkpoint dir is off-limits to the `Read` tool.

## Test plan
- [x] `settings.json` is valid JSON
- [x] Diff is exactly the two tightenings (one allow removed, deny widened)