### PR TITLE
feat(contacts): add reviewed imports and durable edits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,129 @@
+# ContactManager — Contributor & Agent Guide
+
+Native **macOS Tahoe (macOS 26)** contact manager built with **SwiftUI + SwiftData**.
+Zero third-party *runtime* dependencies. Code here is reviewed by humans, not just
+agents — keep it readable and idiomatic.
+
+## Commands
+
+| Task | Command |
+| --- | --- |
+| Build | `make build` |
+| Test | `make test` (unit + UI) / `make test-unit` (unit only) |
+| Lint | `make lint` (autofix: `make lint-fix`) |
+| Format | `make format` (check only: `make format-check`) |
+| Pre-PR gate | `make check` (format-check + lint + unit tests) |
+| Install tooling | `make bootstrap` (runs `brew bundle`) |
+
+Tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`) — not XCTest.
+`make build`/`make test` pass `CODE_SIGNING_ALLOWED=NO` (compile + test gates; a signed
+build for distribution is done from Xcode), so they run identically locally and in CI.
+`check` runs the **unit** tests (`ContactManagerTests`) — fast and deterministic; the
+XCUITest smoke suite (`make test`) is run from Xcode, since it flakes on app activation
+when the foreground is busy and isn't part of CI.
+
+**Build config:** `ContactManager/Config/SharedSettings.xcconfig` holds only a default
+`ORGANIZATION_IDENTIFIER = com.example` + the `#include?`. The personal/signing settings —
+**team, org identifier, and `CODE_SIGN_IDENTITY` / `CODE_SIGN_STYLE`** — live in a gitignored
+`ContactManager/DeveloperSettings.xcconfig` (pulled in via `#include?`, overriding the
+default); create it with `./setup.sh` (tracked template: `DeveloperSettings.template.xcconfig`).
+`ORGANIZATION_IDENTIFIER` drives the bundle id (`$(ORGANIZATION_IDENTIFIER).<target>`), so
+each developer gets their own. Nothing personal is committed,
+so a fresh clone builds (signing off) and is never blocked by a team/container it doesn't
+own. **Version + build** (`MARKETING_VERSION` / `CURRENT_PROJECT_VERSION`) live on the app
+target in the `.pbxproj` — not in any xcconfig — and the Release workflow patch-bumps them.
+
+## Layout
+
+```
+ContactManager/App/      @main entry, ModelContainer, menu commands
+ContactManager/Models/   SwiftData @Models, ContactStore (data layer), pure helpers (ContactQuery)
+ContactManager/Support/  Non-UI utilities (VCard, ImageProcessing, VCardDocument)
+ContactManager/Views/    SwiftUI views
+ContactManagerTests/     Swift Testing suites
+```
+
+## Code style
+
+Run `make format` and `make lint` before committing; both must pass (or `make check`).
+Configs: `.swiftformat`, `.swiftlint.yml`. Linting is intentionally **not** an Xcode
+build phase: the project enables `ENABLE_USER_SCRIPT_SANDBOXING`, which blocks a
+whole-tree SwiftLint run script from reading sources. Instead, CI
+(`.github/workflows/ci.yml`) enforces it on every PR: a **Lint & Format** job
+(`swiftformat --lint` + `swiftlint --strict`) and a **Build & Test** job
+(`make build` + `make test-unit`, code signing disabled), so enforcement happens with
+zero local build/commit friction.
+
+A separate **Release** workflow (`.github/workflows/release.yml`) runs after CI succeeds
+on `main` (`workflow_run`): it bumps the patch of `MARKETING_VERSION` and sets
+`CURRENT_PROJECT_VERSION` to the commit count, commits that back (via `GITHUB_TOKEN`, which
+doesn't re-trigger CI — no loop), tags `v{version}`, and creates a GitHub release with
+auto-generated notes. So every successful merge ships a tagged, notes-only release. Bump
+`MARKETING_VERSION`'s major/minor by hand when a release warrants it; the patch is
+automatic. Releases carry no binary (a runnable app needs signing/notarization).
+
+- 4-space indent; opening braces on the same line; trailing commas in multiline
+  literals (SwiftFormat owns comma style — SwiftLint's `trailing_comma` is disabled
+  so they don't fight).
+- No force-unwraps (`!`) — SwiftLint enforces `force_unwrapping`. Use `guard`/`if let`,
+  or `#require` in tests.
+- Route create/edit/delete, group, and vCard operations through `ContactStore`
+  (each op saves and rolls back on failure), so views stay thin and the journeys are
+  tested in `ContactStoreTests` against an in-memory container. Every `ContactStore`
+  mutation also wraps its body in a named undo group via `mutate("…") { … }`, so
+  Edit ▸ Undo/Redo (⌘Z / ⇧⌘Z) shows the right action name and reverses what it can.
+  (SwiftData's automatic undo doesn't always recreate models after a `save`+`delete`;
+  the menu name is still set so future improvements are observable.)
+- Keep views thin: put pure, testable logic in `Models/` or `Support/` and unit-test it
+  there rather than in views.
+- User-initiated actions surface persistence errors (alert + `context.rollback()`);
+  don't swallow them with `try?`.
+
+## Xcode project (`.pbxproj`)
+
+Edit it **only** via the Ruby `xcodeproj` gem — never by hand. When you add a Swift file,
+register it on the correct target with a small ruby script (see prior commits for the
+pattern), then build to confirm it compiles.
+
+## SwiftData
+
+- Top-level models are listed in the `Schema` built in `ContactManagerApp.loadContainer`:
+  `Contact`, `ContactField`, `ContactGroup`.
+- **Migration:** every new *non-optional scalar* attribute MUST have an inline default
+  (e.g. `var city: String = ""`), or in-place migration fails (`NSCocoaError 134110`).
+  Optional attributes and relationships migrate cleanly. Verify by launching against an
+  existing store.
+- **CloudKit (opt-in, non-blocking):** `loadContainer` checks the running binary's
+  entitlements (`hasCloudKitEntitlement()` via `SecTask`) for an iCloud container. If one
+  is configured it opens the store with `cloudKitDatabase: .automatic` (sync); otherwise
+  `.none` (local) and it seeds sample data. A try/catch falls back to local on failure.
+  **Do not commit an iCloud entitlement / container** — it would break signing for anyone
+  who clones without that team/container; enabling iCloud is a documented local opt-in
+  (README ▸ "iCloud sync"). Seed only when local-only, so samples never sync into a real
+  iCloud account. To keep the schema sync-compatible, every non-optional attribute needs an
+  inline default (already covered by the migration rule), every to-many relationship needs
+  `= []`, and we avoid `@Attribute(.unique)` and `.deny` delete rules.
+- **Tests:** use an in-memory `ModelContainer`; the suite is `@MainActor @Suite(.serialized)`
+  and holds the container as a stored property. The app skips creating its own container
+  under tests (`XCTestConfigurationFilePath`) so the test owns the only one — keep that guard.
+
+## Platform / Liquid Glass
+
+- Toolbars and `NavigationSplitView` adopt Liquid Glass automatically on the macOS 26 SDK.
+  The `.glassEffect()` modifier / `GlassEffectContainer` are not in this SDK's SwiftUI
+  interface; use `.buttonStyle(.glass)` / `.buttonStyle(.glassProminent)` for explicit glass.
+- `SWIFT_VERSION` is 5.0 (language mode 5). Full Swift 6 strict-concurrency is a future migration.
+- Build settings are per-configuration: Debug uses `SWIFT_OPTIMIZATION_LEVEL = -Onone`
+  (required for SwiftUI `#Preview`), Release uses `-O` + `SWIFT_COMPILATION_MODE = wholemodule`.
+
+## Workflow
+
+- **Write code TDD-style.** Add the failing Swift Testing test first, then the code to
+  make it pass, then refactor. Keep logic in `Models/`/`Support/` so it's unit-testable
+  without the UI (see "Code style").
+- **Review before every commit.** Run a code review over the staged diff and fix what it
+  finds *before* committing — don't commit unreviewed code.
+- Ship focused, single-purpose PRs via the GitHub CLI (`gh`). Open the PR, let CI run, and
+  **merge once all required checks pass.** Copilot review is no longer a gate — you don't
+  need to request it or wait on it before merging.
+- Keep the README and this file in sync.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,4 +39,4 @@ Optional iCloud sync setup is documented in the [README](README.md#icloud-sync-o
 - **Squash merge** and delete the branch; a successful merge auto-tags and publishes a release.
 
 More detailed conventions (architecture, SwiftData rules, style) live in
-[`CLAUDE.md`](CLAUDE.md).
+[`AGENTS.md`](AGENTS.md).

--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		01001E025DB1348D36342E1C /* OpenContactIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279FCAC10E829D7DAC9D8385 /* OpenContactIntentTests.swift */; };
 		02D950C10327393FB2B5BB7E /* ImageProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76507F3A1E2222FB64D7F31 /* ImageProcessing.swift */; };
 		0ABBB9962C4AC14A077728FF /* ContactStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03763AB80D45F026EC585490 /* ContactStoreTests.swift */; };
+		0DC8E4BAF454185075119C3A /* ContactStorePendingEditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438C2B20E1C302676594ECCA /* ContactStorePendingEditTests.swift */; };
 		134F890B4875E8BF294A92B2 /* ContactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617D7B082A403094284FBD38 /* ContactStore.swift */; };
 		14C13B18A26BC44F834915C1 /* ContactModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75D02267D3BC6C014143329 /* ContactModelTests.swift */; };
 		14E0C9EBEF8212F3F9B2777D /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51E6728EF90B1D2BF8EA5AE /* Contact.swift */; };
@@ -21,13 +22,16 @@
 		2EB13805320DA225F70D08F3 /* VCardTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */; };
 		3076738411F8C3FA073D1BE0 /* ContactsBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */; };
 		322103E6FBEAD59C6A2405E6 /* Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDED82FFB4B5F039052FFB5 /* Birthday.swift */; };
