### PR TITLE
feat(contacts): add contact history notes

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		2EB13805320DA225F70D08F3 /* VCardTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */; };
 		3076738411F8C3FA073D1BE0 /* ContactsBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */; };
 		322103E6FBEAD59C6A2405E6 /* Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDED82FFB4B5F039052FFB5 /* Birthday.swift */; };
+		337B23E02F63EB1A294A5A41 /* ContactHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764B3FB47DAFF8CE837BDE9D /* ContactHistoryTests.swift */; };
 		39D33CDF2E0495FCCA8D7E13 /* QuickCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C76A783B91BD2AA6D3F70B /* QuickCaptureTests.swift */; };
 		3EDDAA184C377D9C16AAF08A /* ContactStore+PendingEdits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */; };
 		3FA1770FF1649CC78510AF10 /* ContentView+Alerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0401F25DFDF91CE847706D08 /* ContentView+Alerts.swift */; };
@@ -29,6 +30,7 @@
 		444B949F37F7FF7DD98A4C6B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */; };
 		4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */; };
 		465C6AF22F5A45925B879752 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */; };
+		4748DC4114188B76B5384A8D /* ContactInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9116FC0A7E009E9A806FD48F /* ContactInteraction.swift */; };
 		488CA0C339AD3218073A02E8 /* PrintableContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37DB6CC43A76261CFF3987D /* PrintableContactView.swift */; };
 		48DA73BF161A4ABB5DBE4291 /* QuickCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D7E9FD22709F6D14A87952 /* QuickCapture.swift */; };
 		4B9EAE3500BB10401AEB3746 /* ContactActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CF4C47C670B0A8C3B6B384 /* ContactActivity.swift */; };
@@ -56,6 +58,7 @@
 		827CF451F0B38B89C4469595 /* DuplicateFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */; };
 		8397B67D483997505B17269E /* ContactDetailView+Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */; };
 		847D0CD5B12E83CD53951DA2 /* ContactFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E63AB996E12C5978B4A8F1 /* ContactFieldRow.swift */; };
+		84EC52BD6CC2F06EFFFF0758 /* ContactDetailView+History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784AEA3986875E3472052482 /* ContactDetailView+History.swift */; };
 		8C6AC6410FA2258ADB2BF640 /* ContactManagerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001F8DF120EBA372663EC888 /* ContactManagerUITests.swift */; };
 		8DF0A36CE542853FF12BEF1A /* Chunking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436B4115937E4350EB9A7EF7 /* Chunking.swift */; };
 		8EF7CD9AAA833F08834D2AA4 /* QuickCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5951D4D8D52B6CDB782FE37D /* QuickCaptureView.swift */; };
@@ -82,6 +85,7 @@
 		CFFC58E9EA162230275F2301 /* ContactEntityQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874742D7DC5E9C20D3A88459 /* ContactEntityQuery.swift */; };
 		D09BB01ED8C135141953AFE7 /* ImportReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA2237DBD182839EAF04F1 /* ImportReviewView.swift */; };
 		D4431A7BEF48D8A75EFB8DC8 /* ContactStore+QuickCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34532FC6E64B32F9A27FCDCD /* ContactStore+QuickCapture.swift */; };
+		D5255AD7FAD03FD891ECC97B /* ContactStore+Interactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7466E6CBC023A24F4365537C /* ContactStore+Interactions.swift */; };
 		E5EB465B5CE3964197D29ADF /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F82C8A388E97CC4F1106176 /* SampleData.swift */; };
 		ECB7FDD8D0C3091EA0D42917 /* UndoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DCAF444714BC3726B212C4 /* UndoTests.swift */; };
 		ECDA4BC68D3FAE4CCF428675 /* ContactDetailView+Saving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */; };
