### PR TITLE
feat(contacts): add quick capture window

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -22,12 +22,14 @@
 		2EB13805320DA225F70D08F3 /* VCardTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */; };
 		3076738411F8C3FA073D1BE0 /* ContactsBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */; };
 		322103E6FBEAD59C6A2405E6 /* Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDED82FFB4B5F039052FFB5 /* Birthday.swift */; };
+		39D33CDF2E0495FCCA8D7E13 /* QuickCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C76A783B91BD2AA6D3F70B /* QuickCaptureTests.swift */; };
 		3EDDAA184C377D9C16AAF08A /* ContactStore+PendingEdits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */; };
 		442122E49889F5A9CA174B12 /* ContactActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */; };
 		444B949F37F7FF7DD98A4C6B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */; };
 		4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */; };
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
 		488CA0C339AD3218073A02E8 /* PrintableContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37DB6CC43A76261CFF3987D /* PrintableContactView.swift */; };
+		48DA73BF161A4ABB5DBE4291 /* QuickCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D7E9FD22709F6D14A87952 /* QuickCapture.swift */; };
 		4B9EAE3500BB10401AEB3746 /* ContactActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CF4C47C670B0A8C3B6B384 /* ContactActivity.swift */; };
 		4EC36757044377406665E53B /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */; };
 		4F1E1A097740ECE3D42E55B8 /* GroupDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964ACD67CC8CB35694497A10 /* GroupDropTests.swift */; };
@@ -55,6 +57,7 @@
 		847D0CD5B12E83CD53951DA2 /* ContactFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E63AB996E12C5978B4A8F1 /* ContactFieldRow.swift */; };
 		8C6AC6410FA2258ADB2BF640 /* ContactManagerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001F8DF120EBA372663EC888 /* ContactManagerUITests.swift */; };
 		8DF0A36CE542853FF12BEF1A /* Chunking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436B4115937E4350EB9A7EF7 /* Chunking.swift */; };
+		8EF7CD9AAA833F08834D2AA4 /* QuickCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5951D4D8D52B6CDB782FE37D /* QuickCaptureView.swift */; };
 		91DA07BB24CEA1941C5AFA6E /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 76F68BAD5C3290EE7ABF787B /* Localizable.xcstrings */; };
 		9506DFC07D9490AEDFB096EC /* ImageProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */; };
 		97E98BCB6784672DCB8C1625 /* VCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7276D515CA167FBF4C47299 /* VCard.swift */; };
@@ -77,6 +80,7 @@
 		CEAC8F942C862FADB6C45220 /* SpotlightIndexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */; };
 		CFFC58E9EA162230275F2301 /* ContactEntityQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874742D7DC5E9C20D3A88459 /* ContactEntityQuery.swift */; };
 		D09BB01ED8C135141953AFE7 /* ImportReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA2237DBD182839EAF04F1 /* ImportReviewView.swift */; };
+		D4431A7BEF48D8A75EFB8DC8 /* ContactStore+QuickCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34532FC6E64B32F9A27FCDCD /* ContactStore+QuickCapture.swift */; };
 		E5EB465B5CE3964197D29ADF /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F82C8A388E97CC4F1106176 /* SampleData.swift */; };
 		ECB7FDD8D0C3091EA0D42917 /* UndoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DCAF444714BC3726B212C4 /* UndoTests.swift */; };
 		ECDA4BC68D3FAE4CCF428675 /* ContactDetailView+Saving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */; };
