### PR TITLE
Extract + test the avatar palette index (negative-seed crash guard)

### DIFF
--- a/ContactManager/Models/Contact.swift
+++ b/ContactManager/Models/Contact.swift
@@ -119,6 +119,21 @@ extension Contact {
         Int(truncatingIfNeeded: createdAt.timeIntervalSinceReferenceDate.bitPattern)
     }
 
+    /// Index into an avatar palette of `count` colors for a stable `seed`.
+    /// Normalizes into range without `abs` (which traps on `Int.min`), so any
+    /// seed — including a negative `colorSeed` — yields a valid index. Returns
+    /// 0 for a non-positive `count`. Shared by `AvatarView` and the printable
+    /// card so both pick the same color.
+    static func avatarPaletteIndex(seed: Int, count: Int) -> Int {
+        guard count > 0 else { return 0 }
+        return ((seed % count) + count) % count
+    }
+
+    /// Avatar palette index for this contact's `colorSeed`.
+    func avatarPaletteIndex(count: Int) -> Int {
+        Self.avatarPaletteIndex(seed: colorSeed, count: count)
+    }
+
     /// Primary/secondary keys for a given sort order. The primary key also
     /// drives alphabetical section grouping.
     func sortKeys(for order: ContactSortOrder) -> (primary: String, secondary: String) {

--- a/ContactManager/Views/AvatarView.swift
+++ b/ContactManager/Views/AvatarView.swift
@@ -55,9 +55,7 @@ struct AvatarView: View {
     /// A stable per-contact color so avatars stay visually distinct.
     private var gradient: LinearGradient {
         let palette: [Color] = [.blue, .indigo, .teal, .pink, .orange, .purple, .green, .red]
-        // Wrap into range without `abs`, which can trap on Int.min.
-        let index = ((contact.colorSeed % palette.count) + palette.count) % palette.count
-        let base = palette[index]
+        let base = palette[contact.avatarPaletteIndex(count: palette.count)]
         return LinearGradient(
             colors: [base, base.opacity(0.65)],
             startPoint: .topLeading,

--- a/ContactManager/Views/PrintableContactView.swift
+++ b/ContactManager/Views/PrintableContactView.swift
@@ -71,8 +71,7 @@ struct PrintableContactView: View {
     /// deliberately; the print layout needs a synchronous variant).
     private var avatarGradient: LinearGradient {
         let palette: [Color] = [.blue, .indigo, .teal, .pink, .orange, .purple, .green, .red]
-        let index = ((contact.colorSeed % palette.count) + palette.count) % palette.count
-        let base = palette[index]
+        let base = palette[contact.avatarPaletteIndex(count: palette.count)]
         return LinearGradient(
             colors: [base, base.opacity(0.65)],
             startPoint: .topLeading,

--- a/ContactManagerTests/ContactModelTests.swift
+++ b/ContactManagerTests/ContactModelTests.swift
@@ -154,6 +154,26 @@ struct ContactModelTests {
         #expect(Contact(street: "  ", city: "Reno").addressLines == ["Reno"])
     }
 
+    @Test func avatarPaletteIndexStaysInRangeForAnySeed() {
+        let count = 8
+        // Negative seeds (a real colorSeed can be negative) and Int.min must
+        // not produce a negative index or trap.
+        for seed in [0, 1, 7, 8, 9, -1, -8, -9, Int.min, Int.max] {
+            #expect((0 ..< count).contains(Contact.avatarPaletteIndex(seed: seed, count: count)))
+        }
+    }
+
+    @Test func avatarPaletteIndexWrapsDeterministically() {
+        #expect(Contact.avatarPaletteIndex(seed: 10, count: 8) == 2)
+        #expect(Contact.avatarPaletteIndex(seed: -1, count: 8) == 7)
+        #expect(Contact.avatarPaletteIndex(seed: Int.min, count: 8) == 0)
+    }
+
+    @Test func avatarPaletteIndexHandlesNonPositiveCount() {
+        #expect(Contact.avatarPaletteIndex(seed: 5, count: 0) == 0)
+        #expect(Contact.avatarPaletteIndex(seed: 5, count: -3) == 0)
+    }
+
     // MARK: - Query helpers
 
     @Test func sortingOrdersByLastNameThenFirstName() {


### PR DESCRIPTION
## Summary
`AvatarView` and `PrintableContactView` each computed the avatar color index with the same inline expression — `((colorSeed % count) + count) % count` — whose purpose is to normalize a possibly-negative `colorSeed` into range **without `abs`** (which traps on `Int.min`). That subtle, crash-prone logic was duplicated across two views and had no test.

- Extracted to a pure, static **`Contact.avatarPaletteIndex(seed:count:)`** (plus an instance convenience over `colorSeed`); both views now index their palette through it.
- Because `colorSeed` derives from `createdAt` and isn't settable, the static form takes the seed explicitly so edge seeds are directly testable.

## Test plan
- [x] `make test-unit` green — **+3 tests (160 → 163)**: in-range for negative / `Int.min` / `Int.max` seeds, deterministic wrapping, non-positive count → 0
- [x] `make lint` / `make format-check` clean
- [x] Avatar rendering behavior unchanged (same palette, same index)