@@ -145,7 +149,10 @@
 		6EE79F02FFFD9820269D3725 /* ContactLinkTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactLinkTests.swift; sourceTree = "<group>"; };
 		734D363DD0CB0BAA7AE9460B /* LayoutMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LayoutMetrics.swift; sourceTree = "<group>"; };
 		73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactDetailView.swift; sourceTree = "<group>"; };
+		7466E6CBC023A24F4365537C /* ContactStore+Interactions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+Interactions.swift"; sourceTree = "<group>"; };
+		764B3FB47DAFF8CE837BDE9D /* ContactHistoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactHistoryTests.swift; sourceTree = "<group>"; };
 		76F68BAD5C3290EE7ABF787B /* Localizable.xcstrings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		784AEA3986875E3472052482 /* ContactDetailView+History.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+History.swift"; sourceTree = "<group>"; };
 		7B17AADA860AEDB87017DF0B /* ContactWindowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactWindowView.swift; sourceTree = "<group>"; };
 		7B27494A51645ACA6BED8EA8 /* OpenContactIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenContactIntent.swift; sourceTree = "<group>"; };
 		7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactsBridgeTests.swift; sourceTree = "<group>"; };
@@ -154,6 +161,7 @@
 		83E63AB996E12C5978B4A8F1 /* ContactFieldRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactFieldRow.swift; sourceTree = "<group>"; };
 		874742D7DC5E9C20D3A88459 /* ContactEntityQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityQuery.swift; sourceTree = "<group>"; };
 		90E3C45DEC115A2BF7DE83DF /* ContactLink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactLink.swift; sourceTree = "<group>"; };
+		9116FC0A7E009E9A806FD48F /* ContactInteraction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactInteraction.swift; sourceTree = "<group>"; };
 		915AF700C971510D0B642590 /* ContactEntity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntity.swift; sourceTree = "<group>"; };
 		92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Saving.swift"; sourceTree = "<group>"; };
 		93C12246003379D5966F0210 /* ContactEntityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityTests.swift; sourceTree = "<group>"; };
@@ -250,6 +258,8 @@
 				DB522F18FE21A503D7C480AB /* ImportReview.swift */,
 				C90D71F3F01E29B7C4B739A7 /* ContactStore+ImportReview.swift */,
 				45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */,
+				9116FC0A7E009E9A806FD48F /* ContactInteraction.swift */,
+				7466E6CBC023A24F4365537C /* ContactStore+Interactions.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -309,6 +319,7 @@
 				92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */,
 				B7C0DCB1419D1BD49893F8AD /* ContactDetailView+QuickInfo.swift */,
 				83E63AB996E12C5978B4A8F1 /* ContactFieldRow.swift */,
+				784AEA3986875E3472052482 /* ContactDetailView+History.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -380,6 +391,7 @@
 				399A72E1BB6BEC0B54D356E7 /* ContactEntityQueryTests.swift */,
 				C95BBAB51882751053816B2C /* ImportReviewTests.swift */,
 				438C2B20E1C302676594ECCA /* ContactStorePendingEditTests.swift */,
+				764B3FB47DAFF8CE837BDE9D /* ContactHistoryTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -563,6 +575,9 @@
 				D4431A7BEF48D8A75EFB8DC8 /* ContactStore+QuickCapture.swift in Sources */,
 				8EF7CD9AAA833F08834D2AA4 /* QuickCaptureView.swift in Sources */,
 				3FA1770FF1649CC78510AF10 /* ContentView+Alerts.swift in Sources */,
+				4748DC4114188B76B5384A8D /* ContactInteraction.swift in Sources */,
+				D5255AD7FAD03FD891ECC97B /* ContactStore+Interactions.swift in Sources */,
+				84EC52BD6CC2F06EFFFF0758 /* ContactDetailView+History.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -593,6 +608,7 @@
 				ABF907FAA713351663F3889A /* ImportReviewTests.swift in Sources */,
 				0DC8E4BAF454185075119C3A /* ContactStorePendingEditTests.swift in Sources */,
 				39D33CDF2E0495FCCA8D7E13 /* QuickCaptureTests.swift in Sources */,
