### PR TITLE
feat(contacts): add smart lists and contact tracking

### DIFF
--- a/ContactManager/Models/Contact.swift
+++ b/ContactManager/Models/Contact.swift
@@ -27,6 +27,7 @@ final class Contact {
 
     // Misc
     var birthday: Date?
+    var lastContactedAt: Date?
     var notes: String = ""
     var createdAt: Date = Date.now
 
@@ -52,6 +53,7 @@ final class Contact {
         postalCode: String = "",
         country: String = "",
         birthday: Date? = nil,
+        lastContactedAt: Date? = nil,
         notes: String = "",
         createdAt: Date = .now
     ) {
@@ -65,6 +67,7 @@ final class Contact {
         self.postalCode = postalCode
         self.country = country
         self.birthday = birthday
+        self.lastContactedAt = lastContactedAt
         self.notes = notes
         self.createdAt = createdAt
         fields = []

--- a/ContactManager/Models/ContactQuery.swift
+++ b/ContactManager/Models/ContactQuery.swift
@@ -23,6 +23,39 @@ enum ContactSortOrder: String, CaseIterable, Identifiable {
     }
 }
 
+/// Built-in relationship-oriented lists. They are computed locally from the
+/// contact model rather than persisted, so they stay current as edits save.
+enum ContactSmartList: String, CaseIterable, Identifiable, Hashable {
+    case recentlyContacted
+    case needsFollowUp
+    case noEmail
+    case birthdaysSoon
+
+    static let recentContactDays = 14
+    static let followUpDays = 30
+    static let birthdayWindowDays = 30
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .recentlyContacted: "Recently Contacted"
+        case .needsFollowUp: "Needs Follow-up"
+        case .noEmail: "No Email"
+        case .birthdaysSoon: "Birthdays Soon"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .recentlyContacted: "clock.arrow.circlepath"
+        case .needsFollowUp: "bell.badge"
+        case .noEmail: "envelope.badge"
+        case .birthdaysSoon: "gift"
+        }
+    }
+}
+
 /// An alphabetical group of contacts, titled by initial ("A"…"Z" or "#").
 struct ContactSection: Identifiable {
     let title: String
@@ -63,6 +96,30 @@ enum ContactQuery {
         }
     }
 
+    static func filtered(
+        _ contacts: [Contact],
+        by smartList: ContactSmartList,
+        now: Date = .now
+    ) -> [Contact] {
+        contacts.filter { contact in
+            switch smartList {
+            case .recentlyContacted:
+                guard let lastContactedAt = contact.lastContactedAt else { return false }
+                let daysSinceContact = daysBetween(lastContactedAt, and: now)
+                return daysSinceContact >= 0 && daysSinceContact <= ContactSmartList.recentContactDays
+            case .needsFollowUp:
+                guard let lastContactedAt = contact.lastContactedAt else { return true }
+                let daysSinceContact = daysBetween(lastContactedAt, and: now)
+                return daysSinceContact > ContactSmartList.followUpDays
+            case .noEmail:
+                return contact.primaryEmail == nil
+            case .birthdaysSoon:
+                guard let birthday = contact.birthday else { return false }
+                return birthdayIsSoon(birthday, now: now)
+            }
+        }
+    }
+
     /// Groups contacts into alphabetical sections by their initial, sorted
     /// within each section. Names that don't start with a letter land in a
     /// trailing "#" section.
@@ -84,5 +141,41 @@ enum ContactQuery {
             return "#"
         }
         return String(first).uppercased()
+    }
+
+    private static func daysBetween(_ start: Date, and end: Date) -> Int {
+        let startOfStart = Birthday.calendar.startOfDay(for: start)
+        let startOfEnd = Birthday.calendar.startOfDay(for: end)
+        return Birthday.calendar.dateComponents([.day], from: startOfStart, to: startOfEnd).day ?? 0
+    }
+
+    private static func birthdayIsSoon(_ birthday: Date, now: Date) -> Bool {
+        let today = Birthday.calendar.startOfDay(for: now)
+        let fields = Birthday.fields(of: birthday)
+        let currentYear = Birthday.calendar.component(.year, from: today)
+        let nextBirthday = birthdayDate(month: fields.month, day: fields.day, year: currentYear, today: today)
+        let days = Birthday.calendar.dateComponents([.day], from: today, to: nextBirthday).day
+        return (days ?? Int.max) <= ContactSmartList.birthdayWindowDays
+    }
+
+    private static func birthdayDate(month: Int, day: Int, year: Int, today: Date) -> Date {
+        for candidateYear in year ... (year + 4) {
+            let candidate = exactBirthdayDate(month: month, day: day, year: candidateYear)
+                ?? Birthday.date(
+                    year: candidateYear,
+                    month: month,
+                    day: Birthday.clampDay(day, month: month, year: candidateYear)
+                )
+            if let candidate, candidate >= today {
+                return candidate
+            }
+        }
+        return today
+    }
+
+    private static func exactBirthdayDate(month: Int, day: Int, year: Int) -> Date? {
+        guard let date = Birthday.date(year: year, month: month, day: day) else { return nil }
+        let fields = Birthday.fields(of: date)
+        return fields.month == month && fields.day == day ? date : nil
     }
 }