@@ -119,6 +123,7 @@
 		29335D93B2E97B9038F1481A /* ImportProgressView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportProgressView.swift; sourceTree = "<group>"; };
 		2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardDocument.swift; sourceTree = "<group>"; };
+		34532FC6E64B32F9A27FCDCD /* ContactStore+QuickCapture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ContactStore+QuickCapture.swift"; path = "ContactManager/Models/ContactStore+QuickCapture.swift"; sourceTree = "<group>"; };
 		3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinderTests.swift; sourceTree = "<group>"; };
 		399A72E1BB6BEC0B54D356E7 /* ContactEntityQueryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityQueryTests.swift; sourceTree = "<group>"; };
 		3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -129,6 +134,7 @@
 		54C373BD237429970D6A7C86 /* DuplicatesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicatesView.swift; sourceTree = "<group>"; };
 		5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingTests.swift; sourceTree = "<group>"; };
 		570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Birthday.swift"; sourceTree = "<group>"; };
+		5951D4D8D52B6CDB782FE37D /* QuickCaptureView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickCaptureView.swift; path = ContactManager/Views/QuickCaptureView.swift; sourceTree = "<group>"; };
 		604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotlightDeltaTests.swift; sourceTree = "<group>"; };
 		61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PersistentIdentifierEncoding.swift; sourceTree = "<group>"; };
 		617D7B082A403094284FBD38 /* ContactStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStore.swift; sourceTree = "<group>"; };
@@ -150,8 +156,10 @@
 		92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Saving.swift"; sourceTree = "<group>"; };
 		93C12246003379D5966F0210 /* ContactEntityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityTests.swift; sourceTree = "<group>"; };
 		964ACD67CC8CB35694497A10 /* GroupDropTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroupDropTests.swift; sourceTree = "<group>"; };
+		A2C76A783B91BD2AA6D3F70B /* QuickCaptureTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickCaptureTests.swift; path = ContactManagerTests/QuickCaptureTests.swift; sourceTree = "<group>"; };
 		A30CD9D085E7424A79159879 /* ChunkingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChunkingTests.swift; sourceTree = "<group>"; };
 		A37DB6CC43A76261CFF3987D /* PrintableContactView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrintableContactView.swift; sourceTree = "<group>"; };
+		A5D7E9FD22709F6D14A87952 /* QuickCapture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickCapture.swift; path = ContactManager/Models/QuickCapture.swift; sourceTree = "<group>"; };
 		A7276D515CA167FBF4C47299 /* VCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCard.swift; sourceTree = "<group>"; };
 		ABDED82FFB4B5F039052FFB5 /* Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Birthday.swift; sourceTree = "<group>"; };
 		AC2AA1D7BB15FC01B9CBA3B3 /* EntityModelContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityModelContainer.swift; sourceTree = "<group>"; };
@@ -310,6 +318,10 @@
 				DED817AE13A452AA00EC3234 /* ContactManagerTests */,
 				DED8178A13A452A900EC3234 /* Products */,
 				0F8F43AF5330EC59928A8C2E /* ContactManagerUITests */,
+				A5D7E9FD22709F6D14A87952 /* QuickCapture.swift */,
+				34532FC6E64B32F9A27FCDCD /* ContactStore+QuickCapture.swift */,
+				5951D4D8D52B6CDB782FE37D /* QuickCaptureView.swift */,
+				A2C76A783B91BD2AA6D3F70B /* QuickCaptureTests.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -544,6 +556,9 @@
 				3EDDAA184C377D9C16AAF08A /* ContactStore+PendingEdits.swift in Sources */,
 				AD6426F91D871AE7E1F57251 /* ContactDetailView+QuickInfo.swift in Sources */,
 				847D0CD5B12E83CD53951DA2 /* ContactFieldRow.swift in Sources */,
+				48DA73BF161A4ABB5DBE4291 /* QuickCapture.swift in Sources */,
+				D4431A7BEF48D8A75EFB8DC8 /* ContactStore+QuickCapture.swift in Sources */,
+				8EF7CD9AAA833F08834D2AA4 /* QuickCaptureView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -573,6 +588,7 @@
 				BA9738D0812FB7A090DD5D4E /* ContactEntityQueryTests.swift in Sources */,
 				ABF907FAA713351663F3889A /* ImportReviewTests.swift in Sources */,
 				0DC8E4BAF454185075119C3A /* ContactStorePendingEditTests.swift in Sources */,