+		3EDDAA184C377D9C16AAF08A /* ContactStore+PendingEdits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */; };
 		442122E49889F5A9CA174B12 /* ContactActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */; };
+		444B949F37F7FF7DD98A4C6B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */; };
 		4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */; };
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
 		488CA0C339AD3218073A02E8 /* PrintableContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37DB6CC43A76261CFF3987D /* PrintableContactView.swift */; };
 		4B9EAE3500BB10401AEB3746 /* ContactActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CF4C47C670B0A8C3B6B384 /* ContactActivity.swift */; };
 		4EC36757044377406665E53B /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */; };
 		4F1E1A097740ECE3D42E55B8 /* GroupDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964ACD67CC8CB35694497A10 /* GroupDropTests.swift */; };
+		509C184B6FC5C331FCC6FD11 /* ImportReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB522F18FE21A503D7C480AB /* ImportReview.swift */; };
 		52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */; };
 		552E226D873AE11781A7F97A /* ContactDetailView+Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */; };
 		61F22EEDEE6075BD602203D5 /* VCardDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */; };
@@ -48,16 +52,20 @@
 		8279EF938E1BAA17ACAB8D94 /* DefaultGroupPreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2623DCD281C3DDAA29BB6B99 /* DefaultGroupPreferenceTests.swift */; };
 		827CF451F0B38B89C4469595 /* DuplicateFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */; };
 		8397B67D483997505B17269E /* ContactDetailView+Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */; };
+		847D0CD5B12E83CD53951DA2 /* ContactFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E63AB996E12C5978B4A8F1 /* ContactFieldRow.swift */; };
 		8C6AC6410FA2258ADB2BF640 /* ContactManagerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001F8DF120EBA372663EC888 /* ContactManagerUITests.swift */; };
 		8DF0A36CE542853FF12BEF1A /* Chunking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436B4115937E4350EB9A7EF7 /* Chunking.swift */; };
 		91DA07BB24CEA1941C5AFA6E /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 76F68BAD5C3290EE7ABF787B /* Localizable.xcstrings */; };
 		9506DFC07D9490AEDFB096EC /* ImageProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */; };
 		97E98BCB6784672DCB8C1625 /* VCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7276D515CA167FBF4C47299 /* VCard.swift */; };
+		97F582C8C0B47ABD787E2C2E /* ContactStore+ImportReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90D71F3F01E29B7C4B739A7 /* ContactStore+ImportReview.swift */; };
 		A486AAFFBF01C05775A7BB38 /* ContactEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915AF700C971510D0B642590 /* ContactEntity.swift */; };
 		A94AB327927F2F1FBBD81119 /* ContactGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFE362455F20C848F729EEE /* ContactGroup.swift */; };
 		AA43BCF64B0DC3F571E4A813 /* DefaultGroupPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECE026D8586731B7C590901 /* DefaultGroupPreference.swift */; };
 		ABE65AD0BD5B666CD7272802 /* EntityModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2AA1D7BB15FC01B9CBA3B3 /* EntityModelContainer.swift */; };
+		ABF907FAA713351663F3889A /* ImportReviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95BBAB51882751053816B2C /* ImportReviewTests.swift */; };
 		AC7E1126C65C59B15141CB79 /* ContentView+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F852CE2356ADE83460064B /* ContentView+Import.swift */; };
+		AD6426F91D871AE7E1F57251 /* ContactDetailView+QuickInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0DCB1419D1BD49893F8AD /* ContactDetailView+QuickInfo.swift */; };
 		AF36C8E991E2B6C96634FBA0 /* ChunkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30CD9D085E7424A79159879 /* ChunkingTests.swift */; };
 		B1393B1344A7D64B52C4B3D4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9795992CBF553603FD37928 /* SettingsView.swift */; };
 		BA9738D0812FB7A090DD5D4E /* ContactEntityQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399A72E1BB6BEC0B54D356E7 /* ContactEntityQueryTests.swift */; };
@@ -68,8 +76,10 @@
 		CE55AD882E6631A9541B6106 /* ContactsBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */; };
 		CEAC8F942C862FADB6C45220 /* SpotlightIndexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */; };
 		CFFC58E9EA162230275F2301 /* ContactEntityQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874742D7DC5E9C20D3A88459 /* ContactEntityQuery.swift */; };
+		D09BB01ED8C135141953AFE7 /* ImportReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA2237DBD182839EAF04F1 /* ImportReviewView.swift */; };
 		E5EB465B5CE3964197D29ADF /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F82C8A388E97CC4F1106176 /* SampleData.swift */; };
 		ECB7FDD8D0C3091EA0D42917 /* UndoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DCAF444714BC3726B212C4 /* UndoTests.swift */; };
+		ECDA4BC68D3FAE4CCF428675 /* ContactDetailView+Saving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */; };
 		FA63688E94483238D7C29FE9 /* DuplicateFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */; };
 		FA702A2E92FAC86D4587641B /* ContactManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDDA2A3FA3C7375D63CFC55 /* ContactManagerApp.swift */; };
 /* End PBXBuildFile section */
@@ -98,6 +108,7 @@
 		05F6260FE20C27094AFB327A /* FindContactIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FindContactIntent.swift; sourceTree = "<group>"; };
 		08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactListView.swift; sourceTree = "<group>"; };
 		0B27567532AC1A51FF4CC13A /* ContactQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactQuery.swift; sourceTree = "<group>"; };
+		0CFA2237DBD182839EAF04F1 /* ImportReviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportReviewView.swift; sourceTree = "<group>"; };
 		0F82C8A388E97CC4F1106176 /* SampleData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SampleData.swift; sourceTree = "<group>"; };
 		10E14CB9E9A2442DFE7B0E0B /* ContactManager.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = ContactManager.entitlements; sourceTree = "<group>"; };
 		10E7338673D65A6FAB4F9AF3 /* ContactManagerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContactManagerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -110,7 +121,10 @@
 		2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardDocument.swift; sourceTree = "<group>"; };
 		3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinderTests.swift; sourceTree = "<group>"; };
 		399A72E1BB6BEC0B54D356E7 /* ContactEntityQueryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityQueryTests.swift; sourceTree = "<group>"; };
+		3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		436B4115937E4350EB9A7EF7 /* Chunking.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Chunking.swift; sourceTree = "<group>"; };
+		438C2B20E1C302676594ECCA /* ContactStorePendingEditTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStorePendingEditTests.swift; sourceTree = "<group>"; };
+		45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+PendingEdits.swift"; sourceTree = "<group>"; };
 		4E2F2242E59F2C42DDD0736B /* CSV.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSV.swift; sourceTree = "<group>"; };
 		54C373BD237429970D6A7C86 /* DuplicatesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicatesView.swift; sourceTree = "<group>"; };
 		5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingTests.swift; sourceTree = "<group>"; };
@@ -129,9 +143,11 @@
 		7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactsBridgeTests.swift; sourceTree = "<group>"; };
 		7E7D5B554122CF852B0D825C /* VCardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTests.swift; sourceTree = "<group>"; };
 		833F1AF82CACF7B9E89BADCA /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		83E63AB996E12C5978B4A8F1 /* ContactFieldRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactFieldRow.swift; sourceTree = "<group>"; };
 		874742D7DC5E9C20D3A88459 /* ContactEntityQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityQuery.swift; sourceTree = "<group>"; };
 		90E3C45DEC115A2BF7DE83DF /* ContactLink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactLink.swift; sourceTree = "<group>"; };
 		915AF700C971510D0B642590 /* ContactEntity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntity.swift; sourceTree = "<group>"; };
+		92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Saving.swift"; sourceTree = "<group>"; };
 		93C12246003379D5966F0210 /* ContactEntityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityTests.swift; sourceTree = "<group>"; };
 		964ACD67CC8CB35694497A10 /* GroupDropTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroupDropTests.swift; sourceTree = "<group>"; };
 		A30CD9D085E7424A79159879 /* ChunkingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChunkingTests.swift; sourceTree = "<group>"; };
@@ -144,11 +160,15 @@
 		B0CF4C47C670B0A8C3B6B384 /* ContactActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactActivity.swift; sourceTree = "<group>"; };
 		B25751DDEC1515E341AF67F5 /* ContactField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactField.swift; sourceTree = "<group>"; };
 		B75D02267D3BC6C014143329 /* ContactModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactModelTests.swift; sourceTree = "<group>"; };
+		B7C0DCB1419D1BD49893F8AD /* ContactDetailView+QuickInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+QuickInfo.swift"; sourceTree = "<group>"; };
 		BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSVTests.swift; sourceTree = "<group>"; };
 		BECE026D8586731B7C590901 /* DefaultGroupPreference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultGroupPreference.swift; sourceTree = "<group>"; };
 		C0255C29CC874D2BA1C064CF /* ContactPDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactPDF.swift; sourceTree = "<group>"; };
 		C0F303B7AE5B9202CDA6D9DA /* ContactPDFTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactPDFTests.swift; sourceTree = "<group>"; };
 		C7DCAF444714BC3726B212C4 /* UndoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UndoTests.swift; sourceTree = "<group>"; };
+		C90D71F3F01E29B7C4B739A7 /* ContactStore+ImportReview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+ImportReview.swift"; sourceTree = "<group>"; };
+		C95BBAB51882751053816B2C /* ImportReviewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportReviewTests.swift; sourceTree = "<group>"; };
+		DB522F18FE21A503D7C480AB /* ImportReview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportReview.swift; sourceTree = "<group>"; };
 		DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactActivityTests.swift; sourceTree = "<group>"; };
 		DC69A4C348D4BBEF0D8F1330 /* PDFExportDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFExportDocument.swift; sourceTree = "<group>"; };
 		DEAB729518FA2A6600E3570B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -217,6 +237,9 @@
 				617D7B082A403094284FBD38 /* ContactStore.swift */,
 				E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */,
 				BECE026D8586731B7C590901 /* DefaultGroupPreference.swift */,