--- a/ContactManager/Models/ContactStore.swift
+++ b/ContactManager/Models/ContactStore.swift
@@ -47,6 +47,12 @@ struct ContactStore {
         }
     }
 
+    func markContacted(_ contact: Contact, at date: Date = .now) throws {
+        try mutate("Mark Contacted") {
+            contact.lastContactedAt = date
+        }
+    }
+
     // MARK: - Fields (emails / phones)
 
     /// Adds a labeled field, keeping `sortIndex` strictly increasing so order

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -21,6 +21,7 @@ struct ContactDetailView: View {
     /// First Name; the view clears it via `onNameFieldFocused` after focusing.
     var focusNameField = false
     var onNameFieldFocused: () -> Void = {}
+    var markContacted: (Contact) -> Void = { _ in }
     @Query(sort: \ContactGroup.name) private var allGroups: [ContactGroup]
     @State private var isImportingPhoto = false
     // Not private: the photo handlers in ContactDetailView+Photo.swift read them.
@@ -53,6 +54,23 @@ struct ContactDetailView: View {
                     .accessibilityIdentifier("contact-company-field")
                 TextField("Job Title", text: $contact.jobTitle)
                     .accessibilityIdentifier("contact-job-title-field")
+            }
+
+            Section("Relationship") {
+                LabeledContent("Last Contacted") {
+                    if let lastContactedAt = contact.lastContactedAt {
+                        Text(lastContactedAt, format: .dateTime.month().day().year())
+                    } else {
+                        Text("Never")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Button {
+                    markContacted(contact)
+                } label: {
+                    Label("Mark Contacted Today", systemImage: "checkmark.circle")
+                }
+                .accessibilityIdentifier("mark-contacted-button")
             }
 
             fieldSection("Email", kind: .email, fields: contact.emails)
@@ -134,6 +152,15 @@ struct ContactDetailView: View {
             if focused { onNameFieldFocused() }
         }
         .toolbar {
+            ToolbarItem {
+                Button {
+                    markContacted(contact)
+                } label: {
+                    Label("Mark Contacted Today", systemImage: "checkmark.circle")
+                }
+                .help("Mark Contacted Today")
+                .accessibilityIdentifier("mark-contacted-toolbar-button")
+            }
             ToolbarItem {
                 ShareLink(item: vcardTransfer, preview: SharePreview(shareTitle))
                     .help("Share this contact as a vCard")

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -9,8 +9,10 @@
 import SwiftUI
 
 struct ContactListView: View {
+    let title: String
     let sections: [ContactSection]
     let totalCount: Int
+    let emptyTitle: String
     @Binding var searchText: String
     @Binding var sortOrder: ContactSortOrder
     @Binding var selection: Contact?
@@ -42,7 +44,7 @@ struct ContactListView: View {
                 }
             }
         }
-        .navigationTitle("Contacts")
+        .navigationTitle(title)
         .navigationSplitViewColumnWidth(
             min: LayoutMetrics.listMinWidth,
             ideal: LayoutMetrics.listIdealWidth,
@@ -125,7 +127,7 @@ struct ContactListView: View {
             if totalCount == 0 {
                 // An empty store always reads as "No Contacts", even mid-search.
                 ContentUnavailableView {
-                    Label("No Contacts", systemImage: "person.crop.circle.badge.plus")
+                    Label(emptyTitle, systemImage: "person.crop.circle.badge.plus")
                 } description: {
                     Text("Add a contact to get started.")
                 } actions: {

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -23,18 +23,10 @@ struct ContentView: View {
 
     @State private var sidebarSelection: SidebarItem? = .allContacts
     @State private var selectedContact: Contact?
-    /// The contact just created via ⌘N/＋, so the detail form can open with
-    /// the cursor in First Name. Cleared once the field takes focus.
     @State private var contactPendingNameFocus: PersistentIdentifier?
-    /// Internal so the import handlers in `ContentView+Import.swift` can
-    /// set this when a parse/insert fails.
     @State var errorMessage: String?
-    // Drives the import progress overlay; set by the import handlers.
     @State var importProgress: ImportProgress?
     @State private var searchText = ""
-    /// Trails `searchText` by 150 ms so we don't re-filter the entire contact
-    /// list on every keystroke. Cleared instantly when the user clears the
-    /// search field — only typing-into-non-empty pays the debounce delay.
     @State private var debouncedSearchText = ""
     @AppStorage("contactSortOrder") private var sortOrder: ContactSortOrder = .lastName
     @AppStorage("defaultGroupID") private var defaultGroupID: String = ""
@@ -51,40 +43,51 @@ struct ContentView: View {
     @State var isReviewingImport = false
     @State var importSummary: ImportReviewResult?
 
-    /// Internal so the import handlers in `ContentView+Import.swift` can
-    /// reach the same store the main view uses.
     var store: ContactStore { ContactStore(context) }
 
-    /// The group backing the current sidebar selection, if any.
     private var selectedGroup: ContactGroup? {
         guard case .group(let id) = sidebarSelection else { return nil }
         return groups.first { $0.persistentModelID == id }
     }
 
-    /// User-configured default group for new contacts when the sidebar is
-    /// on All Contacts. Resolved by encoded `PersistentIdentifier` so it
-    /// survives a rename; if the target group was deleted the lookup
-    /// returns nil and SettingsView prunes the preference on next view.
+    private var selectedSmartList: ContactSmartList? {
+        guard case .smartList(let smartList) = sidebarSelection else { return nil }
+        return smartList
+    }
+
+    private var smartListCounts: [ContactSmartList: Int] {
+        Dictionary(uniqueKeysWithValues: ContactSmartList.allCases.map { smartList in
+            (smartList, ContactQuery.filtered(contacts, by: smartList).count)
+        })
+    }
+
     private var defaultGroup: ContactGroup? {
         DefaultGroupPreference.group(stored: defaultGroupID, in: groups)
     }
 
-    /// Where a new contact should land. The default group is only used when
-    /// the sidebar is explicitly on All Contacts — never as a silent rescue
-    /// from a `.group(...)` selection whose target was deleted, which would
-    /// surprise the user by adding their contact to an unrelated group.
     private var groupForNewContact: ContactGroup? {
         switch sidebarSelection {
         case .group: selectedGroup
-        case .allContacts, .none: defaultGroup
+        case .allContacts, .smartList, .none: defaultGroup
         }
     }
 
-    /// Contacts shown for the current sidebar selection, before search.
-    /// Reads a group's members from the relationship rather than scanning
-    /// every contact's groups.
     private var scopedContacts: [Contact] {
-        selectedGroup?.contacts ?? contacts
+        if let selectedGroup { return selectedGroup.contacts }
+        if let selectedSmartList { return ContactQuery.filtered(contacts, by: selectedSmartList) }
+        return contacts
+    }
+
+    private var listTitle: String {
+        if let selectedGroup { return selectedGroup.displayName }
+        if let selectedSmartList { return selectedSmartList.title }
+        return "Contacts"
+    }
+
+    private var emptyListTitle: String {
+        if selectedGroup != nil { return "No Contacts in Group" }
+        if selectedSmartList != nil { return "No Contacts Match" }
+        return "No Contacts"
     }
 
     private var sections: [ContactSection] {
@@ -97,9 +100,6 @@ struct ContentView: View {
     var body: some View {
         let scene = splitView
             .task(id: searchText) {
-                // Empty → clear immediately. Otherwise wait 150 ms before
-                // committing the new query so a burst of keystrokes only
-                // triggers one filter pass.
                 if searchText.isEmpty {
                     debouncedSearchText = ""
                     return
@@ -112,15 +112,11 @@ struct ContentView: View {
                 }
             }
             .onAppear {
-                // Route every ContactStore mutation through the window's undo
-                // manager so Edit ▸ Undo/Redo (⌘Z / ⇧⌘Z) work.
                 context.undoManager = undoManager
             }
             .onChange(of: undoManager) { _, new in
                 context.undoManager = new
             }
-        // Split into helpers so the modifier chain stays within the SwiftUI
-        // type-checker's budget (and the type-body length limit).
         return handlingFileDialogs(handlingHandoff(handlingMenuCommands(scene)))
     }
 
@@ -130,6 +126,7 @@ struct ContentView: View {
             SidebarView(
                 selection: $sidebarSelection,
                 contactCount: contacts.count,
+                smartListCounts: smartListCounts,
                 groups: groups,
                 addGroup: addGroup,
                 renameGroup: renameGroup,
@@ -138,8 +135,10 @@ struct ContentView: View {
             )
         } content: {
             ContactListView(
+                title: listTitle,
                 sections: sections,
                 totalCount: scopedContacts.count,
+                emptyTitle: emptyListTitle,
                 searchText: $searchText,
                 sortOrder: $sortOrder,
                 selection: $selectedContact,
@@ -153,7 +152,8 @@ struct ContentView: View {
                     ContactDetailView(
                         contact: selectedContact,
                         focusNameField: selectedContact.persistentModelID == contactPendingNameFocus,
-                        onNameFieldFocused: { contactPendingNameFocus = nil }
+                        onNameFieldFocused: { contactPendingNameFocus = nil },
+                        markContacted: markContacted
                     )
                     .id(selectedContact.persistentModelID)
                 } else {
@@ -180,6 +180,7 @@ struct ContentView: View {
     private func addContact() {
         do {
             let contact = try store.createContact(in: groupForNewContact)
+            if selectedSmartList != nil { sidebarSelection = .allContacts }
             contactPendingNameFocus = contact.persistentModelID
             withAnimation(reduceMotion ? nil : .snappy) { selectedContact = contact }
         } catch {
@@ -192,6 +193,14 @@ struct ContentView: View {
         do {
             try store.delete(contact)
             if wasSelected { selectedContact = nil }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func markContacted(_ contact: Contact) {
+        do {
+            try store.markContacted(contact)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/ContactManager/Views/SidebarView.swift
+++ b/ContactManager/Views/SidebarView.swift
@@ -11,12 +11,14 @@ import SwiftUI
 
 enum SidebarItem: Hashable {
     case allContacts
+    case smartList(ContactSmartList)
     case group(PersistentIdentifier)
 }
 
 struct SidebarView: View {
     @Binding var selection: SidebarItem?
     let contactCount: Int
+    let smartListCounts: [ContactSmartList: Int]
     let groups: [ContactGroup]
     var addGroup: () -> Void
     var renameGroup: (ContactGroup, String) -> Void
@@ -34,6 +36,15 @@ struct SidebarView: View {
                     .badge(contactCount)
                     .tag(SidebarItem.allContacts)
                     .accessibilityIdentifier("sidebar-all-contacts-row")
+            }
+
+            Section("Smart Lists") {
+                ForEach(ContactSmartList.allCases) { smartList in
+                    Label(smartList.title, systemImage: smartList.systemImage)
+                        .badge(smartListCounts[smartList] ?? 0)
+                        .tag(SidebarItem.smartList(smartList))
+                        .accessibilityIdentifier("sidebar-smart-list-row-\(smartList.rawValue)")
+                }
             }
 
             Section("Groups") {

--- a/ContactManagerTests/ContactModelTests.swift
+++ b/ContactManagerTests/ContactModelTests.swift
@@ -7,6 +7,7 @@
 //
 
 @testable import ContactManager
+import Foundation
 import SwiftData
 import Testing
 
@@ -233,5 +234,52 @@ struct ContactModelTests {
         #expect(ContactQuery.filtered(all, matching: "7555").first?.firstName == "Alan") // phone field
         #expect(ContactQuery.filtered(all, matching: "").count == 2)
         #expect(ContactQuery.filtered(all, matching: "nobody").isEmpty)
+    }
+
+    @Test func smartListsFilterRelationshipSignals() throws {
+        let reference = try #require(Birthday.calendar.date(from: DateComponents(
+            year: 2026, month: 6, day: 7
+        )))
+        let recent = Contact(firstName: "Recent")
+        recent.lastContactedAt = reference.addingTimeInterval(-7 * 24 * 60 * 60)
+        recent.fields = [ContactField(kind: .email, value: "recent@example.com")]
+        let old = Contact(firstName: "Old")
+        old.lastContactedAt = reference.addingTimeInterval(-45 * 24 * 60 * 60)
+        old.fields = [ContactField(kind: .email, value: "old@example.com")]
+        let missingEmail = Contact(firstName: "No Email")
+
+        let contacts = [recent, old, missingEmail]
+
+        let recentNames = ContactQuery.filtered(contacts, by: .recentlyContacted, now: reference).map(\.firstName)
+        let followUpNames = ContactQuery.filtered(contacts, by: .needsFollowUp, now: reference).map(\.firstName)
+        let noEmailNames = ContactQuery.filtered(contacts, by: .noEmail, now: reference).map(\.firstName)
+
+        #expect(recentNames == ["Recent"])
+        #expect(followUpNames == ["Old", "No Email"])
+        #expect(noEmailNames == ["No Email"])
+    }
+
+    @Test func birthdaysSoonIgnoresStoredYearAndWrapsAcrossYearEnd() throws {
+        let reference = try #require(Birthday.calendar.date(from: DateComponents(
+            year: 2026, month: 12, day: 20
+        )))
+        let soon = Contact(firstName: "Soon", birthday: Birthday.date(year: 1980, month: 1, day: 5))
+        let later = Contact(firstName: "Later", birthday: Birthday.date(year: 1980, month: 2, day: 15))
+        let none = Contact(firstName: "None")
+
+        let birthdays = ContactQuery.filtered([soon, later, none], by: .birthdaysSoon, now: reference)
+
+        #expect(birthdays.map(\.firstName) == ["Soon"])
+    }
+
+    @Test func pastLeapDayBirthdayIsNotSoonInANonLeapYear() throws {
+        let reference = try #require(Birthday.calendar.date(from: DateComponents(
+            year: 2026, month: 3, day: 1
+        )))
+        let leapDay = Contact(firstName: "Leap", birthday: Birthday.date(year: 1980, month: 2, day: 29))
+
+        let birthdays = ContactQuery.filtered([leapDay], by: .birthdaysSoon, now: reference)
+
+        #expect(birthdays.isEmpty)
     }
 }

--- a/ContactManagerTests/ContactStoreTests.swift
+++ b/ContactManagerTests/ContactStoreTests.swift
@@ -129,6 +129,19 @@ struct ContactStoreTests {
         #expect(contact.photoData == nil)
     }
 
+    // MARK: - Journey: track relationship activity
+
+    @Test func markContactedStoresTheContactDate() throws {
+        let contactedAt = try #require(Birthday.calendar.date(from: DateComponents(
+            year: 2026, month: 6, day: 7, hour: 12
+        )))
+        let contact = try store.createContact()
+
+        try store.markContacted(contact, at: contactedAt)
+
+        #expect(contact.lastContactedAt == contactedAt)
+    }
+
     // MARK: - Journey: import contacts from a vCard
 
     @Test func importVCardCreatesContactsWithFields() throws {

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -114,6 +114,22 @@ final class ContactManagerUITests: XCTestCase {
         )
     }
 
+    /// Verifies the relationship-intelligence affordances render in the live
+    /// app: smart-list sidebar rows and the selected contact's mark-contacted
+    /// action. Filtering behavior stays in the deterministic unit tests.
+    func test_smartListsAndMarkContactedControlsRender() {
+        let app = bootSeededApp()
+
+        XCTAssertTrue(app.staticTexts["Recently Contacted"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["Needs Follow-up"].exists)
+        XCTAssertTrue(app.staticTexts["No Email"].exists)
+        XCTAssertTrue(app.staticTexts["Birthdays Soon"].exists)
+
+        app.typeKey("n", modifierFlags: .command)
+
+        XCTAssertTrue(app.buttons["mark-contacted-button"].waitForExistence(timeout: 3))
+    }
+
     /// Verifies the quick-capture command opens a focused capture window and
     /// creates a searchable contact from natural text.
     func test_quickCaptureCreatesSearchableContact() {


### PR DESCRIPTION
## Summary
Adds relationship-intelligence basics: last-contacted metadata, a durable mark-contacted action, and built-in smart lists for maintaining contacts.

## Changes
- Add optional lastContactedAt metadata to Contact.
- Add ContactStore.markContacted so the action saves through the existing mutation, undo, rollback, and Spotlight notification pipeline.
- Add smart-list filtering for Recently Contacted, Needs Follow-up, No Email, and Birthdays Soon.
- Show smart-list rows and counts in the sidebar, and scope the contact list to the selected smart list.
- Add a Relationship section and toolbar action for marking a contact contacted today.
- Add unit coverage for smart-list filters, leap-day birthday handling, and mark-contacted persistence.
- Add UI smoke coverage for smart-list rows and the mark-contacted control.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - make check
  - xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerUITests

## Screenshots (if applicable)
Not applicable.

## Related Issues
Closes #