### PR TITLE
feat(contacts): add backup restore flow

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		01001E025DB1348D36342E1C /* OpenContactIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279FCAC10E829D7DAC9D8385 /* OpenContactIntentTests.swift */; };
+		012DFE934E6F0E77278DA1B1 /* ContactBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A10D26E6D853A5EB462682B /* ContactBackupTests.swift */; };
 		02D950C10327393FB2B5BB7E /* ImageProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76507F3A1E2222FB64D7F31 /* ImageProcessing.swift */; };
 		0ABBB9962C4AC14A077728FF /* ContactStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03763AB80D45F026EC585490 /* ContactStoreTests.swift */; };
 		0DC8E4BAF454185075119C3A /* ContactStorePendingEditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438C2B20E1C302676594ECCA /* ContactStorePendingEditTests.swift */; };
@@ -26,6 +27,7 @@
 		39D33CDF2E0495FCCA8D7E13 /* QuickCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C76A783B91BD2AA6D3F70B /* QuickCaptureTests.swift */; };
 		3EDDAA184C377D9C16AAF08A /* ContactStore+PendingEdits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */; };
 		3FA1770FF1649CC78510AF10 /* ContentView+Alerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0401F25DFDF91CE847706D08 /* ContentView+Alerts.swift */; };
+		42F87AE7D82D2D802D7B670E /* ContactBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E45011FDD9D571FF1834F5 /* ContactBackup.swift */; };
 		442122E49889F5A9CA174B12 /* ContactActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */; };
 		444B949F37F7FF7DD98A4C6B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */; };
 		4515C79B40C414630F64BC5D /* PersistentIdentifierEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */; };
@@ -50,6 +52,7 @@
 		6DDC44CAA558E1DB276460CF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833F1AF82CACF7B9E89BADCA /* ContentView.swift */; };
 		6DF39989CF5CF55F228DA933 /* PDFExportDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC69A4C348D4BBEF0D8F1330 /* PDFExportDocument.swift */; };
 		7755029B0E36200BB139ECFA /* VCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7D5B554122CF852B0D825C /* VCardTests.swift */; };
+		77E57EC2CBB52AF28D0DD20F /* ContactStore+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF65D4073AB3F28A3F52005 /* ContactStore+Backup.swift */; };
 		7CD9C3EBF737E415B2561168 /* CSV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2F2242E59F2C42DDD0736B /* CSV.swift */; };
 		7F3D3F509379FD171AEC3606 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DEAB729518FA2A6600E3570B /* Images.xcassets */; };
 		8108F2C0C987CDC1258A3E7C /* ContactLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E3C45DEC115A2BF7DE83DF /* ContactLink.swift */; };
@@ -64,8 +67,10 @@
 		8EF7CD9AAA833F08834D2AA4 /* QuickCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5951D4D8D52B6CDB782FE37D /* QuickCaptureView.swift */; };
 		91DA07BB24CEA1941C5AFA6E /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 76F68BAD5C3290EE7ABF787B /* Localizable.xcstrings */; };
 		9506DFC07D9490AEDFB096EC /* ImageProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */; };
+		96FB713B5A967D1C076AE445 /* ContentView+FileDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C83A331432D80A054D0AE94 /* ContentView+FileDialogs.swift */; };
 		97E98BCB6784672DCB8C1625 /* VCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7276D515CA167FBF4C47299 /* VCard.swift */; };
 		97F582C8C0B47ABD787E2C2E /* ContactStore+ImportReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90D71F3F01E29B7C4B739A7 /* ContactStore+ImportReview.swift */; };
+		A04D61E7D5979B59983B7EF9 /* ContactBackupDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937EFD55691DF4EA887DF2CA /* ContactBackupDocument.swift */; };
 		A486AAFFBF01C05775A7BB38 /* ContactEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915AF700C971510D0B642590 /* ContactEntity.swift */; };
 		A94AB327927F2F1FBBD81119 /* ContactGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFE362455F20C848F729EEE /* ContactGroup.swift */; };
 		AA43BCF64B0DC3F571E4A813 /* DefaultGroupPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECE026D8586731B7C590901 /* DefaultGroupPreference.swift */; };
@@ -86,6 +91,7 @@
 		D09BB01ED8C135141953AFE7 /* ImportReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA2237DBD182839EAF04F1 /* ImportReviewView.swift */; };
 		D4431A7BEF48D8A75EFB8DC8 /* ContactStore+QuickCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34532FC6E64B32F9A27FCDCD /* ContactStore+QuickCapture.swift */; };
 		D5255AD7FAD03FD891ECC97B /* ContactStore+Interactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7466E6CBC023A24F4365537C /* ContactStore+Interactions.swift */; };