+				337B23E02F63EB1A294A5A41 /* ContactHistoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -152,7 +152,7 @@ struct ContactManagerApp: App {
             deleteDefaultStore()
         }
 
-        let schema = Schema([Contact.self, ContactField.self, ContactGroup.self])
+        let schema = Schema([Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self])
 
         // UI-test mode uses an in-memory, CloudKit-disabled container so
         // tests are deterministic and can't sync sample contacts to a

--- a/ContactManager/Models/Contact.swift
+++ b/ContactManager/Models/Contact.swift
@@ -39,6 +39,10 @@ final class Contact {
     @Relationship(deleteRule: .cascade, inverse: \ContactField.contact)
     var fields: [ContactField] = []
 
+    /// Relationship-history entries such as calls, meetings, and notes.
+    @Relationship(deleteRule: .cascade, inverse: \ContactInteraction.contact)
+    var interactions: [ContactInteraction] = []
+
     /// Groups this contact belongs to (many-to-many; inverse on ContactGroup).
     var groups: [ContactGroup] = []
 
@@ -71,6 +75,7 @@ final class Contact {
         self.notes = notes
         self.createdAt = createdAt
         fields = []
+        interactions = []
     }
 }
 
@@ -163,6 +168,14 @@ extension Contact {
     /// The first non-empty email, used as the list subtitle.
     var primaryEmail: String? {
         emails.first { !$0.value.trimmingCharacters(in: .whitespaces).isEmpty }?.value
+    }
+
+    var sortedInteractions: [ContactInteraction] {
+        interactions.sorted { lhs, rhs in
+            if lhs.date != rhs.date { return lhs.date > rhs.date }
+            if lhs.kind.rawValue != rhs.kind.rawValue { return lhs.kind.rawValue < rhs.kind.rawValue }
+            return lhs.summary < rhs.summary
+        }
     }
 
     /// The first non-empty phone number.

--- a/ContactManager/Models/ContactInteraction.swift
+++ b/ContactManager/Models/ContactInteraction.swift
@@ -1,0 +1,60 @@
+//
+//  ContactInteraction.swift
+//  ContactManager
+//
+//  Relationship-history entries attached to a contact.
+//
+
+import Foundation
+import SwiftData
+
+enum ContactInteractionKind: String, Codable, CaseIterable, Identifiable {
+    case note
+    case call
+    case email
+    case meeting
+    case message
+    case other
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .note: "Note"
+        case .call: "Call"
+        case .email: "Email"
+        case .meeting: "Meeting"
+        case .message: "Message"
+        case .other: "Other"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .note: "note.text"
+        case .call: "phone"
+        case .email: "envelope"
+        case .meeting: "person.2"
+        case .message: "message"
+        case .other: "ellipsis.circle"
+        }
+    }
+}
+
+@Model
+final class ContactInteraction {
+    var date: Date = Date.now
+    var kind: ContactInteractionKind = ContactInteractionKind.note
+    var summary: String = ""
+    var contact: Contact?
+
+    init(
+        kind: ContactInteractionKind = .note,
+        summary: String = "",
+        date: Date = .now
+    ) {
+        self.kind = kind
+        self.summary = summary
+        self.date = date
+    }
+}

--- a/ContactManager/Models/ContactStore+Interactions.swift
+++ b/ContactManager/Models/ContactStore+Interactions.swift
@@ -1,0 +1,41 @@
+//
+//  ContactStore+Interactions.swift
+//  ContactManager
+//
+//  Relationship-history mutations.
+//
+
+import Foundation
+
+extension ContactStore {
+    @discardableResult
+    func addInteraction(
+        to contact: Contact,
+        kind: ContactInteractionKind = .note,
+        summary: String,
+        at date: Date = .now
+    ) throws -> ContactInteraction {
+        let trimmedSummary = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        return try mutate("Add History Note") {
+            let interaction = ContactInteraction(kind: kind, summary: trimmedSummary, date: date)
+            interaction.contact = contact
+            context.insert(interaction)
+            if contact.lastContactedAt.map({ date > $0 }) ?? true {
+                contact.lastContactedAt = date
+            }
+            return interaction
+        }
+    }
+
+    func delete(_ interaction: ContactInteraction) throws {
+        try mutate("Delete History Note") {
+            context.delete(interaction)
+        }
+    }
+
+    func adoptInteractions(into primary: Contact, from other: Contact) {
+        for interaction in other.sortedInteractions {
+            interaction.contact = primary
+        }
+    }
+}

--- a/ContactManager/Models/ContactStore.swift
+++ b/ContactManager/Models/ContactStore.swift
@@ -162,6 +162,7 @@ struct ContactStore {
             for other in others {
                 fillEmptyFields(of: primary, from: other)
                 adoptGroups(into: primary, from: other)
+                adoptInteractions(into: primary, from: other)
             }
             mergeFields(into: primary, from: Array(others))
             others.forEach(context.delete)

--- a/ContactManager/Views/ContactDetailView+History.swift
+++ b/ContactManager/Views/ContactDetailView+History.swift
@@ -1,0 +1,59 @@
+//
+//  ContactDetailView+History.swift
+//  ContactManager
+//
+//  Contact-history controls for the detail form.
+//
+
+import SwiftUI
+
+extension ContactDetailView {
+    var historySection: some View {
+        Section("History") {
+            Picker("Kind", selection: $interactionKind) {
+                ForEach(ContactInteractionKind.allCases) { kind in
+                    Label(kind.title, systemImage: kind.systemImage)
+                        .tag(kind)
+                }
+            }
+            .pickerStyle(.menu)
+            .accessibilityIdentifier("interaction-kind-picker")
+
+            TextField("Add a note", text: $interactionSummary, axis: .vertical)
+                .lineLimit(2 ... 4)
+                .accessibilityIdentifier("interaction-summary-field")
+
+            Button {
+                addInteraction()
+            } label: {
+                Label("Add to History", systemImage: "plus.circle.fill")
+            }
+            .disabled(interactionSummary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .accessibilityIdentifier("add-interaction-button")
+
+            ForEach(contact.sortedInteractions.prefix(5)) { interaction in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Label(interaction.kind.title, systemImage: interaction.kind.systemImage)
+                        .labelStyle(.iconOnly)
+                        .foregroundStyle(.secondary)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(interaction.summary)
+                        Text(interaction.date, format: .dateTime.month().day().year())
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    func addInteraction() {
+        do {
+            try store.addInteraction(to: contact, kind: interactionKind, summary: interactionSummary)
+            interactionSummary = ""
+            interactionKind = .note
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -28,6 +28,8 @@ struct ContactDetailView: View {
     @State var errorMessage: String?
     @FocusState private var nameFieldFocused: Bool
     @State var lastSavedFingerprint = ""
+    @State var interactionKind: ContactInteractionKind = .note
+    @State var interactionSummary = ""
 
     var store: ContactStore { ContactStore(context) }
 
@@ -72,6 +74,8 @@ struct ContactDetailView: View {
                 }
                 .accessibilityIdentifier("mark-contacted-button")
             }
+
+            historySection
 
             fieldSection("Email", kind: .email, fields: contact.emails)
             fieldSection("Phone", kind: .phone, fields: contact.phones)

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -367,8 +367,6 @@ private extension ContentView {
             })
     }
 
-    // MARK: - Print / PDF
-
     func exportSelectedContactAsPDF() {
         guard let contact = selectedContact else {
             errorMessage = "Select a contact to export as PDF."
@@ -396,5 +394,7 @@ private extension ContentView {
 
 #Preview {
     ContentView()
-        .modelContainer(for: Contact.self, inMemory: true)
+        .modelContainer(for: [
+            Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+        ], inMemory: true)
 }

--- a/ContactManager/Views/QuickCaptureView.swift
+++ b/ContactManager/Views/QuickCaptureView.swift
@@ -121,5 +121,8 @@ private struct QuickCapturePreview: View {
 
 #Preview {
     QuickCaptureView()
-        .modelContainer(for: [Contact.self, ContactField.self, ContactGroup.self], inMemory: true)
+        .modelContainer(
+            for: [Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self],
+            inMemory: true
+        )
 }

--- a/ContactManagerTests/ContactEntityQueryTests.swift
+++ b/ContactManagerTests/ContactEntityQueryTests.swift
@@ -21,7 +21,7 @@ final class ContactEntityQueryTests {
 
     init() throws {
         container = try ModelContainer(
-            for: Contact.self, ContactField.self, ContactGroup.self,
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         // The query reads contacts from this process-wide handle.

--- a/ContactManagerTests/ContactHistoryTests.swift
+++ b/ContactManagerTests/ContactHistoryTests.swift
@@ -1,0 +1,107 @@
+//
+//  ContactHistoryTests.swift
+//  ContactManagerTests
+//
+//  Relationship-history ContactStore behavior.
+//
+
+@testable import ContactManager
+import Foundation
+import SwiftData
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct ContactHistoryTests {
+    let container: ModelContainer
+    let store: ContactStore
+    var context: ModelContext { container.mainContext }
+
+    init() throws {
+        container = try ModelContainer(
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        store = ContactStore(container.mainContext)
+    }
+
+    private func count<T: PersistentModel>(_: T.Type) throws -> Int {
+        try context.fetchCount(FetchDescriptor<T>())
+    }
+
+    @Test func addInteractionPersistsHistoryAndMarksContacted() throws {
+        let contactedAt = try #require(Birthday.calendar.date(from: DateComponents(
+            year: 2026, month: 6, day: 7, hour: 12
+        )))
+        let contact = try store.createContact()
+
+        let interaction = try store.addInteraction(
+            to: contact,
+            kind: .call,
+            summary: "Called about conference follow-up.",
+            at: contactedAt
+        )
+
+        #expect(interaction.contact?.persistentModelID == contact.persistentModelID)
+        #expect(interaction.kind == .call)
+        #expect(interaction.summary == "Called about conference follow-up.")
+        #expect(contact.lastContactedAt == contactedAt)
+        #expect(contact.interactions.map(\.summary) == ["Called about conference follow-up."])
+        #expect(try count(ContactInteraction.self) == 1)
+    }
+
+    @Test func interactionsAreSortedNewestFirst() throws {
+        let olderDate = try #require(Birthday.calendar.date(from: DateComponents(
+            year: 2026, month: 6, day: 1, hour: 12
+        )))
+        let newerDate = try #require(Birthday.calendar.date(from: DateComponents(
+            year: 2026, month: 6, day: 7, hour: 12
+        )))
+        let contact = try store.createContact()
+        _ = try store.addInteraction(to: contact, kind: .meeting, summary: "Planning meeting.", at: olderDate)
+        _ = try store.addInteraction(to: contact, kind: .email, summary: "Sent recap.", at: newerDate)
+
+        #expect(contact.sortedInteractions.map(\.summary) == ["Sent recap.", "Planning meeting."])
+    }
+
+    @Test func backfilledInteractionDoesNotRegressLastContactedDate() throws {
+        let olderDate = try #require(Birthday.calendar.date(from: DateComponents(
+            year: 2026, month: 6, day: 1, hour: 12
+        )))
+        let newerDate = try #require(Birthday.calendar.date(from: DateComponents(
+            year: 2026, month: 6, day: 7, hour: 12
+        )))
+        let contact = try store.createContact()
+        try store.markContacted(contact, at: newerDate)
+
+        _ = try store.addInteraction(to: contact, kind: .note, summary: "Backfilled note.", at: olderDate)
+
+        #expect(contact.lastContactedAt == newerDate)
+    }
+
+    @Test func deletingContactCascadesToInteractions() throws {
+        let contact = try store.createContact()
+        _ = try store.addInteraction(to: contact, kind: .note, summary: "Initial note.")
+        #expect(try count(ContactInteraction.self) == 1)
+
+        try store.delete(contact)
+
+        #expect(try count(Contact.self) == 0)
+        #expect(try count(ContactInteraction.self) == 0)
+    }
+
+    @Test func mergePreservesHistoryFromMergedContacts() throws {
+        let primary = try store.createContact()
+        primary.firstName = "Ada"
+        let duplicate = try store.createContact()
+        duplicate.firstName = "Ada"
+        _ = try store.addInteraction(to: duplicate, kind: .meeting, summary: "Met at WWDC.")
+
+        let merged = try store.merge([primary, duplicate])
+
+        #expect(try count(Contact.self) == 1)
+        #expect(try count(ContactInteraction.self) == 1)
+        #expect(merged.sortedInteractions.map(\.summary) == ["Met at WWDC."])
+        #expect(merged.sortedInteractions.first?.contact?.persistentModelID == primary.persistentModelID)
+    }
+}

--- a/ContactManagerTests/ContactModelTests.swift
+++ b/ContactManagerTests/ContactModelTests.swift
@@ -21,7 +21,7 @@ struct ContactModelTests {
 
     init() throws {
         container = try ModelContainer(
-            for: Contact.self, ContactField.self, ContactGroup.self,
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
     }

--- a/ContactManagerTests/ContactStorePendingEditTests.swift
+++ b/ContactManagerTests/ContactStorePendingEditTests.swift
@@ -18,7 +18,7 @@ struct ContactStorePendingEditTests {
 
     init() throws {
         container = try ModelContainer(
-            for: Contact.self, ContactField.self, ContactGroup.self,
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/ContactStoreTests.swift
+++ b/ContactManagerTests/ContactStoreTests.swift
@@ -23,7 +23,7 @@ struct ContactStoreTests {
 
     init() throws {
         container = try ModelContainer(
-            for: Contact.self, ContactField.self, ContactGroup.self,
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/DefaultGroupPreferenceTests.swift
+++ b/ContactManagerTests/DefaultGroupPreferenceTests.swift
@@ -20,7 +20,7 @@ struct DefaultGroupPreferenceTests {
 
     init() throws {
         container = try ModelContainer(
-            for: Contact.self, ContactField.self, ContactGroup.self,
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/GroupDropTests.swift
+++ b/ContactManagerTests/GroupDropTests.swift
@@ -19,7 +19,7 @@ struct GroupDropTests {
 
     init() throws {
         container = try ModelContainer(
-            for: Contact.self, ContactField.self, ContactGroup.self,
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/ImportReviewTests.swift
+++ b/ContactManagerTests/ImportReviewTests.swift
@@ -20,7 +20,7 @@ struct ImportReviewTests {
 
     init() throws {
         container = try ModelContainer(
-            for: Contact.self, ContactField.self, ContactGroup.self,
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/QuickCaptureTests.swift
+++ b/ContactManagerTests/QuickCaptureTests.swift
@@ -20,7 +20,7 @@ struct QuickCaptureTests {
 
     init() throws {
         container = try ModelContainer(
-            for: Contact.self, ContactField.self, ContactGroup.self,
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/SpotlightDeltaTests.swift
+++ b/ContactManagerTests/SpotlightDeltaTests.swift
@@ -22,7 +22,7 @@ struct SpotlightDeltaTests {
 
     init() throws {
         container = try ModelContainer(
-            for: Contact.self, ContactField.self, ContactGroup.self,
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/UndoTests.swift
+++ b/ContactManagerTests/UndoTests.swift
@@ -21,7 +21,7 @@ struct UndoTests {
 
     init() throws {
         container = try ModelContainer(
-            for: Contact.self, ContactField.self, ContactGroup.self,
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         undoManager = UndoManager()

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -115,8 +115,9 @@ final class ContactManagerUITests: XCTestCase {
     }
 
     /// Verifies the relationship-intelligence affordances render in the live
-    /// app: smart-list sidebar rows and the selected contact's mark-contacted
-    /// action. Filtering behavior stays in the deterministic unit tests.
+    /// app: smart-list sidebar rows, mark-contacted, and contact-history
+    /// controls. Filtering and persistence behavior stay in deterministic unit
+    /// tests.
     func test_smartListsAndMarkContactedControlsRender() {
         let app = bootSeededApp()
 
@@ -128,6 +129,9 @@ final class ContactManagerUITests: XCTestCase {
         app.typeKey("n", modifierFlags: .command)
 
         XCTAssertTrue(app.buttons["mark-contacted-button"].waitForExistence(timeout: 3))
+        let historyNote = app.descendants(matching: .any)["interaction-summary-field"]
+        XCTAssertTrue(historyNote.waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["add-interaction-button"].exists)
     }
 
     /// Verifies the quick-capture command opens a focused capture window and


### PR DESCRIPTION
## Summary
Add contact-history notes so a contact can track calls, emails, meetings, messages, and notes from the detail view.

## Changes
- Added a SwiftData ContactInteraction model and registered it in the app/test schemas.
- Added ContactStore interaction mutations with undo/save/rollback behavior through the existing mutation pipeline.
- Added a History section in ContactDetailView with stable accessibility identifiers.
- Preserved interaction history during duplicate merges and prevented backfilled notes from regressing last-contacted dates.
- Added ContactHistoryTests and expanded UI smoke coverage for the new controls.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - make check
  - make test

## Screenshots (if applicable)
N/A

## Related Issues
Closes #