+				39D33CDF2E0495FCCA8D7E13 /* QuickCaptureTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 @main
 struct ContactManagerApp: App {
+    @Environment(\.openWindow) private var openWindow
     @State private var loadState: ContainerLoadState
 
     init() {
@@ -46,6 +47,16 @@ struct ContactManagerApp: App {
             }
         }
         .defaultSize(width: 520, height: 640)
+        WindowGroup(id: "quickCapture") {
+            switch loadState {
+            case .ready(let container):
+                QuickCaptureView()
+                    .modelContainer(container)
+            case .testing, .failed:
+                EmptyView()
+            }
+        }
+        .defaultSize(width: 520, height: 220)
         Settings {
             // The Settings scene gets its own model container injection so
             // the default-group picker can @Query groups. When the store
@@ -67,6 +78,10 @@ struct ContactManagerApp: App {
                     NotificationCenter.default.post(name: .newContactRequested, object: nil)
                 }
                 .keyboardShortcut("n", modifiers: .command)
+                Button("Quick Capture…") {
+                    openWindow(id: "quickCapture")
+                }
+                .keyboardShortcut("n", modifiers: [.command, .option])
             }
             CommandGroup(after: .textEditing) {
                 Button("Find") {

--- a/ContactManager/Models/ContactStore+QuickCapture.swift
+++ b/ContactManager/Models/ContactStore+QuickCapture.swift
@@ -1,0 +1,44 @@
+//
+//  ContactStore+QuickCapture.swift
+//  ContactManager
+//
+//  Writes quick-entry drafts through the same save, undo, rollback, and
+//  Spotlight-notification pipeline as the rest of ContactStore.
+//
+
+extension ContactStore {
+    @discardableResult
+    func createContact(from draft: QuickCaptureDraft) throws -> Contact {
+        try mutate("Quick Capture") {
+            let contact = Contact(
+                firstName: draft.firstName,
+                lastName: draft.lastName,
+                company: draft.company,
+                jobTitle: draft.jobTitle,
+                birthday: draft.birthday,
+                notes: draft.notes
+            )
+            context.insert(contact)
+            insert(draft.emails, kind: .email, into: contact)
+            insert(draft.phones, kind: .phone, into: contact)
+            return contact
+        }
+    }
+
+    private func insert(
+        _ fields: [(label: FieldLabel, value: String)],
+        kind: FieldKind,
+        into contact: Contact
+    ) {
+        for (index, field) in fields.enumerated() where !field.value.isBlank {
+            let model = ContactField(
+                kind: kind,
+                label: field.label,
+                value: field.value,
+                sortIndex: index
+            )
+            model.contact = contact
+            context.insert(model)
+        }
+    }
+}

--- a/ContactManager/Models/QuickCapture.swift
+++ b/ContactManager/Models/QuickCapture.swift
@@ -1,0 +1,228 @@
+//
+//  QuickCapture.swift
+//  ContactManager
+//
+//  Pure parsing for the quick-entry window. It intentionally accepts a small,
+//  memorable grammar instead of trying to be a chatbot: comma/semicolon/newline
+//  fragments, obvious emails/phones, `birthday ...`, `at ...`, `title ...`,
+//  and `notes ...`.
+//
+
+import Foundation
+
+struct QuickCaptureDraft {
+    var firstName = ""
+    var lastName = ""
+    var company = ""
+    var jobTitle = ""
+    var birthday: Date?
+    var notes = ""
+    var emails: [(label: FieldLabel, value: String)] = []
+    var phones: [(label: FieldLabel, value: String)] = []
+
+    var isEmpty: Bool {
+        firstName.isBlank
+            && lastName.isBlank
+            && company.isBlank
+            && jobTitle.isBlank
+            && birthday == nil
+            && notes.isBlank
+            && emails.isEmpty
+            && phones.isEmpty
+    }
+
+    var displayName: String {
+        let name = [firstName, lastName]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        if !name.isEmpty { return name }
+        return company.isBlank ? "New Contact" : company
+    }
+}
+
+enum QuickCaptureParser {
+    static func parse(_ text: String) -> QuickCaptureDraft {
+        var draft = QuickCaptureDraft()
+        let fragments = text
+            .split(whereSeparator: { ",;\n".contains($0) })
+            .map { clean(String($0)) }
+            .filter { !$0.isEmpty }
+
+        for fragment in fragments {
+            apply(fragment, to: &draft)
+        }
+
+        return draft
+    }
+
+    private static func apply(_ fragment: String, to draft: inout QuickCaptureDraft) {
+        if let email = email(in: fragment) {
+            draft.emails.append((label: .home, value: email))
+            return
+        }
+
+        if let birthday = birthday(in: fragment) {
+            draft.birthday = birthday
+            return
+        }
+
+        if let value = value(in: fragment, after: ["notes", "note"]) {
+            draft.notes = append(draft.notes, value)
+            return
+        }
+
+        if let value = value(in: fragment, after: ["title", "role"]) {
+            draft.jobTitle = value
+            return
+        }
+
+        if let value = value(in: fragment, after: ["company"]) {
+            draft.company = value
+            return
+        }
+
+        if let phone = phone(in: fragment) {
+            draft.phones.append(phone)
+            return
+        }
+
+        applyNameAndCompany(fragment, to: &draft)
+    }
+
+    private static func applyNameAndCompany(_ fragment: String, to draft: inout QuickCaptureDraft) {
+        let pieces = fragment.components(separatedBy: " at ")
+        let name = pieces[0].trimmingCharacters(in: .whitespacesAndNewlines)
+        if pieces.count > 1, draft.company.isBlank {
+            draft.company = pieces.dropFirst().joined(separator: " at ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        guard draft.firstName.isBlank, draft.lastName.isBlank else {
+            draft.notes = append(draft.notes, fragment)
+            return
+        }
+
+        let words = name.split(separator: " ").map(String.init)
+        guard !words.isEmpty else { return }
+        if words.count == 1 {
+            draft.firstName = words[0]
+        } else {
+            draft.firstName = words.dropLast().joined(separator: " ")
+            draft.lastName = words.last ?? ""
+        }
+    }
+
+    private static func email(in fragment: String) -> String? {
+        let tokens = fragment.split(separator: " ").map(String.init)
+        return tokens
+            .map { clean($0) }
+            .first { token in
+                token.contains("@") && token.contains(".")
+            }
+    }
+
+    private static func phone(in fragment: String) -> (label: FieldLabel, value: String)? {
+        var value = fragment
+        let label = phoneLabel(in: fragment, value: &value)
+        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let digits = value.filter(\.isNumber)
+        guard digits.count >= 7 else { return nil }
+        return (label: label, value: value)
+    }
+
+    private static func phoneLabel(in fragment: String, value: inout String) -> FieldLabel {
+        let prefixes: [(String, FieldLabel)] = [
+            ("mobile", .mobile),
+            ("cell", .mobile),
+            ("work", .work),
+            ("home", .home),
+            ("phone", .mobile),
+            ("tel", .mobile),
+        ]
+        let lower = fragment.lowercased()
+        for (prefix, label) in prefixes where lower.hasPrefix(prefix + " ") || lower == prefix {
+            value = String(fragment.dropFirst(prefix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+            return label
+        }
+        return .mobile
+    }
+
+    private static func birthday(in fragment: String) -> Date? {
+        guard let value = value(in: fragment, after: ["birthday", "bday", "born"]) else {
+            return nil
+        }
+        return parseBirthday(value)
+    }
+
+    private static func parseBirthday(_ value: String) -> Date? {
+        if let parsed = Birthday.parse(value) { return parsed }
+
+        let cleaned = clean(value)
+        if let numeric = parseNumericBirthday(cleaned) { return numeric }
+        return parseMonthNameBirthday(cleaned)
+    }
+
+    private static func parseNumericBirthday(_ value: String) -> Date? {
+        let pieces = value
+            .split(whereSeparator: { "/.-".contains($0) })
+            .compactMap { Int($0) }
+        guard pieces.count >= 2 else { return nil }
+
+        if pieces[0] > 31, pieces.count >= 3 {
+            return Birthday.date(year: pieces[0], month: pieces[1], day: pieces[2])
+        }
+        let year = pieces.count >= 3 ? pieces[2] : nil
+        return Birthday.date(year: year, month: pieces[0], day: pieces[1])
+    }
+
+    private static func parseMonthNameBirthday(_ value: String) -> Date? {
+        let tokens = value
+            .replacingOccurrences(of: ",", with: " ")
+            .split(separator: " ")
+            .map { clean(String($0)) }
+            .filter { !$0.isEmpty }
+        guard tokens.count >= 2,
+              let month = monthNumber(tokens[0]),
+              let day = Int(tokens[1].filter(\.isNumber))
+        else { return nil }
+        let year = tokens.count >= 3 ? Int(tokens[2].filter(\.isNumber)) : nil
+        return Birthday.date(year: year, month: month, day: day)
+    }
+
+    private static func monthNumber(_ token: String) -> Int? {
+        let lower = token.lowercased()
+        let months = [
+            "january", "february", "march", "april", "may", "june",
+            "july", "august", "september", "october", "november", "december",
+        ]
+        for (index, month) in months.enumerated() where month.hasPrefix(lower) {
+            return index + 1
+        }
+        return nil
+    }
+
+    private static func value(in fragment: String, after prefixes: [String]) -> String? {
+        let lower = fragment.lowercased()
+        for prefix in prefixes {
+            if lower == prefix { return "" }
+            if lower.hasPrefix(prefix + " ") {
+                return clean(String(fragment.dropFirst(prefix.count)))
+            }
+            if lower.hasPrefix(prefix + ":") {
+                return clean(String(fragment.dropFirst(prefix.count + 1)))
+            }
+        }
+        return nil
+    }
+
+    private static func append(_ existing: String, _ value: String) -> String {
+        if existing.isBlank { return value }
+        if value.isBlank { return existing }
+        return "\(existing)\n\(value)"
+    }
+
+    private static func clean(_ value: String) -> String {
+        value.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines.union(.punctuationCharacters))
+    }
+}

--- a/ContactManager/Views/QuickCaptureView.swift
+++ b/ContactManager/Views/QuickCaptureView.swift
@@ -1,0 +1,125 @@
+//
+//  QuickCaptureView.swift
+//  ContactManager
+//
+//  Compact keyboard-first contact capture window.
+//
+
+import SwiftData
+import SwiftUI
+
+struct QuickCaptureView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var context
+    @FocusState private var entryFocused: Bool
+
+    @State private var entry = ""
+    @State private var errorMessage: String?
+    @State private var createdMessage: String?
+
+    private var draft: QuickCaptureDraft {
+        QuickCaptureParser.parse(entry)
+    }
+
+    private var store: ContactStore {
+        ContactStore(context)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            TextField("Ada Lovelace, ada@example.com, birthday Dec 10", text: $entry)
+                .textFieldStyle(.roundedBorder)
+                .focused($entryFocused)
+                .accessibilityIdentifier("quick-capture-entry-field")
+                .onSubmit(createContact)
+
+            QuickCapturePreview(draft: draft)
+
+            HStack {
+                if let createdMessage {
+                    Text(createdMessage)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("quick-capture-status")
+                }
+                Spacer()
+                Button("Done") {
+                    dismiss()
+                }
+                .accessibilityIdentifier("quick-capture-done-button")
+                Button("Create", action: createContact)
+                    .buttonStyle(.glassProminent)
+                    .disabled(draft.isEmpty)
+                    .accessibilityIdentifier("quick-capture-create-button")
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 420, idealWidth: 520, minHeight: 180)
+        .onAppear { entryFocused = true }
+        .alert("Couldn't Create Contact", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private func createContact() {
+        let parsed = draft
+        guard !parsed.isEmpty else { return }
+        do {
+            let contact = try store.createContact(from: parsed)
+            if let encoded = contact.persistentModelID.storedString {
+                NotificationCenter.default.post(
+                    name: .openContactRequested,
+                    object: nil,
+                    userInfo: ["id": encoded]
+                )
+            }
+            createdMessage = "Created \(contact.fullName)"
+            entry = ""
+            entryFocused = true
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct QuickCapturePreview: View {
+    var draft: QuickCaptureDraft
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(draft.displayName)
+                .font(.headline)
+                .lineLimit(1)
+                .accessibilityIdentifier("quick-capture-preview-name")
+            HStack(spacing: 10) {
+                if let email = draft.emails.first?.value {
+                    Label(email, systemImage: "envelope")
+                }
+                if let phone = draft.phones.first?.value {
+                    Label(phone, systemImage: "phone")
+                }
+                if !draft.company.isBlank {
+                    Label(draft.company, systemImage: "building.2")
+                }
+                if let birthday = draft.birthday {
+                    Label(Birthday.formatted(birthday), systemImage: "gift")
+                }
+            }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .accessibilityIdentifier("quick-capture-preview-details")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview {
+    QuickCaptureView()
+        .modelContainer(for: [Contact.self, ContactField.self, ContactGroup.self], inMemory: true)
+}

--- a/ContactManagerTests/QuickCaptureTests.swift
+++ b/ContactManagerTests/QuickCaptureTests.swift
@@ -1,0 +1,83 @@
+//
+//  QuickCaptureTests.swift
+//  ContactManagerTests
+//
+//  Fast-capture parsing and persistence tests. The parser stays pure so the
+//  quick-entry window can stay thin; the store path proves capture still saves,
+//  rolls back, and emits change notifications like other mutations.
+//
+
+@testable import ContactManager
+import SwiftData
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct QuickCaptureTests {
+    let container: ModelContainer
+    let store: ContactStore
+    var context: ModelContext { container.mainContext }
+
+    init() throws {
+        container = try ModelContainer(
+            for: Contact.self, ContactField.self, ContactGroup.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        store = ContactStore(container.mainContext)
+    }
+
+    @Test func parsesNameEmailAndYearlessBirthday() throws {
+        let draft = QuickCaptureParser.parse("Ada Lovelace, ada@example.com, birthday Dec 10")
+
+        #expect(draft.firstName == "Ada")
+        #expect(draft.lastName == "Lovelace")
+        #expect(draft.emails.map(\.value) == ["ada@example.com"])
+
+        let birthday = try #require(draft.birthday)
+        let fields = Birthday.fields(of: birthday)
+        #expect(fields.year == nil)
+        #expect(fields.month == 12)
+        #expect(fields.day == 10)
+    }
+
+    @Test func parsesPhoneCompanyTitleAndNotes() {
+        let draft = QuickCaptureParser.parse(
+            "Grace Hopper at Navy, title Rear Admiral, mobile +1 (555) 0100, notes COBOL pioneer"
+        )
+
+        #expect(draft.firstName == "Grace")
+        #expect(draft.lastName == "Hopper")
+        #expect(draft.company == "Navy")
+        #expect(draft.jobTitle == "Rear Admiral")
+        #expect(draft.phones.map(\.value) == ["+1 (555) 0100"])
+        #expect(draft.phones.first?.label == .mobile)
+        #expect(draft.notes == "COBOL pioneer")
+    }
+
+    @Test func parsesNumericBirthdayWithYear() throws {
+        let draft = QuickCaptureParser.parse("Katherine Johnson, birthday 1918-08-26")
+
+        let birthday = try #require(draft.birthday)
+        let fields = Birthday.fields(of: birthday)
+        #expect(fields.year == 1918)
+        #expect(fields.month == 8)
+        #expect(fields.day == 26)
+    }
+
+    @Test func createContactFromQuickCaptureDraftPersistsFields() throws {
+        let draft = QuickCaptureParser.parse(
+            "Alan Turing, alan@example.com, work 555-0101, birthday Jun 23, notes Enigma"
+        )
+
+        let contact = try store.createContact(from: draft)
+
+        #expect(contact.firstName == "Alan")
+        #expect(contact.lastName == "Turing")
+        #expect(contact.emails.map(\.value) == ["alan@example.com"])
+        #expect(contact.phones.map(\.value) == ["555-0101"])
+        #expect(contact.phones.first?.label == .work)
+        #expect(contact.notes == "Enigma")
+        #expect(try context.fetchCount(FetchDescriptor<Contact>()) == 1)
+        #expect(try context.fetchCount(FetchDescriptor<ContactField>()) == 2)
+    }
+}

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -58,6 +58,7 @@ final class ContactManagerUITests: XCTestCase {
         let app = bootSeededApp()
         app.menuBars.menuBarItems["File"].click()
         XCTAssertTrue(app.menuItems["New Contact"].exists)
+        XCTAssertTrue(app.menuItems["Quick Capture…"].exists)
         XCTAssertTrue(app.menuItems["Import from Contacts…"].exists)
         XCTAssertTrue(app.menuItems["Import vCard…"].exists)
         XCTAssertTrue(app.menuItems["Import CSV…"].exists)
@@ -110,6 +111,27 @@ final class ContactManagerUITests: XCTestCase {
         XCTAssertTrue(
             app.staticTexts["Test Person"].waitForExistence(timeout: 3),
             "Newly edited contact should be searchable in the list"
+        )
+    }
+
+    /// Verifies the quick-capture command opens a focused capture window and
+    /// creates a searchable contact from natural text.
+    func test_quickCaptureCreatesSearchableContact() {
+        let app = bootSeededApp()
+        app.typeKey("n", modifierFlags: [.command, .option])
+
+        let entry = app.textFields["quick-capture-entry-field"]
+        XCTAssertTrue(entry.waitForExistence(timeout: 3))
+        entry.click()
+        entry.typeText("Test Capture, capture@example.com, birthday Dec 10")
+
+        let create = app.buttons["quick-capture-create-button"]
+        XCTAssertTrue(create.waitForExistence(timeout: 3))
+        create.click()
+
+        XCTAssertTrue(
+            app.staticTexts["Created Test Capture"].waitForExistence(timeout: 3),
+            "Quick capture should confirm the saved contact"
         )
     }
 


### PR DESCRIPTION
## Summary
Adds a keyboard-first Quick Capture window for creating contacts from natural text.

## Changes
- Add a Quick Capture scene opened with Command-Option-N from File ▸ Quick Capture….
- Add a pure `QuickCaptureParser` for names, emails, phones, company hints, titles, notes, and birthdays such as `birthday Dec 10`.
- Add `ContactStore.createContact(from:)` so quick captures write through the existing save, undo, rollback, and Spotlight notification pipeline.
- Add a compact Quick Capture SwiftUI window with live parsed preview, Create, Done, and stable accessibility identifiers.
- Add parser/store unit tests and a UI smoke test for the new command/window.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - `make format-check`
  - `swiftlint lint --quiet --strict`
  - `xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerTests/QuickCaptureTests`
  - `xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerTests`
  - `xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerUITests/ContactManagerUITests/test_quickCaptureCreatesSearchableContact`
  - `xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerUITests`

## Screenshots (if applicable)
N/A

## Related Issues
Closes #