+		E11A07680CCF44C864B95662 /* ContentView+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C8E57A2BB1F32050119C06 /* ContentView+Backup.swift */; };
 		E5EB465B5CE3964197D29ADF /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F82C8A388E97CC4F1106176 /* SampleData.swift */; };
 		ECB7FDD8D0C3091EA0D42917 /* UndoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DCAF444714BC3726B212C4 /* UndoTests.swift */; };
 		ECDA4BC68D3FAE4CCF428675 /* ContactDetailView+Saving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */; };
@@ -128,6 +134,7 @@
 		279FCAC10E829D7DAC9D8385 /* OpenContactIntentTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenContactIntentTests.swift; sourceTree = "<group>"; };
 		29335D93B2E97B9038F1481A /* ImportProgressView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportProgressView.swift; sourceTree = "<group>"; };
 		2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
+		2C83A331432D80A054D0AE94 /* ContentView+FileDialogs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+FileDialogs.swift"; sourceTree = "<group>"; };
 		2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardDocument.swift; sourceTree = "<group>"; };
 		34532FC6E64B32F9A27FCDCD /* ContactStore+QuickCapture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ContactStore+QuickCapture.swift"; path = "ContactManager/Models/ContactStore+QuickCapture.swift"; sourceTree = "<group>"; };
 		3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinderTests.swift; sourceTree = "<group>"; };
@@ -136,15 +143,19 @@
 		436B4115937E4350EB9A7EF7 /* Chunking.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Chunking.swift; sourceTree = "<group>"; };
 		438C2B20E1C302676594ECCA /* ContactStorePendingEditTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStorePendingEditTests.swift; sourceTree = "<group>"; };
 		45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+PendingEdits.swift"; sourceTree = "<group>"; };
+		4A10D26E6D853A5EB462682B /* ContactBackupTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactBackupTests.swift; sourceTree = "<group>"; };
 		4E2F2242E59F2C42DDD0736B /* CSV.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSV.swift; sourceTree = "<group>"; };
 		54C373BD237429970D6A7C86 /* DuplicatesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicatesView.swift; sourceTree = "<group>"; };
 		5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingTests.swift; sourceTree = "<group>"; };
 		570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Birthday.swift"; sourceTree = "<group>"; };
 		5951D4D8D52B6CDB782FE37D /* QuickCaptureView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickCaptureView.swift; path = ContactManager/Views/QuickCaptureView.swift; sourceTree = "<group>"; };
+		5BF65D4073AB3F28A3F52005 /* ContactStore+Backup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+Backup.swift"; sourceTree = "<group>"; };
 		604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotlightDeltaTests.swift; sourceTree = "<group>"; };
 		61587B4E14B400AF1CB16862 /* PersistentIdentifierEncoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PersistentIdentifierEncoding.swift; sourceTree = "<group>"; };
 		617D7B082A403094284FBD38 /* ContactStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStore.swift; sourceTree = "<group>"; };
+		61C8E57A2BB1F32050119C06 /* ContentView+Backup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+Backup.swift"; sourceTree = "<group>"; };
 		6303A7F66E428BF3662142C0 /* SidebarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
+		66E45011FDD9D571FF1834F5 /* ContactBackup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactBackup.swift; sourceTree = "<group>"; };
 		66F852CE2356ADE83460064B /* ContentView+Import.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+Import.swift"; sourceTree = "<group>"; };
 		6EE79F02FFFD9820269D3725 /* ContactLinkTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactLinkTests.swift; sourceTree = "<group>"; };
 		734D363DD0CB0BAA7AE9460B /* LayoutMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LayoutMetrics.swift; sourceTree = "<group>"; };
@@ -164,6 +175,7 @@
 		9116FC0A7E009E9A806FD48F /* ContactInteraction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactInteraction.swift; sourceTree = "<group>"; };
 		915AF700C971510D0B642590 /* ContactEntity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntity.swift; sourceTree = "<group>"; };
 		92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Saving.swift"; sourceTree = "<group>"; };
+		937EFD55691DF4EA887DF2CA /* ContactBackupDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactBackupDocument.swift; sourceTree = "<group>"; };
 		93C12246003379D5966F0210 /* ContactEntityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityTests.swift; sourceTree = "<group>"; };
 		964ACD67CC8CB35694497A10 /* GroupDropTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroupDropTests.swift; sourceTree = "<group>"; };
 		A2C76A783B91BD2AA6D3F70B /* QuickCaptureTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickCaptureTests.swift; path = ContactManagerTests/QuickCaptureTests.swift; sourceTree = "<group>"; };
@@ -260,6 +272,7 @@
 				45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */,
 				9116FC0A7E009E9A806FD48F /* ContactInteraction.swift */,
 				7466E6CBC023A24F4365537C /* ContactStore+Interactions.swift */,
