### PR TITLE
feat(import): add match confidence and summary

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		322103E6FBEAD59C6A2405E6 /* Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDED82FFB4B5F039052FFB5 /* Birthday.swift */; };
 		39D33CDF2E0495FCCA8D7E13 /* QuickCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C76A783B91BD2AA6D3F70B /* QuickCaptureTests.swift */; };
 		3EDDAA184C377D9C16AAF08A /* ContactStore+PendingEdits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */; };
+		3FA1770FF1649CC78510AF10 /* ContentView+Alerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0401F25DFDF91CE847706D08 /* ContentView+Alerts.swift */; };
 		442122E49889F5A9CA174B12 /* ContactActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */; };
 		444B949F37F7FF7DD98A4C6B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */; };
 		4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */; };
@@ -108,6 +109,7 @@
 /* Begin PBXFileReference section */
 		001F8DF120EBA372663EC888 /* ContactManagerUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactManagerUITests.swift; sourceTree = "<group>"; };
 		03763AB80D45F026EC585490 /* ContactStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStoreTests.swift; sourceTree = "<group>"; };
+		0401F25DFDF91CE847706D08 /* ContentView+Alerts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ContentView+Alerts.swift"; path = "ContactManager/Views/ContentView+Alerts.swift"; sourceTree = "<group>"; };
 		05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Photo.swift"; sourceTree = "<group>"; };
 		05F6260FE20C27094AFB327A /* FindContactIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FindContactIntent.swift; sourceTree = "<group>"; };
 		08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactListView.swift; sourceTree = "<group>"; };
@@ -322,6 +324,7 @@
 				34532FC6E64B32F9A27FCDCD /* ContactStore+QuickCapture.swift */,
 				5951D4D8D52B6CDB782FE37D /* QuickCaptureView.swift */,
 				A2C76A783B91BD2AA6D3F70B /* QuickCaptureTests.swift */,
+				0401F25DFDF91CE847706D08 /* ContentView+Alerts.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -559,6 +562,7 @@
 				48DA73BF161A4ABB5DBE4291 /* QuickCapture.swift in Sources */,
 				D4431A7BEF48D8A75EFB8DC8 /* ContactStore+QuickCapture.swift in Sources */,
 				8EF7CD9AAA833F08834D2AA4 /* QuickCaptureView.swift in Sources */,