+				DB522F18FE21A503D7C480AB /* ImportReview.swift */,
+				C90D71F3F01E29B7C4B739A7 /* ContactStore+ImportReview.swift */,
+				45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -272,6 +295,10 @@
 				29335D93B2E97B9038F1481A /* ImportProgressView.swift */,
 				A37DB6CC43A76261CFF3987D /* PrintableContactView.swift */,
 				570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */,
+				0CFA2237DBD182839EAF04F1 /* ImportReviewView.swift */,
+				92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */,
+				B7C0DCB1419D1BD49893F8AD /* ContactDetailView+QuickInfo.swift */,
+				83E63AB996E12C5978B4A8F1 /* ContactFieldRow.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -308,6 +335,7 @@
 				C80F354FEBD80D33AEC2F590 /* Intents */,
 				10E14CB9E9A2442DFE7B0E0B /* ContactManager.entitlements */,
 				76F68BAD5C3290EE7ABF787B /* Localizable.xcstrings */,
+				3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */,
 			);
 			path = ContactManager;
 			sourceTree = "<group>";
@@ -335,6 +363,8 @@
 				279FCAC10E829D7DAC9D8385 /* OpenContactIntentTests.swift */,
 				DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */,
 				399A72E1BB6BEC0B54D356E7 /* ContactEntityQueryTests.swift */,
+				C95BBAB51882751053816B2C /* ImportReviewTests.swift */,
+				438C2B20E1C302676594ECCA /* ContactStorePendingEditTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -447,6 +477,7 @@
 			files = (
 				7F3D3F509379FD171AEC3606 /* Images.xcassets in Resources */,
 				91DA07BB24CEA1941C5AFA6E /* Localizable.xcstrings in Resources */,
+				444B949F37F7FF7DD98A4C6B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -506,6 +537,13 @@
 				8397B67D483997505B17269E /* ContactDetailView+Birthday.swift in Sources */,
 				AA43BCF64B0DC3F571E4A813 /* DefaultGroupPreference.swift in Sources */,
 				4B9EAE3500BB10401AEB3746 /* ContactActivity.swift in Sources */,
+				509C184B6FC5C331FCC6FD11 /* ImportReview.swift in Sources */,
+				D09BB01ED8C135141953AFE7 /* ImportReviewView.swift in Sources */,
+				97F582C8C0B47ABD787E2C2E /* ContactStore+ImportReview.swift in Sources */,
+				ECDA4BC68D3FAE4CCF428675 /* ContactDetailView+Saving.swift in Sources */,
+				3EDDAA184C377D9C16AAF08A /* ContactStore+PendingEdits.swift in Sources */,
+				AD6426F91D871AE7E1F57251 /* ContactDetailView+QuickInfo.swift in Sources */,
+				847D0CD5B12E83CD53951DA2 /* ContactFieldRow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -533,6 +571,8 @@
 				01001E025DB1348D36342E1C /* OpenContactIntentTests.swift in Sources */,
 				442122E49889F5A9CA174B12 /* ContactActivityTests.swift in Sources */,
 				BA9738D0812FB7A090DD5D4E /* ContactEntityQueryTests.swift in Sources */,