+				5BF65D4073AB3F28A3F52005 /* ContactStore+Backup.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -281,6 +294,8 @@
 				C0255C29CC874D2BA1C064CF /* ContactPDF.swift */,
 				DC69A4C348D4BBEF0D8F1330 /* PDFExportDocument.swift */,
 				B0CF4C47C670B0A8C3B6B384 /* ContactActivity.swift */,
+				66E45011FDD9D571FF1834F5 /* ContactBackup.swift */,
+				937EFD55691DF4EA887DF2CA /* ContactBackupDocument.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -320,6 +335,8 @@
 				B7C0DCB1419D1BD49893F8AD /* ContactDetailView+QuickInfo.swift */,
 				83E63AB996E12C5978B4A8F1 /* ContactFieldRow.swift */,
 				784AEA3986875E3472052482 /* ContactDetailView+History.swift */,
+				2C83A331432D80A054D0AE94 /* ContentView+FileDialogs.swift */,
+				61C8E57A2BB1F32050119C06 /* ContentView+Backup.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -392,6 +409,7 @@
 				C95BBAB51882751053816B2C /* ImportReviewTests.swift */,
 				438C2B20E1C302676594ECCA /* ContactStorePendingEditTests.swift */,
 				764B3FB47DAFF8CE837BDE9D /* ContactHistoryTests.swift */,
+				4A10D26E6D853A5EB462682B /* ContactBackupTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -578,6 +596,11 @@
 				4748DC4114188B76B5384A8D /* ContactInteraction.swift in Sources */,
 				D5255AD7FAD03FD891ECC97B /* ContactStore+Interactions.swift in Sources */,
 				84EC52BD6CC2F06EFFFF0758 /* ContactDetailView+History.swift in Sources */,
+				77E57EC2CBB52AF28D0DD20F /* ContactStore+Backup.swift in Sources */,
+				42F87AE7D82D2D802D7B670E /* ContactBackup.swift in Sources */,
+				A04D61E7D5979B59983B7EF9 /* ContactBackupDocument.swift in Sources */,
+				96FB713B5A967D1C076AE445 /* ContentView+FileDialogs.swift in Sources */,
+				E11A07680CCF44C864B95662 /* ContentView+Backup.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -609,6 +632,7 @@
 				0DC8E4BAF454185075119C3A /* ContactStorePendingEditTests.swift in Sources */,
 				39D33CDF2E0495FCCA8D7E13 /* QuickCaptureTests.swift in Sources */,
 				337B23E02F63EB1A294A5A41 /* ContactHistoryTests.swift in Sources */,