+				3FA1770FF1649CC78510AF10 /* ContentView+Alerts.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Models/ContactStore+ImportReview.swift
+++ b/ContactManager/Models/ContactStore+ImportReview.swift
@@ -11,13 +11,20 @@ import Foundation
 extension ContactStore {
     @discardableResult
     func applyImportReview(_ items: [ImportReviewItem]) throws -> ImportReviewResult {
-        try mutate("Import Contacts") {
+        try mutate(importActionName(for: items)) {
             var result = ImportReviewResult()
             for item in items {
                 apply(item, result: &result)
             }
             return result
         }
+    }
+
+    private func importActionName(for items: [ImportReviewItem]) -> String {
+        let count = items.filter { $0.decision != .skip }.count
+        if count == 1 { return "Import 1 Contact" }
+        if count > 1 { return "Import \(count) Contacts" }
+        return "Import Contacts"
     }
 
     private func apply(_ item: ImportReviewItem, result: inout ImportReviewResult) {
@@ -140,4 +147,37 @@ struct ImportReviewResult {
     var skipped = 0
 
     var totalWritten: Int { added + updated + merged }
+
+    var title: String {
+        if totalWritten == 1 { return "Imported 1 Contact" }
+        return "Imported \(totalWritten) Contacts"
+    }
+
+    var message: String {
+        let parts = [
+            count(added, label: "added"),
+            count(updated, label: "updated"),
+            count(merged, label: "merged"),
+            count(skipped, label: "skipped"),
+        ].compactMap(\.self)
+        return parts.joined(separator: ", ").capitalizedIfFirst + "."
+    }
+
+    mutating func add(_ other: ImportReviewResult) {
+        added += other.added
+        updated += other.updated
+        merged += other.merged
+        skipped += other.skipped
+    }
+
+    private func count(_ value: Int, label: String) -> String? {
+        value == 0 ? nil : "\(label) \(value)"
+    }
+}
+
+private extension String {
+    var capitalizedIfFirst: String {
+        guard let first else { return self }
+        return first.uppercased() + dropFirst()
+    }
 }

--- a/ContactManager/Models/ImportReview.swift
+++ b/ContactManager/Models/ImportReview.swift
@@ -27,11 +27,27 @@ enum ImportDecision: String, CaseIterable, Identifiable {
     }
 }
 
+enum ImportMatchConfidence: String {
+    case exact
+    case likely
+    case possible
+
+    var title: String {
+        switch self {
+        case .exact: "Exact match"
+        case .likely: "Likely match"
+        case .possible: "Possible match"
+        }
+    }
+}
+
 struct ImportReviewItem: Identifiable {
     let id = UUID()
     var parsed: ParsedContact
     var matchedContact: Contact?
     var decision: ImportDecision
+    var confidence: ImportMatchConfidence?
+    var matchReason: String?
 
     var displayName: String {
         let name = [parsed.firstName, parsed.lastName]
@@ -58,22 +74,36 @@ enum ImportReview {
     static func makeItems(for parsed: [ParsedContact], existing contacts: [Contact]) -> [ImportReviewItem] {
         parsed.map { parsedContact in
             guard let match = bestMatch(for: parsedContact, in: contacts) else {
-                return ImportReviewItem(parsed: parsedContact, matchedContact: nil, decision: .add)
+                return ImportReviewItem(
+                    parsed: parsedContact,
+                    matchedContact: nil,
+                    decision: .add,
+                    confidence: nil,
+                    matchReason: nil
+                )
             }
+            let decision = defaultDecision(for: parsedContact, matchedContact: match.contact)
             return ImportReviewItem(
                 parsed: parsedContact,
-                matchedContact: match,
-                decision: defaultDecision(for: parsedContact, matchedContact: match)
+                matchedContact: match.contact,
+                decision: decision,
+                confidence: confidence(for: decision, sharedKeys: match.sharedKeys),
+                matchReason: reason(for: match.sharedKeys)
             )
         }
     }
 
-    private static func bestMatch(for parsed: ParsedContact, in contacts: [Contact]) -> Contact? {
+    private static func bestMatch(
+        for parsed: ParsedContact,
+        in contacts: [Contact]
+    ) -> (contact: Contact, sharedKeys: Set<ContactMatchKey>)? {
         let keys = ContactMatchKey.keys(for: parsed)
         guard !keys.isEmpty else { return nil }
-        return ContactQuery.sorted(contacts).first { contact in
-            !DuplicateFinder.matchKeys(for: contact).isDisjoint(with: keys)
+        for contact in ContactQuery.sorted(contacts) {
+            let shared = DuplicateFinder.matchKeys(for: contact).intersection(keys)
+            if !shared.isEmpty { return (contact, shared) }
         }
+        return nil
     }
 
     private static func defaultDecision(
@@ -83,6 +113,22 @@ enum ImportReview {
         if parsed.hasNoNewData(comparedWith: contact) { return .skip }
         if parsed.canFill(contact) { return .updateExisting }
         return .merge
+    }
+
+    private static func confidence(
+        for decision: ImportDecision,
+        sharedKeys: Set<ContactMatchKey>
+    ) -> ImportMatchConfidence {
+        if decision == .skip { return .exact }
+        if sharedKeys.contains(where: \.isStrongMatch) { return .likely }
+        return .possible
+    }
+
+    private static func reason(for sharedKeys: Set<ContactMatchKey>) -> String? {
+        if sharedKeys.contains(where: \.isEmail) { return "same email" }
+        if sharedKeys.contains(where: \.isPhone) { return "same phone" }
+        if sharedKeys.contains(where: \.isName) { return "same full name" }
+        return nil
     }
 }
 
@@ -97,9 +143,32 @@ extension ContactMatchKey {
     }
 }
 
+private extension ContactMatchKey {
+    var isStrongMatch: Bool {
+        isEmail || isPhone
+    }
+
+    var isEmail: Bool {
+        if case .email = self { return true }
+        return false
+    }
+
+    var isPhone: Bool {
+        if case .phone = self { return true }
+        return false
+    }
+
+    var isName: Bool {
+        if case .name = self { return true }
+        return false
+    }
+}
+
 private extension ParsedContact {
     func hasNoNewData(comparedWith contact: Contact) -> Bool {
-        canFill(contact)
+        scalarsAlreadyPresent(comparedWith: contact)
+            && birthdayAlreadyPresent(in: contact)
+            && photoAlreadyPresent(in: contact)
             && emailValues.allSatisfy { existingEmailValues(in: contact).contains($0) }
             && phoneValues.allSatisfy { existingPhoneValues(in: contact).contains($0) }
     }
@@ -113,6 +182,12 @@ private extension ParsedContact {
     private func scalarsAreSameOrFillBlank(comparedWith contact: Contact) -> Bool {
         scalarPairs(comparedWith: contact).allSatisfy { incoming, existing in
             incoming.isBlank || existing.isBlank || incoming.normalizedText == existing.normalizedText
+        }
+    }
+
+    private func scalarsAlreadyPresent(comparedWith contact: Contact) -> Bool {
+        scalarPairs(comparedWith: contact).allSatisfy { incoming, existing in
+            incoming.isBlank || incoming.normalizedText == existing.normalizedText
         }
     }
 
@@ -137,6 +212,14 @@ private extension ParsedContact {
 
     private func photoCanFill(_ contact: Contact) -> Bool {
         photoData == nil || contact.photoData == nil || photoData == contact.photoData
+    }
+
+    private func birthdayAlreadyPresent(in contact: Contact) -> Bool {
+        birthday == nil || birthday == contact.birthday
+    }
+
+    private func photoAlreadyPresent(in contact: Contact) -> Bool {
+        photoData == nil || photoData == contact.photoData
     }
 
     private var emailValues: Set<String> {

--- a/ContactManager/Views/ContentView+Alerts.swift
+++ b/ContactManager/Views/ContentView+Alerts.swift
@@ -1,0 +1,32 @@
+//
+//  ContentView+Alerts.swift
+//  ContactManager
+//
+//  Alert modifiers split out so ContentView stays within lint limits.
+//
+
+import SwiftUI
+
+extension ContentView {
+    func handlingImportAlerts(_ content: some View) -> some View {
+        content
+            .alert(
+                "Something Went Wrong",
+                isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } }),
+                presenting: errorMessage
+            ) { _ in
+                Button("OK", role: .cancel) {}
+            } message: { message in
+                Text(message)
+            }
+            .alert(
+                importSummary?.title ?? "Import Complete",
+                isPresented: Binding(get: { importSummary != nil }, set: { if !$0 { importSummary = nil } }),
+                presenting: importSummary
+            ) { _ in
+                Button("OK", role: .cancel) {}
+            } message: { summary in
+                Text(summary.message)
+            }
+    }
+}

--- a/ContactManager/Views/ContentView+Import.swift
+++ b/ContactManager/Views/ContentView+Import.swift
@@ -55,11 +55,13 @@ extension ContentView {
         importProgress = ImportProgress(done: 0, total: items.count)
         defer { importProgress = nil }
         do {
+            var summary = ImportReviewResult()
             for chunk in items.chunked(into: 500) {
-                try store.applyImportReview(chunk)
+                try summary.add(store.applyImportReview(chunk))
                 importProgress?.done += chunk.count
                 await Task.yield()
             }
+            importSummary = summary
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -49,6 +49,7 @@ struct ContentView: View {
     @State private var pdfFilename = "Contact"
     @State var importReviewItems: [ImportReviewItem] = []
     @State var isReviewingImport = false
+    @State var importSummary: ImportReviewResult?
 
     /// Internal so the import handlers in `ContentView+Import.swift` can
     /// reach the same store the main view uses.
@@ -320,7 +321,7 @@ private extension ContentView {
 
     /// The sheets, importers, exporters, and the error alert.
     func handlingFileDialogs(_ content: some View) -> some View {
-        content
+        handlingImportAlerts(content
             .sheet(isPresented: $showingDuplicates) {
                 DuplicatesView()
             }
@@ -354,16 +355,7 @@ private extension ContentView {
                 ImportReviewView(items: $importReviewItems) { items in
                     Task { await applyImportReview(items) }
                 }
-            }
-            .alert(
-                "Something Went Wrong",
-                isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } }),
-                presenting: errorMessage
-            ) { _ in
-                Button("OK", role: .cancel) {}
-            } message: { message in
-                Text(message)
-            }
+            })
     }
 
     // MARK: - Print / PDF

--- a/ContactManager/Views/ImportReviewView.swift
+++ b/ContactManager/Views/ImportReviewView.swift
@@ -63,7 +63,7 @@ private struct ImportReviewRow: View {
                         .lineLimit(1)
                 }
                 if let matched = item.matchedContact {
-                    Text("Matches \(matched.fullName)")
+                    Text(matchDescription(matched))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else {
@@ -85,6 +85,14 @@ private struct ImportReviewRow: View {
         .padding(.vertical, 4)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("import-review-row-\(item.displayName.normalizedIdentifier)")
+    }
+
+    private func matchDescription(_ matched: Contact) -> String {
+        let confidence = item.confidence?.title ?? "Possible match"
+        if let reason = item.matchReason {
+            return "\(confidence) · \(reason) · \(matched.fullName)"
+        }
+        return "\(confidence) · \(matched.fullName)"
     }
 }
 

--- a/ContactManagerTests/ImportReviewTests.swift
+++ b/ContactManagerTests/ImportReviewTests.swift
@@ -52,6 +52,8 @@ struct ImportReviewTests {
 
         #expect(item.decision == .skip)
         #expect(item.matchedContact?.persistentModelID == existing.persistentModelID)
+        #expect(item.confidence == .exact)
+        #expect(item.matchReason == "same email")
     }
 
     @Test func partialMatchesDefaultToUpdateExisting() throws {
@@ -67,6 +69,22 @@ struct ImportReviewTests {
         let item = try #require(ImportReview.makeItems(for: [parsed], existing: [existing]).first)
 
         #expect(item.decision == .updateExisting)
+        #expect(item.confidence == .likely)
+        #expect(item.matchReason == "same email")
+    }
+
+    @Test func nameOnlyMatchesArePossible() throws {
+        let existing = try store.createContact()
+        existing.firstName = "Katherine"
+        existing.lastName = "Johnson"
+        try context.save()
+        let parsed = ParsedContact(firstName: "Katherine", lastName: "Johnson", company: "NASA")
+
+        let item = try #require(ImportReview.makeItems(for: [parsed], existing: [existing]).first)
+
+        #expect(item.decision == .updateExisting)
+        #expect(item.confidence == .possible)
+        #expect(item.matchReason == "same full name")
     }
 
     @Test func applyingReviewAddsUpdatesSkipsAndMerges() throws {
@@ -114,5 +132,24 @@ struct ImportReviewTests {
         #expect(partial.phones.map(\.value) == ["555-0101"])
         #expect(conflicting.company == "Navy")
         #expect(conflicting.phones.map(\.value) == ["555-0102"])
+    }
+
+    @Test func importSummaryFormatsOnlyNonZeroCounts() {
+        let result = ImportReviewResult(added: 2, updated: 1, merged: 0, skipped: 3)
+
+        #expect(result.title == "Imported 3 Contacts")
+        #expect(result.message == "Added 2, updated 1, skipped 3.")
+    }
+
+    @Test func importSummaryCombinesChunkResults() {
+        var result = ImportReviewResult(added: 1, updated: 0, merged: 1, skipped: 0)
+
+        result.add(ImportReviewResult(added: 0, updated: 2, merged: 0, skipped: 4))
+
+        #expect(result.added == 1)
+        #expect(result.updated == 2)
+        #expect(result.merged == 1)
+        #expect(result.skipped == 4)
+        #expect(result.totalWritten == 4)
     }
 }


### PR DESCRIPTION
## Summary
Polishes the reviewed import flow by showing duplicate confidence/reasons before apply and a post-import summary after the batch is written.

## Changes
- Add exact/likely/possible match confidence and human-readable match reasons to import review items.
- Tighten exact duplicate detection so name-only matches with new incoming data default to update instead of skip.
- Summarize added, updated, merged, and skipped contacts after import apply, including chunked batches.
- Name import undo groups by the number of contacts actually written.
- Split import alerts into a small ContentView extension to keep lint limits green.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - make format-check
  - swiftlint lint --quiet --strict
  - xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerTests/ImportReviewTests
  - xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerTests
  - xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerUITests

## Screenshots (if applicable)
Not applicable.

## Related Issues
Closes #