### PR TITLE
Test the App Intents entity query + Find Contact intent

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		AC7E1126C65C59B15141CB79 /* ContentView+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F852CE2356ADE83460064B /* ContentView+Import.swift */; };
 		AF36C8E991E2B6C96634FBA0 /* ChunkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30CD9D085E7424A79159879 /* ChunkingTests.swift */; };
 		B1393B1344A7D64B52C4B3D4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9795992CBF553603FD37928 /* SettingsView.swift */; };
+		BA9738D0812FB7A090DD5D4E /* ContactEntityQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399A72E1BB6BEC0B54D356E7 /* ContactEntityQueryTests.swift */; };
 		BBD79E7FD90E021417B527A9 /* FindContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F6260FE20C27094AFB327A /* FindContactIntent.swift */; };
 		BC3D0CE8272648D0ACEF0C46 /* BirthdayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B040B21B7E2002E00885A9BA /* BirthdayTests.swift */; };
 		C2A11D686722C70868435ACE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303A7F66E428BF3662142C0 /* SidebarView.swift */; };
@@ -108,6 +109,7 @@
 		2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardDocument.swift; sourceTree = "<group>"; };
 		3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinderTests.swift; sourceTree = "<group>"; };
+		399A72E1BB6BEC0B54D356E7 /* ContactEntityQueryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityQueryTests.swift; sourceTree = "<group>"; };
 		436B4115937E4350EB9A7EF7 /* Chunking.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Chunking.swift; sourceTree = "<group>"; };
 		4E2F2242E59F2C42DDD0736B /* CSV.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSV.swift; sourceTree = "<group>"; };
 		54C373BD237429970D6A7C86 /* DuplicatesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicatesView.swift; sourceTree = "<group>"; };
@@ -332,6 +334,7 @@
 				2623DCD281C3DDAA29BB6B99 /* DefaultGroupPreferenceTests.swift */,
 				279FCAC10E829D7DAC9D8385 /* OpenContactIntentTests.swift */,
 				DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */,
+				399A72E1BB6BEC0B54D356E7 /* ContactEntityQueryTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -529,6 +532,7 @@
 				8279EF938E1BAA17ACAB8D94 /* DefaultGroupPreferenceTests.swift in Sources */,
 				01001E025DB1348D36342E1C /* OpenContactIntentTests.swift in Sources */,
 				442122E49889F5A9CA174B12 /* ContactActivityTests.swift in Sources */,