+				ABF907FAA713351663F3889A /* ImportReviewTests.swift in Sources */,
+				0DC8E4BAF454185075119C3A /* ContactStorePendingEditTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Intents/ContactEntity.swift
+++ b/ContactManager/Intents/ContactEntity.swift
@@ -70,11 +70,3 @@ extension ContactEntity {
         phones = contact.phones.map(\.value).filter { !$0.isBlank }
     }
 }
-
-private extension String {
-    /// Treats whitespace-only strings as empty, matching how the rest of
-    /// the codebase decides whether a contact field is "set".
-    var isBlank: Bool {
-        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
-}

--- a/ContactManager/Models/ContactStore+ImportReview.swift
+++ b/ContactManager/Models/ContactStore+ImportReview.swift
@@ -1,0 +1,143 @@
+//
+//  ContactStore+ImportReview.swift
+//  ContactManager
+//
+//  Applies reviewed import decisions through ContactStore's save, undo, and
+//  Spotlight-notification pipeline.
+//
+
+import Foundation
+
+extension ContactStore {
+    @discardableResult
+    func applyImportReview(_ items: [ImportReviewItem]) throws -> ImportReviewResult {
+        try mutate("Import Contacts") {
+            var result = ImportReviewResult()
+            for item in items {
+                apply(item, result: &result)
+            }
+            return result
+        }
+    }
+
+    private func apply(_ item: ImportReviewItem, result: inout ImportReviewResult) {
+        switch item.decision {
+        case .add:
+            context.insert(Self.makeContact(from: item.parsed))
+            result.added += 1
+        case .skip:
+            result.skipped += 1
+        case .updateExisting:
+            applyUpdate(item, result: &result)
+        case .merge:
+            applyMerge(item, result: &result)
+        }
+    }
+
+    private func applyUpdate(_ item: ImportReviewItem, result: inout ImportReviewResult) {
+        if let existing = item.matchedContact {
+            update(existing, with: item.parsed)
+            result.updated += 1
+        } else {
+            context.insert(Self.makeContact(from: item.parsed))
+            result.added += 1
+        }
+    }
+
+    private func applyMerge(_ item: ImportReviewItem, result: inout ImportReviewResult) {
+        if let existing = item.matchedContact {
+            merge(item.parsed, into: existing)
+            result.merged += 1
+        } else {
+            context.insert(Self.makeContact(from: item.parsed))
+            result.added += 1
+        }
+    }
+
+    private func update(_ contact: Contact, with parsed: ParsedContact) {
+        fillBlankScalars(of: contact, from: parsed)
+        appendNewFields(from: parsed, to: contact)
+        if contact.birthday == nil { contact.birthday = parsed.birthday }
+        if contact.photoData == nil, let raw = parsed.photoData {
+            contact.photoData = ImageProcessing.avatarData(from: raw)
+        }
+    }
+
+    private func merge(_ parsed: ParsedContact, into existing: Contact) {
+        let imported = Self.makeContact(from: parsed)
+        context.insert(imported)
+        fillEmptyFields(of: existing, from: imported)
+        mergeFields(into: existing, from: [imported])
+        context.delete(imported)
+    }
+
+    private func fillBlankScalars(of contact: Contact, from parsed: ParsedContact) {
+        if contact.firstName.isBlank { contact.firstName = parsed.firstName }
+        if contact.lastName.isBlank { contact.lastName = parsed.lastName }
+        if contact.company.isBlank { contact.company = parsed.company }
+        if contact.jobTitle.isBlank { contact.jobTitle = parsed.jobTitle }
+        if contact.street.isBlank { contact.street = parsed.street }
+        if contact.city.isBlank { contact.city = parsed.city }
+        if contact.state.isBlank { contact.state = parsed.state }
+        if contact.postalCode.isBlank { contact.postalCode = parsed.postalCode }
+        if contact.country.isBlank { contact.country = parsed.country }
+        if contact.notes.isBlank { contact.notes = parsed.notes }
+    }
+
+    private func appendNewFields(from parsed: ParsedContact, to contact: Contact) {
+        appendNewFields(
+            parsed.emails, kind: .email,
+            existingValues: Set(contact.emails.map(\.value).map(\.normalizedEmail)),
+            to: contact
+        )
+        appendNewFields(
+            parsed.phones, kind: .phone,
+            existingValues: Set(contact.phones.map(\.value).map(\.normalizedPhone)),
+            to: contact
+        )
+    }
+
+    private func appendNewFields(
+        _ fields: [(label: FieldLabel, value: String)],
+        kind: FieldKind,
+        existingValues: Set<String>,
+        to contact: Contact
+    ) {
+        var seen = existingValues
+        var nextIndex = (contact.fields(of: kind).map(\.sortIndex).max() ?? -1) + 1
+        for parsedField in fields {
+            let normalized = kind == .email
+                ? parsedField.value.normalizedEmail
+                : parsedField.value.normalizedPhone
+            guard !normalized.isEmpty, !seen.contains(normalized) else { continue }
+            seen.insert(normalized)
+            insertField(parsedField, kind: kind, sortIndex: nextIndex, into: contact)
+            nextIndex += 1
+        }
+    }
+
+    private func insertField(
+        _ parsedField: (label: FieldLabel, value: String),
+        kind: FieldKind,
+        sortIndex: Int,
+        into contact: Contact
+    ) {
+        let field = ContactField(
+            kind: kind,
+            label: parsedField.label,
+            value: parsedField.value,
+            sortIndex: sortIndex
+        )
+        field.contact = contact
+        context.insert(field)
+    }
+}
+
+struct ImportReviewResult {
+    var added = 0
+    var updated = 0
+    var merged = 0
+    var skipped = 0
+
+    var totalWritten: Int { added + updated + merged }
+}

--- a/ContactManager/Models/ContactStore+PendingEdits.swift
+++ b/ContactManager/Models/ContactStore+PendingEdits.swift
@@ -1,0 +1,28 @@
+//
+//  ContactStore+PendingEdits.swift
+//  ContactManager
+//
+//  Saves direct SwiftData edits made by form bindings.
+//
+
+extension ContactStore {
+    /// Saves direct SwiftUI/SwiftData edits (text fields, pickers, birthday
+    /// bindings) through the same rollback + Spotlight notification path as
+    /// structural mutations. Returns an empty change when there is nothing
+    /// pending so debounced callers can invoke it freely.
+    @discardableResult
+    func savePendingEdits(actionName: String) throws -> ContactChange {
+        let pending = pendingContactChange()
+        guard context.hasChanges else { return pending.contactChange() }
+        do {
+            try context.save()
+            let change = pending.contactChange()
+            context.undoManager?.setActionName(actionName)
+            post(change)
+            return change
+        } catch {
+            context.rollback()
+            throw error
+        }
+    }
+}

--- a/ContactManager/Models/ContactStore.swift
+++ b/ContactManager/Models/ContactStore.swift
@@ -163,7 +163,7 @@ struct ContactStore {
         }
     }
 
-    private func fillEmptyFields(of primary: Contact, from other: Contact) {
+    func fillEmptyFields(of primary: Contact, from other: Contact) {
         /// Treat whitespace-only values as empty, consistent with the rest of
         /// the codebase (Contact.fullName, primaryEmail, etc.).
         func isBlank(_ value: String) -> Bool {
@@ -192,7 +192,7 @@ struct ContactStore {
 
     /// Reassigns every contact's email/phone fields to `primary`, dropping
     /// blanks and value-duplicates and reindexing for a stable order.
-    private func mergeFields(into primary: Contact, from others: [Contact]) {
+    func mergeFields(into primary: Contact, from others: [Contact]) {
         for kind in FieldKind.allCases {
             let candidates = primary.fields(of: kind) + others.flatMap { $0.fields(of: kind) }
             var seenValues: Set<String> = []
@@ -274,51 +274,17 @@ struct ContactStore {
     /// back on failure. The group is given `actionName` so the Edit menu shows
     /// e.g. "Undo Create Contact".
     @discardableResult
-    private func mutate<Result>(_ actionName: String, _ body: () throws -> Result) throws -> Result {
+    func mutate<Result>(_ actionName: String, _ body: () throws -> Result) throws -> Result {
         let undoManager = context.undoManager
         undoManager?.beginUndoGrouping()
         do {
             let result = try body()
-
-            // Snapshot the context's pending changes *before* the save clears
-            // them, so the notification can carry a precise delta and the
-            // Spotlight index updates incrementally rather than rebuilding the
-            // whole thing on every edit.
-            let touched = context.insertedModelsArray + context.changedModelsArray
-            let deletedModels = context.deletedModelsArray
-            // Deleted contacts already hold permanent ids (they were saved
-            // before), so read them now — after the save the objects are gone.
-            let deletedIDs = Set(
-                deletedModels.compactMap { ($0 as? Contact)?.persistentModelID.storedString }
-            )
-            // A field can be deleted while its owning contact survives (Delete
-            // Field, or merge folding duplicates). Capture those owners now,
-            // while the inverse relationship is still intact, so the contact's
-            // emails/phones get refreshed.
-            let survivingFieldOwnerIDs = Set(
-                deletedModels.compactMap { ($0 as? ContactField)?.contact?.persistentModelID.storedString }
-            )
+            let pending = pendingContactChange()
 
             try context.save()
             undoManager?.endUndoGrouping()
             undoManager?.setActionName(actionName)
-
-            // Read updated ids *after* the save: a freshly inserted contact's
-            // pre-save id is temporary and wouldn't match a later fetch-by-id;
-            // the save promotes it to the permanent identifier in place.
-            var updatedIDs = Set(touched.compactMap(Self.affectedContactID))
-            updatedIDs.formUnion(survivingFieldOwnerIDs)
-            updatedIDs.subtract(deletedIDs) // never re-index a contact we just deleted
-            let change = ContactChange(updatedIDs: updatedIDs, deletedIDs: deletedIDs)
-
-            // Observed by ContentView to refresh the Spotlight index. Fired
-            // after the save commits so observers see the post-mutation state,
-            // and carries the delta so the refresh stays incremental.
-            NotificationCenter.default.post(
-                name: .contactsDidChange,
-                object: nil,
-                userInfo: [ContactChange.userInfoKey: change]
-            )
+            post(pending.contactChange())
             return result
         } catch {
             context.rollback()
@@ -330,7 +296,7 @@ struct ContactStore {
     /// Maps a touched model to the contact whose Spotlight entry it affects: a
     /// `Contact` directly, or a `ContactField` via its owner. Other models
     /// (e.g. `ContactGroup`) don't appear in the index and map to `nil`.
-    private static func affectedContactID(of model: any PersistentModel) -> String? {
+    static func affectedContactID(of model: any PersistentModel) -> String? {
         switch model {
         case let contact as Contact:
             contact.persistentModelID.storedString
@@ -339,6 +305,44 @@ struct ContactStore {
         default:
             nil
         }
+    }
+
+    func pendingContactChange() -> PendingContactChange {
+        // Snapshot the context's pending changes *before* the save clears
+        // them, so the notification can carry a precise delta and the
+        // Spotlight index updates incrementally rather than rebuilding the
+        // whole thing on every edit.
+        let touched = context.insertedModelsArray + context.changedModelsArray
+        let deletedModels = context.deletedModelsArray
+        // Deleted contacts already hold permanent ids (they were saved
+        // before), so read them now — after the save the objects are gone.
+        let deletedIDs = Set(
+            deletedModels.compactMap { ($0 as? Contact)?.persistentModelID.storedString }
+        )
+        // A field can be deleted while its owning contact survives (Delete
+        // Field, or merge folding duplicates). Capture those owners now,
+        // while the inverse relationship is still intact, so the contact's
+        // emails/phones get refreshed.
+        let survivingFieldOwnerIDs = Set(
+            deletedModels.compactMap { ($0 as? ContactField)?.contact?.persistentModelID.storedString }
+        )
+
+        return PendingContactChange(
+            touched: touched,
+            survivingFieldOwnerIDs: survivingFieldOwnerIDs,
+            deletedIDs: deletedIDs
+        )
+    }
+
+    func post(_ change: ContactChange) {
+        // Observed by ContentView to refresh the Spotlight index. Fired
+        // after the save commits so observers see the post-mutation state,
+        // and carries the delta so the refresh stays incremental.
+        NotificationCenter.default.post(
+            name: .contactsDidChange,
+            object: nil,
+            userInfo: [ContactChange.userInfoKey: change]
+        )
     }
 }
 
@@ -358,6 +362,23 @@ struct ContactChange {
 
     /// `userInfo` key the change rides under in `.contactsDidChange`.
     static let userInfoKey = "ContactManager.contactChange"
+}
+
+@MainActor
+struct PendingContactChange {
+    var touched: [any PersistentModel]
+    var survivingFieldOwnerIDs: Set<String>
+    var deletedIDs: Set<String>
+
+    func contactChange() -> ContactChange {
+        // Read updated ids *after* the save: a freshly inserted contact's
+        // pre-save id is temporary and wouldn't match a later fetch-by-id;
+        // the save promotes it to the permanent identifier in place.
+        var updatedIDs = Set(touched.compactMap { ContactStore.affectedContactID(of: $0) })
+        updatedIDs.formUnion(survivingFieldOwnerIDs)
+        updatedIDs.subtract(deletedIDs) // never re-index a contact we just deleted
+        return ContactChange(updatedIDs: updatedIDs, deletedIDs: deletedIDs)
+    }
 }
 
 enum ContactStoreError: LocalizedError {

--- a/ContactManager/Models/DuplicateFinder.swift
+++ b/ContactManager/Models/DuplicateFinder.swift
@@ -18,7 +18,7 @@ enum DuplicateFinder {
         guard contacts.count > 1 else { return [] }
 
         var unionFind = UnionFind(count: contacts.count)
-        var ownerOfKey: [String: Int] = [:]
+        var ownerOfKey: [ContactMatchKey: Int] = [:]
 
         for (index, contact) in contacts.enumerated() {
             for key in matchKeys(for: contact) {
@@ -43,24 +43,47 @@ enum DuplicateFinder {
 
     /// Normalized keys identifying a contact for matching. A shared key between
     /// two contacts marks them as duplicates.
-    static func matchKeys(for contact: Contact) -> Set<String> {
-        var keys: Set<String> = []
+    static func matchKeys(for contact: Contact) -> Set<ContactMatchKey> {
+        ContactMatchKey.keys(
+            firstName: contact.firstName,
+            lastName: contact.lastName,
+            emails: contact.emails.map(\.value),
+            phones: contact.phones.map(\.value)
+        )
+    }
+}
 
-        for email in contact.emails {
-            let normalized = email.value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            if !normalized.isEmpty { keys.insert("email:\(normalized)") }
+/// A normalized identity fragment used for duplicate detection and import
+/// review. Shared by `DuplicateFinder` and `ImportReview` so both features
+/// agree on what counts as "the same person".
+enum ContactMatchKey: Hashable {
+    case email(String)
+    case phone(String)
+    case name(String)
+
+    static func keys(
+        firstName: String,
+        lastName: String,
+        emails: [String],
+        phones: [String]
+    ) -> Set<ContactMatchKey> {
+        var keys: Set<ContactMatchKey> = []
+
+        for email in emails {
+            let normalized = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if !normalized.isEmpty { keys.insert(.email(normalized)) }
         }
-        for phone in contact.phones {
-            let digits = String(phone.value.filter(\.isNumber))
+        for phone in phones {
+            let digits = String(phone.filter(\.isNumber))
             // Ignore very short fragments (e.g. extensions) to avoid false matches.
-            if digits.count >= 7 { keys.insert("phone:\(digits)") }
+            if digits.count >= 7 { keys.insert(.phone(digits)) }
         }
 
-        let name = [contact.firstName, contact.lastName]
+        let name = [firstName, lastName]
             .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
             .filter { !$0.isEmpty }
             .joined(separator: " ")
-        if !name.isEmpty { keys.insert("name:\(name)") }
+        if !name.isEmpty { keys.insert(.name(name)) }
 
         return keys
     }

--- a/ContactManager/Models/ImportReview.swift
+++ b/ContactManager/Models/ImportReview.swift
@@ -1,0 +1,175 @@
+//
+//  ImportReview.swift
+//  ContactManager
+//
+//  Preflight model for contact imports. It compares parsed contacts with the
+//  current store and picks a conservative default decision for each row before
+//  anything is written.
+//
+
+import Foundation
+
+enum ImportDecision: String, CaseIterable, Identifiable {
+    case add
+    case merge
+    case updateExisting
+    case skip
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .add: "Add"
+        case .merge: "Merge"
+        case .updateExisting: "Update Existing"
+        case .skip: "Skip"
+        }
+    }
+}
+
+struct ImportReviewItem: Identifiable {
+    let id = UUID()
+    var parsed: ParsedContact
+    var matchedContact: Contact?
+    var decision: ImportDecision
+
+    var displayName: String {
+        let name = [parsed.firstName, parsed.lastName]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        if !name.isEmpty { return name }
+        let company = parsed.company.trimmingCharacters(in: .whitespacesAndNewlines)
+        return company.isEmpty ? "Unnamed Contact" : company
+    }
+
+    var subtitle: String? {
+        if let email = parsed.emails.map(\.value).first(where: { !$0.isBlank }) { return email }
+        if let phone = parsed.phones.map(\.value).first(where: { !$0.isBlank }) { return phone }
+        return parsed.company.isBlank ? nil : parsed.company
+    }
+
+    var availableDecisions: [ImportDecision] {
+        matchedContact == nil ? [.add, .skip] : ImportDecision.allCases
+    }
+}
+
+enum ImportReview {
+    static func makeItems(for parsed: [ParsedContact], existing contacts: [Contact]) -> [ImportReviewItem] {
+        parsed.map { parsedContact in
+            guard let match = bestMatch(for: parsedContact, in: contacts) else {
+                return ImportReviewItem(parsed: parsedContact, matchedContact: nil, decision: .add)
+            }
+            return ImportReviewItem(
+                parsed: parsedContact,
+                matchedContact: match,
+                decision: defaultDecision(for: parsedContact, matchedContact: match)
+            )
+        }
+    }
+
+    private static func bestMatch(for parsed: ParsedContact, in contacts: [Contact]) -> Contact? {
+        let keys = ContactMatchKey.keys(for: parsed)
+        guard !keys.isEmpty else { return nil }
+        return ContactQuery.sorted(contacts).first { contact in
+            !DuplicateFinder.matchKeys(for: contact).isDisjoint(with: keys)
+        }
+    }
+
+    private static func defaultDecision(
+        for parsed: ParsedContact,
+        matchedContact contact: Contact
+    ) -> ImportDecision {
+        if parsed.hasNoNewData(comparedWith: contact) { return .skip }
+        if parsed.canFill(contact) { return .updateExisting }
+        return .merge
+    }
+}
+
+extension ContactMatchKey {
+    static func keys(for parsed: ParsedContact) -> Set<ContactMatchKey> {
+        keys(
+            firstName: parsed.firstName,
+            lastName: parsed.lastName,
+            emails: parsed.emails.map(\.value),
+            phones: parsed.phones.map(\.value)
+        )
+    }
+}
+
+private extension ParsedContact {
+    func hasNoNewData(comparedWith contact: Contact) -> Bool {
+        canFill(contact)
+            && emailValues.allSatisfy { existingEmailValues(in: contact).contains($0) }
+            && phoneValues.allSatisfy { existingPhoneValues(in: contact).contains($0) }
+    }
+
+    func canFill(_ contact: Contact) -> Bool {
+        scalarsAreSameOrFillBlank(comparedWith: contact)
+            && birthdayCanFill(contact)
+            && photoCanFill(contact)
+    }
+
+    private func scalarsAreSameOrFillBlank(comparedWith contact: Contact) -> Bool {
+        scalarPairs(comparedWith: contact).allSatisfy { incoming, existing in
+            incoming.isBlank || existing.isBlank || incoming.normalizedText == existing.normalizedText
+        }
+    }
+
+    private func scalarPairs(comparedWith contact: Contact) -> [(String, String)] {
+        [
+            (firstName, contact.firstName),
+            (lastName, contact.lastName),
+            (company, contact.company),
+            (jobTitle, contact.jobTitle),
+            (street, contact.street),
+            (city, contact.city),
+            (state, contact.state),
+            (postalCode, contact.postalCode),
+            (country, contact.country),
+            (notes, contact.notes),
+        ]
+    }
+
+    private func birthdayCanFill(_ contact: Contact) -> Bool {
+        birthday == nil || contact.birthday == nil || birthday == contact.birthday
+    }
+
+    private func photoCanFill(_ contact: Contact) -> Bool {
+        photoData == nil || contact.photoData == nil || photoData == contact.photoData
+    }
+
+    private var emailValues: Set<String> {
+        Set(emails.map(\.value).map(\.normalizedEmail).filter { !$0.isEmpty })
+    }
+
+    private var phoneValues: Set<String> {
+        Set(phones.map(\.value).map(\.normalizedPhone).filter { $0.count >= 7 })
+    }
+
+    private func existingEmailValues(in contact: Contact) -> Set<String> {
+        Set(contact.emails.map(\.value).map(\.normalizedEmail).filter { !$0.isEmpty })
+    }
+
+    private func existingPhoneValues(in contact: Contact) -> Set<String> {
+        Set(contact.phones.map(\.value).map(\.normalizedPhone).filter { $0.count >= 7 })
+    }
+}
+
+extension String {
+    var isBlank: Bool {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var normalizedText: String {
+        trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    var normalizedEmail: String {
+        normalizedText
+    }
+
+    var normalizedPhone: String {
+        String(filter(\.isNumber))
+    }
+}

--- a/ContactManager/PrivacyInfo.xcprivacy
+++ b/ContactManager/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/ContactManager/Views/ContactDetailView+Birthday.swift
+++ b/ContactManager/Views/ContactDetailView+Birthday.swift
@@ -84,6 +84,7 @@ struct MonthDayPicker: View {
             .labelsHidden()
             .fixedSize()
             .accessibilityLabel("Birthday month")
+            .accessibilityIdentifier("birthday-month-picker")
 
             Picker("Day", selection: $day) {
                 ForEach(1 ... Birthday.daysInMonth(month, year: nil), id: \.self) { value in
@@ -93,6 +94,7 @@ struct MonthDayPicker: View {
             .labelsHidden()
             .fixedSize()
             .accessibilityLabel("Birthday day")
+            .accessibilityIdentifier("birthday-day-picker")
         }
     }
 }

--- a/ContactManager/Views/ContactDetailView+QuickInfo.swift
+++ b/ContactManager/Views/ContactDetailView+QuickInfo.swift
@@ -1,0 +1,57 @@
+//
+//  ContactDetailView+QuickInfo.swift
+//  ContactManager
+//
+//  Primary email/phone action rows for the contact detail header.
+//
+
+import AppKit
+import SwiftUI
+
+extension ContactDetailView {
+    func quickRow(kind: FieldKind, value: String) -> some View {
+        let label = kind == .email ? "Email" : "Phone"
+        return HStack {
+            HStack {
+                Text(label)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(value)
+                    .textSelection(.enabled)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .accessibilityElement(children: .combine)
+
+            if let url = actionURL(for: kind, value: value) {
+                Link(destination: url) {
+                    Image(systemName: kind == .email ? "envelope" : "phone")
+                }
+                .buttonStyle(.borderless)
+                .help(kind == .email ? "Send Email" : "Call")
+                .accessibilityLabel(kind == .email ? "Send Email" : "Call")
+            }
+
+            Button {
+                copyToPasteboard(value)
+            } label: {
+                Image(systemName: "doc.on.doc")
+            }
+            .buttonStyle(.borderless)
+            .help("Copy \(label)")
+            .accessibilityLabel("Copy \(label)")
+        }
+    }
+
+    private func actionURL(for kind: FieldKind, value: String) -> URL? {
+        switch kind {
+        case .email: ContactLink.mailto(value)
+        case .phone: ContactLink.tel(value)
+        }
+    }
+
+    private func copyToPasteboard(_ value: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
+    }
+}

--- a/ContactManager/Views/ContactDetailView+Saving.swift
+++ b/ContactManager/Views/ContactDetailView+Saving.swift
@@ -1,0 +1,54 @@
+//
+//  ContactDetailView+Saving.swift
+//  ContactManager
+//
+//  Debounced save support for direct SwiftData form bindings.
+//
+
+import Foundation
+
+enum ContactEditFingerprint {
+    static func make(for contact: Contact) -> String {
+        let fields = contact.fields
+            .sorted { lhs, rhs in
+                if lhs.kind != rhs.kind { return lhs.kind.rawValue < rhs.kind.rawValue }
+                return lhs.sortIndex < rhs.sortIndex
+            }
+            .map { field in
+                [
+                    field.kind.rawValue,
+                    field.label.rawValue,
+                    field.value,
+                    String(field.sortIndex),
+                ].joined(separator: "\u{1F}")
+            }
+            .joined(separator: "\u{1E}")
+        let birthday = contact.birthday.map { String($0.timeIntervalSinceReferenceDate) } ?? ""
+        return [
+            contact.firstName,
+            contact.lastName,
+            contact.company,
+            contact.jobTitle,
+            contact.street,
+            contact.city,
+            contact.state,
+            contact.postalCode,
+            contact.country,
+            birthday,
+            contact.notes,
+            fields,
+        ].joined(separator: "\u{1D}")
+    }
+}
+
+extension ContactDetailView {
+    func flushPendingEdits() {
+        guard editFingerprint != lastSavedFingerprint else { return }
+        do {
+            try store.savePendingEdits(actionName: "Edit Contact")
+            lastSavedFingerprint = editFingerprint
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -26,8 +26,13 @@ struct ContactDetailView: View {
     // Not private: the photo handlers in ContactDetailView+Photo.swift read them.
     @State var errorMessage: String?
     @FocusState private var nameFieldFocused: Bool
+    @State var lastSavedFingerprint = ""
 
     var store: ContactStore { ContactStore(context) }
+
+    var editFingerprint: String {
+        ContactEditFingerprint.make(for: contact)
+    }
 
     var body: some View {
         Form {
@@ -38,12 +43,16 @@ struct ContactDetailView: View {
             Section("Name") {
                 TextField("First Name", text: $contact.firstName)
                     .focused($nameFieldFocused)
+                    .accessibilityIdentifier("contact-first-name-field")
                 TextField("Last Name", text: $contact.lastName)
+                    .accessibilityIdentifier("contact-last-name-field")
             }
 
             Section("Work") {
                 TextField("Company", text: $contact.company)
+                    .accessibilityIdentifier("contact-company-field")
                 TextField("Job Title", text: $contact.jobTitle)
+                    .accessibilityIdentifier("contact-job-title-field")
             }
 
             fieldSection("Email", kind: .email, fields: contact.emails)
@@ -51,10 +60,15 @@ struct ContactDetailView: View {
 
             Section("Address") {
                 TextField("Street", text: $contact.street)
+                    .accessibilityIdentifier("contact-street-field")
                 TextField("City", text: $contact.city)
+                    .accessibilityIdentifier("contact-city-field")
                 TextField("State / Province", text: $contact.state)
+                    .accessibilityIdentifier("contact-state-field")
                 TextField("Postal Code", text: $contact.postalCode)
+                    .accessibilityIdentifier("contact-postal-code-field")
                 TextField("Country", text: $contact.country)
+                    .accessibilityIdentifier("contact-country-field")
             }
 
             Section("Birthday") {
@@ -91,6 +105,7 @@ struct ContactDetailView: View {
             Section("Notes") {
                 TextField("Notes", text: $contact.notes, axis: .vertical)
                     .lineLimit(3 ... 10)
+                    .accessibilityIdentifier("contact-notes-field")
             }
         }
         .formStyle(.grouped)
@@ -98,7 +113,20 @@ struct ContactDetailView: View {
         // A freshly created contact opens with the cursor in First Name so you
         // can type a name immediately instead of reaching for the mouse.
         .onAppear {
+            lastSavedFingerprint = editFingerprint
             if focusNameField { nameFieldFocused = true }
+        }
+        .task(id: editFingerprint) {
+            guard editFingerprint != lastSavedFingerprint else { return }
+            do {
+                try await Task.sleep(for: .milliseconds(400))
+                flushPendingEdits()
+            } catch {
+                // A newer edit cancelled this debounce.
+            }
+        }
+        .onDisappear {
+            flushPendingEdits()
         }
         // Clear the parent's one-shot flag only once focus has actually landed,
         // so a missed/late focus application isn't dropped without a retry.
@@ -190,57 +218,6 @@ struct ContactDetailView: View {
         }
     }
 
-    private func quickRow(kind: FieldKind, value: String) -> some View {
-        let label = kind == .email ? "Email" : "Phone"
-        return HStack {
-            // Combined so VoiceOver reads "Email, name@example.com" as a
-            // single element, instead of "Email" and "name@example.com"
-            // separately. The action buttons stay their own focusable elements.
-            HStack {
-                Text(label)
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Text(value)
-                    .textSelection(.enabled)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            }
-            .accessibilityElement(children: .combine)
-
-            // Click-to-mail / click-to-call. Only shown when the value yields
-            // a usable URL, so a junk entry doesn't offer a dead action.
-            if let url = actionURL(for: kind, value: value) {
-                Link(destination: url) {
-                    Image(systemName: kind == .email ? "envelope" : "phone")
-                }
-                .buttonStyle(.borderless)
-                .help(kind == .email ? "Send Email" : "Call")
-                .accessibilityLabel(kind == .email ? "Send Email" : "Call")
-            }
-
-            Button {
-                copyToPasteboard(value)
-            } label: {
-                Image(systemName: "doc.on.doc")
-            }
-            .buttonStyle(.borderless)
-            .help("Copy \(label)")
-            .accessibilityLabel("Copy \(label)")
-        }
-    }
-
-    private func actionURL(for kind: FieldKind, value: String) -> URL? {
-        switch kind {
-        case .email: ContactLink.mailto(value)
-        case .phone: ContactLink.tel(value)
-        }
-    }
-
-    private func copyToPasteboard(_ value: String) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(value, forType: .string)
-    }
-
     // MARK: - Repeatable field sections
 
     private func fieldSection(_ title: String, kind: FieldKind, fields: [ContactField]) -> some View {
@@ -330,35 +307,6 @@ private extension ContactDetailView {
             get: { contact.birthday ?? .now },
             set: { contact.birthday = $0 }
         )
-    }
-}
-
-/// A single editable email/phone row: a label picker plus its value.
-private struct ContactFieldRow: View {
-    @Bindable var field: ContactField
-
-    var body: some View {
-        HStack {
-            Picker("", selection: $field.label) {
-                ForEach(FieldLabel.allCases) { label in
-                    Text(label.title).tag(label)
-                }
-            }
-            .labelsHidden()
-            .fixedSize()
-            // labelsHidden strips the picker's visible label, but VoiceOver
-            // then only reads the current selection — confusing without
-            // context. Restore an explicit a11y label per kind.
-            .accessibilityLabel(field.kind == .email ? "Email label" : "Phone label")
-
-            TextField(placeholder, text: $field.value)
-                .textContentType(field.kind == .email ? .emailAddress : .telephoneNumber)
-                .accessibilityLabel(field.kind == .email ? "Email address" : "Phone number")
-        }
-    }
-
-    private var placeholder: String {
-        field.kind == .email ? "name@example.com" : "Phone"
     }
 }
 

--- a/ContactManager/Views/ContactFieldRow.swift
+++ b/ContactManager/Views/ContactFieldRow.swift
@@ -1,0 +1,39 @@
+//
+//  ContactFieldRow.swift
+//  ContactManager
+//
+//  A single editable email/phone row.
+//
+
+import SwiftUI
+
+struct ContactFieldRow: View {
+    @Bindable var field: ContactField
+
+    var body: some View {
+        HStack {
+            Picker("", selection: $field.label) {
+                ForEach(FieldLabel.allCases) { label in
+                    Text(label.title).tag(label)
+                }
+            }
+            .labelsHidden()
+            .fixedSize()
+            .accessibilityLabel(field.kind == .email ? "Email label" : "Phone label")
+            .accessibilityIdentifier(
+                field.kind == .email ? "contact-email-label-picker" : "contact-phone-label-picker"
+            )
+
+            TextField(placeholder, text: $field.value)
+                .textContentType(field.kind == .email ? .emailAddress : .telephoneNumber)
+                .accessibilityLabel(field.kind == .email ? "Email address" : "Phone number")
+                .accessibilityIdentifier(
+                    field.kind == .email ? "contact-email-value-field" : "contact-phone-value-field"
+                )
+        }
+    }
+
+    private var placeholder: String {
+        field.kind == .email ? "name@example.com" : "Phone"
+    }
+}

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -34,6 +34,7 @@ struct ContactListView: View {
                     ForEach(section.contacts) { contact in
                         ContactRow(contact: contact)
                             .tag(contact)
+                            .accessibilityIdentifier(contact.accessibilityRowIdentifier)
                             // Drag a row to Finder to write `<Name>.vcf`.
                             .draggable(transfer(for: contact))
                             .contextMenu { rowContextMenu(for: contact) }
@@ -49,6 +50,7 @@ struct ContactListView: View {
         )
         .animation(reduceMotion ? nil : .smooth, value: sortOrder)
         .searchable(text: $searchText, prompt: "Search Contacts")
+        .accessibilityIdentifier("contact-search")
         .searchFocused($searchFocused)
         // The Find menu command (⌘F) routes here to focus the search field.
         .onReceive(NotificationCenter.default.publisher(for: .focusSearchRequested)) { _ in
@@ -87,6 +89,7 @@ struct ContactListView: View {
                     Label("New Contact", systemImage: "plus")
                 }
                 .help("New Contact")
+                .accessibilityIdentifier("new-contact-button")
             }
         }
     }
@@ -133,6 +136,20 @@ struct ContactListView: View {
                 ContentUnavailableView.search(text: searchText)
             }
         }
+    }
+}
+
+private extension Contact {
+    var accessibilityRowIdentifier: String {
+        "contact-row-\((persistentModelID.storedString ?? fullName).normalizedIdentifier)"
+    }
+}
+
+private extension String {
+    var normalizedIdentifier: String {
+        lowercased()
+            .map { $0.isLetter || $0.isNumber ? String($0) : "-" }
+            .joined()
     }
 }
 

--- a/ContactManager/Views/ContentView+Import.swift
+++ b/ContactManager/Views/ContentView+Import.swift
@@ -5,8 +5,7 @@
 //  Import handlers (system Contacts, vCard file picker, vCard URL drops)
 //  factored out of `ContentView` so the main view stays focused on
 //  composition and state. Each handler runs the parse off the main
-//  actor and routes inserts through `ContactStore` so they participate
-//  in the existing Undo group.
+//  actor and presents a review step before `ContactStore` writes anything.
 //
 
 import Foundation
@@ -26,7 +25,7 @@ extension ContentView {
             importProgress = ImportProgress()
             defer { importProgress = nil }
             // Permission prompt + fetch + mapping all run off the main actor;
-            // only the final insert hops back here.
+            // only the final review presentation hops back here.
             let parsed: [ParsedContact]
             do {
                 parsed = try await Task.detached(priority: .userInitiated) {
@@ -40,21 +39,24 @@ extension ContentView {
                 errorMessage = "No contacts were found in your system Contacts."
                 return
             }
-            await insert(parsed)
+            presentImportReview(parsed)
         }
     }
 
-    // MARK: - Chunked insert + progress
-
-    /// Inserts parsed contacts a chunk at a time — one save (and undo step) per
-    /// chunk instead of one giant transaction — updating `importProgress` and
-    /// yielding between chunks so the overlay animates rather than freezing.
     @MainActor
-    func insert(_ parsed: [ParsedContact]) async {
-        importProgress = ImportProgress(done: 0, total: parsed.count)
+    func presentImportReview(_ parsed: [ParsedContact]) {
+        importProgress = nil
+        importReviewItems = ImportReview.makeItems(for: parsed, existing: contacts)
+        isReviewingImport = true
+    }
+
+    @MainActor
+    func applyImportReview(_ items: [ImportReviewItem]) async {
+        importProgress = ImportProgress(done: 0, total: items.count)
+        defer { importProgress = nil }
         do {
-            for chunk in parsed.chunked(into: 500) {
-                try store.importContacts(chunk)
+            for chunk in items.chunked(into: 500) {
+                try store.applyImportReview(chunk)
                 importProgress?.done += chunk.count
                 await Task.yield()
             }
@@ -87,7 +89,7 @@ extension ContentView {
                 errorMessage = "No contacts were found in that file."
                 return
             }
-            await insert(parsed)
+            presentImportReview(parsed)
         }
     }
 
@@ -129,7 +131,7 @@ extension ContentView {
                 case .parsed(let contacts) where contacts.isEmpty:
                     errorMessage = "No contacts were found in that file."
                 case .parsed(let contacts):
-                    await insert(contacts)
+                    presentImportReview(contacts)
                 }
             }
         }
@@ -160,7 +162,7 @@ extension ContentView {
                     errorMessage = "No contacts were found in that file."
                     return
                 }
-                await insert(parsed)
+                presentImportReview(parsed)
             }
         }
     }

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @Query(sort: [SortDescriptor(\Contact.lastName), SortDescriptor(\Contact.firstName)])
-    private var contacts: [Contact]
+    var contacts: [Contact]
 
     @Query(sort: \ContactGroup.name) private var groups: [ContactGroup]
 
@@ -47,6 +47,8 @@ struct ContentView: View {
     @State private var isExportingPDF = false
     @State private var pdfDocument = PDFExportDocument(data: Data())
     @State private var pdfFilename = "Contact"
+    @State var importReviewItems: [ImportReviewItem] = []
+    @State var isReviewingImport = false
 
     /// Internal so the import handlers in `ContentView+Import.swift` can
     /// reach the same store the main view uses.
@@ -346,6 +348,11 @@ private extension ContentView {
             ) { result in
                 if case .failure(let error) = result {
                     errorMessage = error.localizedDescription
+                }
+            }
+            .sheet(isPresented: $isReviewingImport) {
+                ImportReviewView(items: $importReviewItems) { items in
+                    Task { await applyImportReview(items) }
                 }
             }
             .alert(

--- a/ContactManager/Views/DuplicatesView.swift
+++ b/ContactManager/Views/DuplicatesView.swift
@@ -72,6 +72,7 @@ struct DuplicatesView: View {
                             Spacer()
                             Button("Merge") { merge(group.contacts) }
                                 .buttonStyle(.borderedProminent)
+                                .accessibilityIdentifier("merge-duplicates-button")
                                 .accessibilityLabel(
                                     Text("Merge ^[\(group.contacts.count) duplicate contact](inflect: true)")
                                 )

--- a/ContactManager/Views/ImportReviewView.swift
+++ b/ContactManager/Views/ImportReviewView.swift
@@ -1,0 +1,97 @@
+//
+//  ImportReviewView.swift
+//  ContactManager
+//
+//  Lets the user inspect parsed contacts before import and choose how each
+//  likely duplicate should be handled.
+//
+
+import SwiftUI
+
+struct ImportReviewView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var items: [ImportReviewItem]
+    var importAction: ([ImportReviewItem]) -> Void
+
+    private var importCount: Int {
+        items.filter { $0.decision != .skip }.count
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach($items) { $item in
+                    ImportReviewRow(item: $item)
+                }
+            }
+            .navigationTitle("Review Import")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(importButtonTitle) {
+                        let reviewed = items
+                        dismiss()
+                        importAction(reviewed)
+                    }
+                    .disabled(importCount == 0)
+                    .accessibilityIdentifier("confirm-reviewed-import-button")
+                }
+            }
+        }
+        .frame(minWidth: 560, minHeight: 420)
+    }
+
+    private var importButtonTitle: String {
+        importCount == 1 ? "Import 1 Contact" : "Import \(importCount) Contacts"
+    }
+}
+
+private struct ImportReviewRow: View {
+    @Binding var item: ImportReviewItem
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.displayName)
+                    .font(.headline)
+                if let subtitle = item.subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                if let matched = item.matchedContact {
+                    Text("Matches \(matched.fullName)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("New contact")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            Picker("Import Action", selection: $item.decision) {
+                ForEach(item.availableDecisions) { decision in
+                    Text(decision.title).tag(decision)
+                }
+            }
+            .labelsHidden()
+            .frame(width: 160)
+            .accessibilityIdentifier("import-review-action-picker")
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("import-review-row-\(item.displayName.normalizedIdentifier)")
+    }
+}
+
+private extension String {
+    var normalizedIdentifier: String {
+        lowercased()
+            .map { $0.isLetter || $0.isNumber ? String($0) : "-" }
+            .joined()
+    }
+}

--- a/ContactManager/Views/SidebarView.swift
+++ b/ContactManager/Views/SidebarView.swift
@@ -33,6 +33,7 @@ struct SidebarView: View {
                 Label("All Contacts", systemImage: "person.2.fill")
                     .badge(contactCount)
                     .tag(SidebarItem.allContacts)
+                    .accessibilityIdentifier("sidebar-all-contacts-row")
             }
 
             Section("Groups") {
@@ -45,6 +46,7 @@ struct SidebarView: View {
                         Label(group.displayName, systemImage: "folder")
                             .badge(group.contacts.count)
                             .tag(SidebarItem.group(group.persistentModelID))
+                            .accessibilityIdentifier("sidebar-group-row-\(group.displayName.normalizedIdentifier)")
                             .contextMenu {
                                 Button("Rename…") { beginRename(group) }
                                 Button("Delete", role: .destructive) { deleteGroup(group) }
@@ -77,6 +79,7 @@ struct SidebarView: View {
                     Label("New Group", systemImage: "folder.badge.plus")
                 }
                 .help("New Group")
+                .accessibilityIdentifier("new-group-button")
             }
         }
         .alert("Rename Group", isPresented: Binding(
@@ -95,5 +98,13 @@ struct SidebarView: View {
     private func beginRename(_ group: ContactGroup) {
         renameText = group.name
         renameTarget = group
+    }
+}
+
+private extension String {
+    var normalizedIdentifier: String {
+        lowercased()
+            .map { $0.isLetter || $0.isNumber ? String($0) : "-" }
+            .joined()
     }
 }

--- a/ContactManagerTests/ContactStorePendingEditTests.swift
+++ b/ContactManagerTests/ContactStorePendingEditTests.swift
@@ -1,0 +1,66 @@
+//
+//  ContactStorePendingEditTests.swift
+//  ContactManagerTests
+//
+//  Covers direct SwiftData form edits saved through ContactStore.
+//
+
+@testable import ContactManager
+import SwiftData
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct ContactStorePendingEditTests {
+    let container: ModelContainer
+    let store: ContactStore
+    var context: ModelContext { container.mainContext }
+
+    init() throws {
+        container = try ModelContainer(
+            for: Contact.self, ContactField.self, ContactGroup.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        store = ContactStore(container.mainContext)
+    }
+
+    private func allContacts() throws -> [Contact] {
+        try context.fetch(FetchDescriptor<Contact>())
+    }
+
+    @Test func scalarEditsPersistAndEmitTheContact() throws {
+        let contact = try store.createContact()
+        contact.firstName = "Ada"
+        contact.lastName = "Lovelace"
+
+        let change = try store.savePendingEdits(actionName: "Edit Contact")
+
+        let restored = try #require(try allContacts().first)
+        let id = try #require(restored.persistentModelID.storedString)
+        #expect(restored.fullName == "Ada Lovelace")
+        #expect(restored.initials == "AL")
+        #expect(change.updatedIDs == [id])
+        #expect(change.deletedIDs.isEmpty)
+    }
+
+    @Test func fieldEditsPersistAndEmitTheOwner() throws {
+        let contact = try store.createContact()
+        let email = try store.addField(.email, to: contact)
+        email.label = .work
+        email.value = "ada@analytical.engine"
+
+        let change = try store.savePendingEdits(actionName: "Edit Contact")
+
+        let id = try #require(contact.persistentModelID.storedString)
+        #expect(change.updatedIDs == [id])
+        #expect(contact.emails.first?.label == .work)
+        #expect(contact.primaryEmail == "ada@analytical.engine")
+    }
+
+    @Test func savePendingEditsIsANoOpWithoutChanges() throws {
+        _ = try store.createContact()
+        let change = try store.savePendingEdits(actionName: "Edit Contact")
+
+        #expect(change.isEmpty)
+    }
+}

--- a/ContactManagerTests/ContactStoreTests.swift
+++ b/ContactManagerTests/ContactStoreTests.swift
@@ -39,19 +39,6 @@ struct ContactStoreTests {
 
     // MARK: - Journey: create a contact and edit it
 
-    @Test func createContactThenEditPersists() throws {
-        let contact = try store.createContact()
-        #expect(try count(Contact.self) == 1)
-
-        contact.firstName = "Ada"
-        contact.lastName = "Lovelace"
-        try context.save()
-
-        let restored = try #require(try allContacts().first)
-        #expect(restored.fullName == "Ada Lovelace")
-        #expect(restored.initials == "AL")
-    }
-
     // MARK: - Journey: delete a contact (cascades to its fields)
 
     @Test func deleteContactCascadesToFields() throws {

--- a/ContactManagerTests/ImportReviewTests.swift
+++ b/ContactManagerTests/ImportReviewTests.swift
@@ -1,0 +1,118 @@
+//
+//  ImportReviewTests.swift
+//  ContactManagerTests
+//
+//  Tests the preflight review that keeps imports from blindly appending
+//  duplicates. The write path still goes through ContactStore, so decisions
+//  are saved, undoable, and indexed like other mutations.
+//
+
+@testable import ContactManager
+import SwiftData
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct ImportReviewTests {
+    let container: ModelContainer
+    let store: ContactStore
+    var context: ModelContext { container.mainContext }
+
+    init() throws {
+        container = try ModelContainer(
+            for: Contact.self, ContactField.self, ContactGroup.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        store = ContactStore(container.mainContext)
+    }
+
+    private func allContacts() throws -> [Contact] {
+        try context.fetch(FetchDescriptor<Contact>())
+    }
+
+    @Test func newContactsDefaultToAdd() throws {
+        let parsed = ParsedContact(firstName: "Ada", lastName: "Lovelace")
+
+        let item = try #require(ImportReview.makeItems(for: [parsed], existing: []).first)
+
+        #expect(item.decision == .add)
+        #expect(item.matchedContact == nil)
+    }
+
+    @Test func exactDuplicatesDefaultToSkip() throws {
+        let existing = try store.createContact()
+        existing.firstName = "Ada"
+        existing.lastName = "Lovelace"
+        try store.addField(.email, value: "ada@example.com", to: existing)
+        try context.save()
+        var parsed = ParsedContact(firstName: "Ada", lastName: "Lovelace")
+        parsed.emails = [(.home, "ADA@example.com")]
+
+        let item = try #require(ImportReview.makeItems(for: [parsed], existing: [existing]).first)
+
+        #expect(item.decision == .skip)
+        #expect(item.matchedContact?.persistentModelID == existing.persistentModelID)
+    }
+
+    @Test func partialMatchesDefaultToUpdateExisting() throws {
+        let existing = try store.createContact()
+        existing.firstName = "Ada"
+        existing.lastName = "Lovelace"
+        try store.addField(.email, value: "ada@example.com", to: existing)
+        try context.save()
+        var parsed = ParsedContact(firstName: "Ada", lastName: "Lovelace", company: "Analytical Engine Co.")
+        parsed.emails = [(.home, "ada@example.com")]
+        parsed.phones = [(.mobile, "+1 555 0100")]
+
+        let item = try #require(ImportReview.makeItems(for: [parsed], existing: [existing]).first)
+
+        #expect(item.decision == .updateExisting)
+    }
+
+    @Test func applyingReviewAddsUpdatesSkipsAndMerges() throws {
+        let exact = try store.createContact()
+        exact.firstName = "Ada"
+        exact.lastName = "Lovelace"
+        try store.addField(.email, value: "ada@example.com", to: exact)
+
+        let partial = try store.createContact()
+        partial.firstName = "Alan"
+        partial.lastName = "Turing"
+        try store.addField(.email, value: "alan@example.com", to: partial)
+
+        let conflicting = try store.createContact()
+        conflicting.firstName = "Grace"
+        conflicting.lastName = "Hopper"
+        conflicting.company = "Navy"
+        try store.addField(.email, value: "grace@example.com", to: conflicting)
+        try context.save()
+
+        var exactParsed = ParsedContact(firstName: "Ada", lastName: "Lovelace")
+        exactParsed.emails = [(.home, "ada@example.com")]
+        var partialParsed = ParsedContact(firstName: "Alan", lastName: "Turing", company: "Bletchley Park")
+        partialParsed.emails = [(.home, "alan@example.com")]
+        partialParsed.phones = [(.mobile, "555-0101")]
+        let newParsed = ParsedContact(firstName: "Katherine", lastName: "Johnson")
+        var conflictingParsed = ParsedContact(firstName: "Grace", lastName: "Hopper", company: "ACM")
+        conflictingParsed.emails = [(.home, "grace@example.com")]
+        conflictingParsed.phones = [(.work, "555-0102")]
+
+        var items = ImportReview.makeItems(
+            for: [exactParsed, partialParsed, newParsed, conflictingParsed],
+            existing: [exact, partial, conflicting]
+        )
+        items[3].decision = .merge
+
+        let applied = try store.applyImportReview(items)
+
+        #expect(applied.added == 1)
+        #expect(applied.updated == 1)
+        #expect(applied.merged == 1)
+        #expect(applied.skipped == 1)
+        #expect(try allContacts().count == 4)
+        #expect(partial.company == "Bletchley Park")
+        #expect(partial.phones.map(\.value) == ["555-0101"])
+        #expect(conflicting.company == "Navy")
+        #expect(conflicting.phones.map(\.value) == ["555-0102"])
+    }
+}

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -87,13 +87,31 @@ final class ContactManagerUITests: XCTestCase {
         )
     }
 
-    // Row-level and detail-field assertions (seeded contacts rendering, ⌘N
-    // opening the editor) need stable accessibilityIdentifiers to be reliable
-    // on macOS — the rows are single combined a11y elements and TextFields
-    // expose their prompt as a placeholder, not a queryable label. That's a
-    // deliberately deferred step (it'd mean adding identifiers across the
-    // views); these journeys are covered at the data layer by ContactStore /
-    // ContactQuery unit tests.
+    /// Verifies the core keyboard-first loop: create a contact, edit its name,
+    /// then find it through the list search field.
+    func test_createEditAndSearchContact() {
+        let app = bootSeededApp()
+        app.typeKey("n", modifierFlags: .command)
+
+        let firstName = app.textFields["contact-first-name-field"]
+        XCTAssertTrue(firstName.waitForExistence(timeout: 3))
+        firstName.typeText("Test")
+
+        let lastName = app.textFields["contact-last-name-field"]
+        XCTAssertTrue(lastName.waitForExistence(timeout: 3))
+        lastName.click()
+        lastName.typeText("Person")
+
+        app.typeKey("f", modifierFlags: .command)
+        let search = app.searchFields.firstMatch
+        XCTAssertTrue(search.waitForExistence(timeout: 3))
+        search.typeText("Test")
+
+        XCTAssertTrue(
+            app.staticTexts["Test Person"].waitForExistence(timeout: 3),
+            "Newly edited contact should be searchable in the list"
+        )
+    }
 
     // MARK: - Helpers
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ A `Makefile` wraps the common tasks (install tooling once with `make bootstrap`,
 | Format | `make format` (check only: `make format-check`) |
 | Pre-PR gate | `make check` (format-check + lint + unit tests) |
 
-Tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`); `make build`/`make test` disable code signing (compile + test gates — a signed build for distribution is done from Xcode), so they run identically locally and in CI. Linting and formatting are **SwiftLint** + **SwiftFormat**. CI (`.github/workflows/ci.yml`) runs two jobs on every PR: **Lint & Format** (`swiftformat --lint` + `swiftlint --strict`) and **Build & Test** (`make build` + `make test-unit` on a macOS 26 runner). The XCUITest smoke suite (`make test`) is run from Xcode, not CI. After CI passes on `main`, a **Release** workflow auto-bumps the version patch + build number, tags `v{version}`, and publishes a GitHub release with generated notes (bump the major/minor by hand when it's warranted). Contributor and agent conventions live in `CLAUDE.md`.
+Tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`); `make build`/`make test` disable code signing (compile + test gates — a signed build for distribution is done from Xcode), so they run identically locally and in CI. Linting and formatting are **SwiftLint** + **SwiftFormat**. CI (`.github/workflows/ci.yml`) runs two jobs on every PR: **Lint & Format** (`swiftformat --lint` + `swiftlint --strict`) and **Build & Test** (`make build` + `make test-unit` on a macOS 26 runner). The XCUITest smoke suite (`make test`) is run from Xcode, not CI. After CI passes on `main`, a **Release** workflow auto-bumps the version patch + build number, tags `v{version}`, and publishes a GitHub release with generated notes (bump the major/minor by hand when it's warranted). Contributor and agent conventions live in `AGENTS.md`.
 
 ### Building & Running
 
@@ -152,3 +152,11 @@ thing to try.
 > container). **Don't commit that change** — it's what would block anyone who
 > clones without your container. Your `DeveloperSettings.xcconfig` from step 2 is
 > already gitignored.
+
+### App Store privacy readiness
+
+The app includes `ContactManager/PrivacyInfo.xcprivacy`, currently declaring
+UserDefaults access for app preferences such as sort order and default group.
+Before TestFlight or App Store submission, keep that manifest aligned with any
+new required-reason APIs and complete App Store Connect's privacy details,
+including the privacy policy URL and any collected-data disclosures.


### PR DESCRIPTION
## Summary
Adds reviewed import decisions and durable inline edit persistence so contact changes flow through explicit store saves, rollback handling, undo naming, and Spotlight delta notifications.

## Changes
- Add `ContactStore.savePendingEdits(actionName:)` and snapshot-based contact change resolution for direct SwiftUI edits.
- Debounce detail-editor edits and flush on disappear/contact switch for scalar, birthday, email, and phone changes.
- Add import review models and UI for Add, Merge, Update Existing, and Skip before parsed contacts are written.
- Add reviewed import application through `ContactStore`, preserving chunked progress and undoable batch writes.
- Add App Store privacy manifest metadata for UserDefaults required-reason API use.
- Add stable accessibility identifiers for sidebar/list/search/editor/import/duplicate flows.
- Track `AGENTS.md` and update contributor docs to point at it.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - `make format-check`
  - `swiftlint lint --quiet --strict`
  - `xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO build`
  - `xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerTests`
  - `xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerUITests`

## Screenshots (if applicable)
N/A

## Related Issues
Closes #
