### PR TITLE
Track .entire shared config; rely on its nested .gitignore

### DIFF
--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,0 +1,5 @@
+tmp/
+settings.local.json
+metadata/
+logs/
+redactors/local/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,4 @@
+{
+  "enabled": true,
+  "telemetry": false
+}

--- a/.gitignore
+++ b/.gitignore
@@ -200,8 +200,8 @@ DerivedData/
 DeveloperSettings.xcconfig
 
 # Agent / tooling state
-# Shared, Entire-managed agent config is checked in (.claude/, .codex/, and
-# .github/hooks/ — all safe no-ops without the Entire CLI). Only per-user grants
-# and local Entire checkpoint state stay untracked.
+# Shared, Entire-managed agent config is checked in (.claude/, .codex/,
+# .github/hooks/, .entire/). The .entire/ dir carries its own nested .gitignore
+# for local checkpoint state, so only it gets excluded. Per-user Claude grants
+# stay untracked here.
 .claude/settings.local.json
-.entire/


### PR DESCRIPTION
## Summary
Stop ignoring the whole `.entire/` directory. It ships its own nested `.gitignore` that already excludes the local checkpoint state, so `git add` tracks only the shareable config:

- **`.entire/.gitignore`** — the nested exclusion rules (`tmp/`, `metadata/`, `logs/`, `settings.local.json`, `redactors/local/`)
- **`.entire/settings.json`** — `{"enabled": true, "telemetry": false}` (no secrets)

This completes tracking the Entire-managed shared agent config alongside `.claude/`, `.codex/`, and `.github/hooks/`. Only per-user Claude grants (`.claude/settings.local.json`) remain ignored at the top level.

## Test plan
- [x] `git add .entire/` stages only `.entire/.gitignore` + `.entire/settings.json` (nested ignore honored)
- [x] No local checkpoint state (metadata/logs/tmp) or secrets staged
- [x] `.entire/settings.json` is valid JSON