+				BA9738D0812FB7A090DD5D4E /* ContactEntityQueryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManagerTests/ContactEntityQueryTests.swift
+++ b/ContactManagerTests/ContactEntityQueryTests.swift
@@ -1,0 +1,122 @@
+//
+//  ContactEntityQueryTests.swift
+//  ContactManagerTests
+//
+//  Integration coverage for the App Intents entity query — the lookup paths
+//  (by free-text, by id, and "all") that live behind the process-wide model
+//  container — plus the Find Contact intent that drives the free-text path.
+//  ContactEntityTests covers the pure Contact → ContactEntity mapping and
+//  explicitly left these container-backed paths "for a future pass"; this is it.
+//
+
+@testable import ContactManager
+import Foundation
+import SwiftData
+import Testing
+
+@MainActor
+@Suite(.serialized)
+final class ContactEntityQueryTests {
+    let container: ModelContainer
+
+    init() throws {
+        container = try ModelContainer(
+            for: Contact.self, ContactField.self, ContactGroup.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        // The query reads contacts from this process-wide handle.
+        EntityModelContainer.shared = container
+    }
+
+    /// Swift Testing builds a fresh instance per test; clear the global handle
+    /// afterward so no other suite/test ever sees a freed container. Setting the
+    /// lock-guarded static is safe from deinit's nonisolated context.
+    deinit { EntityModelContainer.shared = nil }
+
+    @discardableResult
+    private func seed(_ contacts: Contact...) throws -> [Contact] {
+        for contact in contacts {
+            container.mainContext.insert(contact)
+        }
+        try container.mainContext.save()
+        return contacts
+    }
+
+    private func contact(_ first: String, _ last: String, company: String = "") -> Contact {
+        Contact(firstName: first, lastName: last, company: company)
+    }
+
+    // MARK: - entities(matching:)
+
+    @Test func matchingFiltersByName() async throws {
+        try seed(
+            contact("Ada", "Lovelace", company: "Analytical Engine"),
+            contact("Grace", "Hopper", company: "US Navy")
+        )
+        let results = try await ContactEntityQuery().entities(matching: "lovelace")
+        #expect(results.map(\.displayName) == ["Ada Lovelace"])
+    }
+
+    @Test func matchingFiltersByCompany() async throws {
+        try seed(
+            contact("Ada", "Lovelace", company: "Analytical Engine"),
+            contact("Grace", "Hopper", company: "US Navy")
+        )
+        let results = try await ContactEntityQuery().entities(matching: "navy")
+        #expect(results.map(\.displayName) == ["Grace Hopper"])
+    }
+
+    @Test func emptyQueryReturnsNothing() async throws {
+        try seed(contact("Ada", "Lovelace"))
+        let empty = try await ContactEntityQuery().entities(matching: "")
+        let blank = try await ContactEntityQuery().entities(matching: "   \n ")
+        #expect(empty.isEmpty)
+        #expect(blank.isEmpty)
+    }
+
+    @Test func matchingReturnsEmptyWhenNoContainer() async throws {
+        EntityModelContainer.shared = nil
+        let results = try await ContactEntityQuery().entities(matching: "anything")
+        #expect(results.isEmpty)
+    }
+
+    // MARK: - entities(for:)
+
+    @Test func entitiesForIdLooksUpByEncodedIdentifier() async throws {
+        let seeded = try seed(contact("Ada", "Lovelace"), contact("Grace", "Hopper"))
+        let id = try #require(seeded[0].persistentModelID.storedString)
+        let results = try await ContactEntityQuery().entities(for: [id])
+        #expect(results.map(\.displayName) == ["Ada Lovelace"])
+    }
+
+    @Test func entitiesForUnknownIdReturnsNothing() async throws {
+        try seed(contact("Ada", "Lovelace"))
+        let results = try await ContactEntityQuery().entities(for: ["not-a-real-id"])
+        #expect(results.isEmpty)
+    }
+
+    // MARK: - allEntities / suggestedEntities
+
+    @Test func allEntitiesReturnsEverythingSortedByName() async throws {
+        try seed(contact("Ada", "Lovelace"), contact("Grace", "Hopper"))
+        // snapshot() sorts by lastName then firstName: Hopper < Lovelace.
+        let all = try await ContactEntityQuery().allEntities()
+        #expect(all.map(\.displayName) == ["Grace Hopper", "Ada Lovelace"])
+    }
+
+    @Test func suggestedEntitiesMatchesAll() async throws {
+        try seed(contact("Ada", "Lovelace"), contact("Grace", "Hopper"))
+        let suggested = try await ContactEntityQuery().suggestedEntities()
+        #expect(suggested.count == 2)
+    }
+
+    // MARK: - FindContactIntent
+
+    @Test func findContactIntentReturnsMatches() async throws {
+        try seed(contact("Ada", "Lovelace"), contact("Grace", "Hopper"))
+        let intent = FindContactIntent()
+        intent.query = "hopper"
+        let result = try await intent.perform()
+        #expect(result.value?.map(\.displayName) == ["Grace Hopper"])
+    }
+}


### PR DESCRIPTION
## Summary
`ContactEntityTests` covers the pure `Contact → ContactEntity` mapping but explicitly left the container-backed query paths *"for a future pass."* This adds that coverage.

New `ContactEntityQueryTests` suite drives the real `ContactEntityQuery` against an in-memory container set on `EntityModelContainer.shared`:
- `entities(matching:)` — filters by name and company (reusing `ContactQuery.filtered`), and returns nothing for empty/whitespace queries or a missing container.
- `entities(for:)` — resolves by encoded persistent id; ignores unknown ids.
- `allEntities()` / `suggestedEntities()` — return everything, name-sorted.
- `FindContactIntent.perform()` — returns the matching entities (previously untested).

**+9 tests (146 → 155.)**

## Test plan
- [x] `make test-unit` green (155 tests, 20 suites)
- [x] `make lint` / `make format-check` clean
- [x] New file registered on `ContactManagerTests` via the `xcodeproj` gem