+				012DFE934E6F0E77278DA1B1 /* ContactBackupTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -111,6 +111,12 @@ struct ContactManagerApp: App {
                     NotificationCenter.default.post(name: .exportVCardRequested, object: nil)
                 }
                 .keyboardShortcut("e", modifiers: [.command, .shift])
+                Button("Export Backup…") {
+                    NotificationCenter.default.post(name: .exportBackupRequested, object: nil)
+                }
+                Button("Restore Backup…") {
+                    NotificationCenter.default.post(name: .restoreBackupRequested, object: nil)
+                }
                 Button("Export as PDF…") {
                     NotificationCenter.default.post(name: .exportPDFRequested, object: nil)
                 }
@@ -291,6 +297,8 @@ extension Notification.Name {
     static let importCSVRequested = Notification.Name("ContactManager.importCSVRequested")
     static let importSystemContactsRequested = Notification.Name("ContactManager.importSystemContactsRequested")
     static let exportVCardRequested = Notification.Name("ContactManager.exportVCardRequested")
+    static let exportBackupRequested = Notification.Name("ContactManager.exportBackupRequested")
+    static let restoreBackupRequested = Notification.Name("ContactManager.restoreBackupRequested")
     /// Posted by the Export as PDF / Print commands; handled by `ContentView`
     /// for the selected contact.
     static let exportPDFRequested = Notification.Name("ContactManager.exportPDFRequested")

--- a/ContactManager/Models/ContactStore+Backup.swift
+++ b/ContactManager/Models/ContactStore+Backup.swift
@@ -1,0 +1,113 @@
+//
+//  ContactStore+Backup.swift
+//  ContactManager
+//
+//  Additive restore support for ContactManager backup snapshots.
+//
+
+import Foundation
+
+extension ContactStore {
+    @discardableResult
+    func restoreBackup(_ backup: ContactBackup) throws -> BackupRestoreResult {
+        try mutate("Restore Backup") {
+            var result = BackupRestoreResult()
+            var restoredGroups: [String: ContactGroup] = [:]
+
+            for record in backup.groups {
+                let group = ContactGroup(name: record.name, createdAt: record.createdAt)
+                context.insert(group)
+                restoredGroups[record.id] = group
+                result.groupsRestored += 1
+            }
+
+            for record in backup.contacts {
+                let contact = Contact(record)
+                contact.photoData = record.photoData
+                contact.groups = record.groupIDs.compactMap { restoredGroups[$0] }
+                context.insert(contact)
+                restoreFields(record.fields, to: contact)
+                restoreInteractions(record.interactions, to: contact)
+                result.contactsRestored += 1
+                result.interactionsRestored += record.interactions.count
+            }
+
+            return result
+        }
+    }
+
+    private func restoreFields(_ records: [ContactBackup.FieldRecord], to contact: Contact) {
+        for record in records {
+            let field = ContactField(
+                kind: record.kind,
+                label: record.label,
+                value: record.value,
+                sortIndex: record.sortIndex
+            )
+            field.contact = contact
+            context.insert(field)
+        }
+    }
+
+    private func restoreInteractions(_ records: [ContactBackup.InteractionRecord], to contact: Contact) {
+        for record in records {
+            let interaction = ContactInteraction(kind: record.kind, summary: record.summary, date: record.date)
+            interaction.contact = contact
+            context.insert(interaction)
+        }
+    }
+}
+
+private extension Contact {
+    convenience init(_ record: ContactBackup.ContactRecord) {
+        self.init(
+            firstName: record.firstName,
+            lastName: record.lastName,
+            company: record.company,
+            jobTitle: record.jobTitle,
+            street: record.street,
+            city: record.city,
+            state: record.state,
+            postalCode: record.postalCode,
+            country: record.country,
+            birthday: record.birthday,
+            lastContactedAt: record.lastContactedAt,
+            notes: record.notes,
+            createdAt: record.createdAt
+        )
+    }
+}
+
+struct BackupRestoreResult {
+    var contactsRestored = 0
+    var groupsRestored = 0
+    var interactionsRestored = 0
+
+    var title: String {
+        if contactsRestored == 1 { return "Restored 1 Contact" }
+        return "Restored \(contactsRestored) Contacts"
+    }
+
+    var message: String {
+        let parts = [
+            count(contactsRestored, label: "contacts"),
+            count(groupsRestored, label: "groups"),
+            count(interactionsRestored, label: "history notes"),
+        ].compactMap(\.self)
+        if parts.isEmpty {
+            return "No contacts, groups, or history notes restored."
+        }
+        return parts.joined(separator: ", ").capitalizedIfFirst + "."
+    }
+
+    private func count(_ value: Int, label: String) -> String? {
+        value == 0 ? nil : "\(value) \(label)"
+    }
+}
+
+private extension String {
+    var capitalizedIfFirst: String {
+        guard let first else { return self }
+        return first.uppercased() + dropFirst()
+    }
+}

--- a/ContactManager/Support/ContactBackup.swift
+++ b/ContactManager/Support/ContactBackup.swift
@@ -1,0 +1,137 @@
+//
+//  ContactBackup.swift
+//  ContactManager
+//
+//  Codable snapshot format for ContactManager backups.
+//
+
+import Foundation
+import SwiftData
+
+struct ContactBackup: Codable, Equatable {
+    static let currentVersion = 1
+
+    var version: Int
+    var exportedAt: Date
+    var groups: [GroupRecord]
+    var contacts: [ContactRecord]
+
+    init(
+        version: Int = Self.currentVersion,
+        exportedAt: Date = .now,
+        groups: [GroupRecord] = [],
+        contacts: [ContactRecord] = []
+    ) {
+        self.version = version
+        self.exportedAt = exportedAt
+        self.groups = groups
+        self.contacts = contacts
+    }
+
+    static func make(
+        contacts: [Contact],
+        groups: [ContactGroup],
+        exportedAt: Date = .now
+    ) -> ContactBackup {
+        let groupIDs = Dictionary(uniqueKeysWithValues: groups.map { group in
+            (group.persistentModelID, backupID(for: group))
+        })
+        return ContactBackup(
+            exportedAt: exportedAt,
+            groups: groups
+                .sorted { lhs, rhs in
+                    if lhs.displayName != rhs.displayName { return lhs.displayName < rhs.displayName }
+                    return lhs.createdAt < rhs.createdAt
+                }
+                .map { GroupRecord(id: backupID(for: $0), name: $0.name, createdAt: $0.createdAt) },
+            contacts: ContactQuery.sorted(contacts).map { contact in
+                ContactRecord(contact: contact, groupIDs: groupIDs)
+            }
+        )
+    }
+
+    private static func backupID(for group: ContactGroup) -> String {
+        group.persistentModelID.storedString ?? String(describing: group.persistentModelID)
+    }
+}
+
+extension ContactBackup {
+    struct GroupRecord: Codable, Equatable, Identifiable {
+        var id: String
+        var name: String
+        var createdAt: Date
+    }
+
+    struct ContactRecord: Codable, Equatable, Identifiable {
+        var id: String
+        var firstName: String
+        var lastName: String
+        var company: String
+        var jobTitle: String
+        var street: String
+        var city: String
+        var state: String
+        var postalCode: String
+        var country: String
+        var birthday: Date?
+        var lastContactedAt: Date?
+        var notes: String
+        var createdAt: Date
+        var photoData: Data?
+        var fields: [FieldRecord]
+        var groupIDs: [String]
+        var interactions: [InteractionRecord]
+
+        init(contact: Contact, groupIDs: [PersistentIdentifier: String]) {
+            id = contact.persistentModelID.storedString ?? String(describing: contact.persistentModelID)
+            firstName = contact.firstName
+            lastName = contact.lastName
+            company = contact.company
+            jobTitle = contact.jobTitle
+            street = contact.street
+            city = contact.city
+            state = contact.state
+            postalCode = contact.postalCode
+            country = contact.country
+            birthday = contact.birthday
+            lastContactedAt = contact.lastContactedAt
+            notes = contact.notes
+            createdAt = contact.createdAt
+            photoData = contact.photoData
+            fields = contact.fields
+                .sorted { lhs, rhs in
+                    if lhs.kind != rhs.kind { return lhs.kind.rawValue < rhs.kind.rawValue }
+                    return lhs.sortIndex < rhs.sortIndex
+                }
+                .map(FieldRecord.init(field:))
+            self.groupIDs = contact.groups.compactMap { groupIDs[$0.persistentModelID] }.sorted()
+            interactions = contact.sortedInteractions.map(InteractionRecord.init(interaction:))
+        }
+    }
+
+    struct FieldRecord: Codable, Equatable {
+        var kind: FieldKind
+        var label: FieldLabel
+        var value: String
+        var sortIndex: Int
+
+        init(field: ContactField) {
+            kind = field.kind
+            label = field.label
+            value = field.value
+            sortIndex = field.sortIndex
+        }
+    }
+
+    struct InteractionRecord: Codable, Equatable {
+        var date: Date
+        var kind: ContactInteractionKind
+        var summary: String
+
+        init(interaction: ContactInteraction) {
+            date = interaction.date
+            kind = interaction.kind
+            summary = interaction.summary
+        }
+    }
+}

--- a/ContactManager/Support/ContactBackupDocument.swift
+++ b/ContactManager/Support/ContactBackupDocument.swift
@@ -1,0 +1,43 @@
+//
+//  ContactBackupDocument.swift
+//  ContactManager
+//
+//  FileDocument wrapper for ContactManager JSON backups.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ContactBackupDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.json] }
+    static var writableContentTypes: [UTType] { [.json] }
+
+    var backup: ContactBackup
+
+    init(backup: ContactBackup = ContactBackup()) {
+        self.backup = backup
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        guard let data = configuration.file.regularFileContents else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        backup = try Self.decode(data)
+    }
+
+    func fileWrapper(configuration _: WriteConfiguration) throws -> FileWrapper {
+        let data = try Self.encode(backup)
+        return FileWrapper(regularFileWithContents: data)
+    }
+
+    static func encode(_ backup: ContactBackup) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(backup)
+    }
+
+    static func decode(_ data: Data) throws -> ContactBackup {
+        let decoder = JSONDecoder()
+        return try decoder.decode(ContactBackup.self, from: data)
+    }
+}

--- a/ContactManager/Views/ContentView+Alerts.swift
+++ b/ContactManager/Views/ContentView+Alerts.swift
@@ -28,5 +28,14 @@ extension ContentView {
             } message: { summary in
                 Text(summary.message)
             }
+            .alert(
+                restoreSummary?.title ?? "Restore Complete",
+                isPresented: Binding(get: { restoreSummary != nil }, set: { if !$0 { restoreSummary = nil } }),
+                presenting: restoreSummary
+            ) { _ in
+                Button("OK", role: .cancel) {}
+            } message: { summary in
+                Text(summary.message)
+            }
     }
 }

--- a/ContactManager/Views/ContentView+Backup.swift
+++ b/ContactManager/Views/ContentView+Backup.swift
@@ -1,0 +1,31 @@
+//
+//  ContentView+Backup.swift
+//  ContactManager
+//
+//  Backup export and additive restore actions.
+//
+
+import Foundation
+
+extension ContentView {
+    func exportBackup() {
+        backupDocument = ContactBackupDocument(backup: ContactBackup.make(contacts: contacts, groups: groups))
+        isExportingBackup = true
+    }
+
+    func restoreBackup(_ result: Result<URL, Error>) {
+        do {
+            let url = try result.get()
+            let accessing = url.startAccessingSecurityScopedResource()
+            defer {
+                if accessing { url.stopAccessingSecurityScopedResource() }
+            }
+
+            let data = try Data(contentsOf: url)
+            let backup = try ContactBackupDocument.decode(data)
+            restoreSummary = try store.restoreBackup(backup)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ContactManager/Views/ContentView+FileDialogs.swift
+++ b/ContactManager/Views/ContentView+FileDialogs.swift
@@ -1,0 +1,87 @@
+//
+//  ContentView+FileDialogs.swift
+//  ContactManager
+//
+//  File import/export dialogs and single-contact PDF/print commands.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+extension ContentView {
+    /// The sheets, importers, exporters, and the error alert.
+    func handlingFileDialogs(_ content: some View) -> some View {
+        handlingImportAlerts(content
+            .sheet(isPresented: $showingDuplicates) {
+                DuplicatesView()
+            }
+            .fileImporter(isPresented: $isImportingVCard, allowedContentTypes: [.vCard]) { result in
+                handleImport(result)
+            }
+            .fileImporter(isPresented: $isImportingCSV, allowedContentTypes: [.commaSeparatedText]) { result in
+                handleCSVImport(result)
+            }
+            .fileImporter(isPresented: $isRestoringBackup, allowedContentTypes: [.json]) { result in
+                restoreBackup(result)
+            }
+            .fileExporter(
+                isPresented: $isExportingVCard,
+                document: exportDocument,
+                contentType: .vCard,
+                defaultFilename: "Contacts"
+            ) { result in
+                if case .failure(let error) = result {
+                    errorMessage = error.localizedDescription
+                }
+            }
+            .fileExporter(
+                isPresented: $isExportingBackup,
+                document: backupDocument,
+                contentType: .json,
+                defaultFilename: "ContactManager Backup"
+            ) { result in
+                if case .failure(let error) = result {
+                    errorMessage = error.localizedDescription
+                }
+            }
+            .fileExporter(
+                isPresented: $isExportingPDF,
+                document: pdfDocument,
+                contentType: .pdf,
+                defaultFilename: pdfFilename
+            ) { result in
+                if case .failure(let error) = result {
+                    errorMessage = error.localizedDescription
+                }
+            }
+            .sheet(isPresented: $isReviewingImport) {
+                ImportReviewView(items: $importReviewItems) { items in
+                    Task { await applyImportReview(items) }
+                }
+            })
+    }
+
+    func exportSelectedContactAsPDF() {
+        guard let contact = selectedContact else {
+            errorMessage = "Select a contact to export as PDF."
+            return
+        }
+        guard let data = ContactPDF.data(for: contact) else {
+            errorMessage = "Couldn't generate a PDF for that contact."
+            return
+        }
+        pdfDocument = PDFExportDocument(data: data)
+        pdfFilename = ContactPDF.filename(for: contact)
+        isExportingPDF = true
+    }
+
+    func printSelectedContact() {
+        guard let contact = selectedContact else {
+            errorMessage = "Select a contact to print."
+            return
+        }
+        if !ContactPDF.print(contact) {
+            errorMessage = "Couldn't prepare that contact for printing."
+        }
+    }
+}

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -19,10 +19,10 @@ struct ContentView: View {
     @Query(sort: [SortDescriptor(\Contact.lastName), SortDescriptor(\Contact.firstName)])
     var contacts: [Contact]
 
-    @Query(sort: \ContactGroup.name) private var groups: [ContactGroup]
+    @Query(sort: \ContactGroup.name) var groups: [ContactGroup]
 
     @State private var sidebarSelection: SidebarItem? = .allContacts
-    @State private var selectedContact: Contact?
+    @State var selectedContact: Contact?
     @State private var contactPendingNameFocus: PersistentIdentifier?
     @State var errorMessage: String?
     @State var importProgress: ImportProgress?
@@ -31,17 +31,21 @@ struct ContentView: View {
     @AppStorage("contactSortOrder") private var sortOrder: ContactSortOrder = .lastName
     @AppStorage("defaultGroupID") private var defaultGroupID: String = ""
 
-    @State private var isImportingVCard = false
-    @State private var isImportingCSV = false
-    @State private var isExportingVCard = false
-    @State private var exportDocument = VCardDocument(text: "")
-    @State private var showingDuplicates = false
-    @State private var isExportingPDF = false
-    @State private var pdfDocument = PDFExportDocument(data: Data())
-    @State private var pdfFilename = "Contact"
+    @State var isImportingVCard = false
+    @State var isImportingCSV = false
+    @State var isExportingVCard = false
+    @State var exportDocument = VCardDocument(text: "")
+    @State var showingDuplicates = false
+    @State var isExportingPDF = false
+    @State var pdfDocument = PDFExportDocument(data: Data())
+    @State var pdfFilename = "Contact"
+    @State var isExportingBackup = false
+    @State var isRestoringBackup = false
+    @State var backupDocument = ContactBackupDocument()
     @State var importReviewItems: [ImportReviewItem] = []
     @State var isReviewingImport = false
     @State var importSummary: ImportReviewResult?
+    @State var restoreSummary: BackupRestoreResult?
 
     var store: ContactStore { ContactStore(context) }
 
@@ -279,6 +283,12 @@ private extension ContentView {
                 exportDocument = VCardDocument(text: store.exportVCards(contacts))
                 isExportingVCard = true
             }
+            .onReceive(NotificationCenter.default.publisher(for: .exportBackupRequested)) { _ in
+                exportBackup()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .restoreBackupRequested)) { _ in
+                isRestoringBackup = true
+            }
             .onReceive(NotificationCenter.default.publisher(for: .findDuplicatesRequested)) { _ in
                 showingDuplicates = true
             }
@@ -326,69 +336,6 @@ private extension ContentView {
             .onContinueUserActivity(ContactActivity.viewContactType) { activity in
                 selectContact(byEncodedID: ContactActivity.contactID(from: activity))
             }
-    }
-
-    /// The sheets, importers, exporters, and the error alert.
-    func handlingFileDialogs(_ content: some View) -> some View {
-        handlingImportAlerts(content
-            .sheet(isPresented: $showingDuplicates) {
-                DuplicatesView()
-            }
-            .fileImporter(isPresented: $isImportingVCard, allowedContentTypes: [.vCard]) { result in
-                handleImport(result)
-            }
-            .fileImporter(isPresented: $isImportingCSV, allowedContentTypes: [.commaSeparatedText]) { result in
-                handleCSVImport(result)
-            }
-            .fileExporter(
-                isPresented: $isExportingVCard,
-                document: exportDocument,
-                contentType: .vCard,
-                defaultFilename: "Contacts"
-            ) { result in
-                if case .failure(let error) = result {
-                    errorMessage = error.localizedDescription
-                }
-            }
-            .fileExporter(
-                isPresented: $isExportingPDF,
-                document: pdfDocument,
-                contentType: .pdf,
-                defaultFilename: pdfFilename
-            ) { result in
-                if case .failure(let error) = result {
-                    errorMessage = error.localizedDescription
-                }
-            }
-            .sheet(isPresented: $isReviewingImport) {
-                ImportReviewView(items: $importReviewItems) { items in
-                    Task { await applyImportReview(items) }
-                }
-            })
-    }
-
-    func exportSelectedContactAsPDF() {
-        guard let contact = selectedContact else {
-            errorMessage = "Select a contact to export as PDF."
-            return
-        }
-        guard let data = ContactPDF.data(for: contact) else {
-            errorMessage = "Couldn't generate a PDF for that contact."
-            return
-        }
-        pdfDocument = PDFExportDocument(data: data)
-        pdfFilename = ContactPDF.filename(for: contact)
-        isExportingPDF = true
-    }
-
-    func printSelectedContact() {
-        guard let contact = selectedContact else {
-            errorMessage = "Select a contact to print."
-            return
-        }
-        if !ContactPDF.print(contact) {
-            errorMessage = "Couldn't prepare that contact for printing."
-        }
     }
 }
 

--- a/ContactManagerTests/ContactBackupTests.swift
+++ b/ContactManagerTests/ContactBackupTests.swift
@@ -1,0 +1,129 @@
+//
+//  ContactBackupTests.swift
+//  ContactManagerTests
+//
+//  Backup/export and additive restore coverage.
+//
+
+@testable import ContactManager
+import Foundation
+import SwiftData
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct ContactBackupTests {
+    let container: ModelContainer
+    let store: ContactStore
+    var context: ModelContext { container.mainContext }
+
+    init() throws {
+        container = try ModelContainer(
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        store = ContactStore(container.mainContext)
+    }
+
+    private func allContacts() throws -> [Contact] {
+        try context.fetch(FetchDescriptor<Contact>())
+    }
+
+    private func allGroups() throws -> [ContactGroup] {
+        try context.fetch(FetchDescriptor<ContactGroup>())
+    }
+
+    @Test func backupCapturesContactsGroupsFieldsAndHistory() throws {
+        let contact = try makePopulatedContact()
+        let contacts = try allContacts()
+        let groups = try allGroups()
+
+        let backup = ContactBackup.make(
+            contacts: contacts,
+            groups: groups,
+            exportedAt: Date(timeIntervalSinceReferenceDate: 42)
+        )
+
+        let record = try #require(backup.contacts.first)
+        #expect(backup.exportedAt == Date(timeIntervalSinceReferenceDate: 42))
+        #expect(record.firstName == "Ada")
+        #expect(record.fields.map(\.value) == ["ada@example.com"])
+        #expect(record.groupIDs.count == 1)
+        #expect(record.interactions.map(\.summary) == ["Met at WWDC."])
+        #expect(record.lastContactedAt == contact.lastContactedAt)
+        #expect(backup.groups.map(\.name) == ["Work"])
+    }
+
+    @Test func restoreBackupRecreatesContactsGroupsFieldsAndHistory() throws {
+        let contact = try makePopulatedContact()
+        let groups = try allGroups()
+        let original = ContactBackup.make(
+            contacts: [contact],
+            groups: groups,
+            exportedAt: Date(timeIntervalSinceReferenceDate: 42)
+        )
+
+        let contactsBeforeRestore = try allContacts()
+        let groupsBeforeRestore = try allGroups()
+        let contactBeforeRestore = try #require(contactsBeforeRestore.first)
+        let groupBeforeRestore = try #require(groupsBeforeRestore.first)
+        try store.delete(contactBeforeRestore)
+        try store.delete(groupBeforeRestore)
+
+        let result = try store.restoreBackup(original)
+
+        let restoredContacts = try allContacts()
+        let restored = try #require(restoredContacts.first)
+        #expect(result.contactsRestored == 1)
+        #expect(result.groupsRestored == 1)
+        #expect(result.interactionsRestored == 1)
+        #expect(restored.fullName == "Ada Lovelace")
+        #expect(restored.lastContactedAt == Date(timeIntervalSinceReferenceDate: 200))
+        #expect(restored.emails.map(\.value) == ["ada@example.com"])
+        #expect(restored.groups.map(\.displayName) == ["Work"])
+        #expect(restored.sortedInteractions.map(\.summary) == ["Met at WWDC."])
+    }
+
+    @Test func backupDocumentRoundTripsJSON() throws {
+        let contact = try makePopulatedContact()
+        let groups = try allGroups()
+        let backup = ContactBackup.make(
+            contacts: [contact],
+            groups: groups,
+            exportedAt: Date(timeIntervalSinceReferenceDate: 42)
+        )
+
+        let data = try ContactBackupDocument.encode(backup)
+        let decoded = try ContactBackupDocument.decode(data)
+
+        #expect(decoded == backup)
+    }
+
+    @Test func emptyRestoreSummaryExplainsNothingWasRestored() throws {
+        let result = try store.restoreBackup(ContactBackup())
+
+        #expect(result.contactsRestored == 0)
+        #expect(result.title == "Restored 0 Contacts")
+        #expect(result.message == "No contacts, groups, or history notes restored.")
+    }
+
+    @discardableResult
+    private func makePopulatedContact() throws -> Contact {
+        let group = try store.createGroup(named: "Work")
+        let contact = try store.createContact(in: group)
+        contact.firstName = "Ada"
+        contact.lastName = "Lovelace"
+        contact.company = "Analytical Engine Co."
+        contact.lastContactedAt = Date(timeIntervalSinceReferenceDate: 200)
+        contact.createdAt = Date(timeIntervalSinceReferenceDate: 100)
+        contact.photoData = Data([0x01, 0x02, 0x03])
+        try store.addField(.email, value: "ada@example.com", to: contact)
+        _ = try store.addInteraction(
+            to: contact,
+            kind: .meeting,
+            summary: "Met at WWDC.",
+            at: Date(timeIntervalSinceReferenceDate: 150)
+        )
+        return contact
+    }
+}

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -63,6 +63,8 @@ final class ContactManagerUITests: XCTestCase {
         XCTAssertTrue(app.menuItems["Import vCard…"].exists)
         XCTAssertTrue(app.menuItems["Import CSV…"].exists)
         XCTAssertTrue(app.menuItems["Export vCard…"].exists)
+        XCTAssertTrue(app.menuItems["Export Backup…"].exists)
+        XCTAssertTrue(app.menuItems["Restore Backup…"].exists)
         XCTAssertTrue(app.menuItems["Export as PDF…"].exists)
         XCTAssertTrue(app.menuItems["Print…"].exists)
     }


### PR DESCRIPTION
## Summary
Add a first-party JSON backup/restore flow for ContactManager so users can export their full local contact data and restore it additively without deleting existing records.

## Changes
- Added a Codable backup snapshot covering contacts, fields, groups, photos, birthdays, last-contacted dates, created dates, and history notes.
- Added a FileDocument wrapper for pretty-printed JSON backup export/import.
- Added additive restore through ContactStore.mutate so save, rollback, undo naming, and ContactChange notifications stay on the durable mutation path.
- Wired File menu commands for Export Backup… and Restore Backup… plus restore summary/error handling.
- Added unit coverage for snapshot content, additive restore, JSON roundtrip, and empty restore messaging.
- Extended the File menu UI smoke test to verify the new backup commands.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - make check
  - make test

## Screenshots (if applicable)
N/A

## Related Issues
Closes #