### PR TITLE
feat(contacts): preview backup restores

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		14C13B18A26BC44F834915C1 /* ContactModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75D02267D3BC6C014143329 /* ContactModelTests.swift */; };
 		14E0C9EBEF8212F3F9B2777D /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51E6728EF90B1D2BF8EA5AE /* Contact.swift */; };
 		15AD8E34CC4EF4BC81F8A159 /* ContactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */; };
+		164F9364D1D551BB99D50F13 /* ContactBackupPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B2B9B4E62C9BAA67FB718B /* ContactBackupPreview.swift */; };
 		1BE87CA3661CF6390FF9EEC4 /* VCardTransferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F733D535CFC76FA07FB61E /* VCardTransferTests.swift */; };
 		21EF2DF533DFA347DCF69BD0 /* ContactLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE79F02FFFD9820269D3725 /* ContactLinkTests.swift */; };
 		23BF1F338E4C813308B5DEE2 /* ContactField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25751DDEC1515E341AF67F5 /* ContactField.swift */; };
@@ -62,6 +63,7 @@
 		8397B67D483997505B17269E /* ContactDetailView+Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */; };
 		847D0CD5B12E83CD53951DA2 /* ContactFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E63AB996E12C5978B4A8F1 /* ContactFieldRow.swift */; };
 		84EC52BD6CC2F06EFFFF0758 /* ContactDetailView+History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784AEA3986875E3472052482 /* ContactDetailView+History.swift */; };
+		8C03F04FC7178FCE2929E507 /* RestoreBackupPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B2FF6326B588F81435F358 /* RestoreBackupPreviewView.swift */; };
 		8C6AC6410FA2258ADB2BF640 /* ContactManagerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001F8DF120EBA372663EC888 /* ContactManagerUITests.swift */; };
 		8DF0A36CE542853FF12BEF1A /* Chunking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436B4115937E4350EB9A7EF7 /* Chunking.swift */; };
 		8EF7CD9AAA833F08834D2AA4 /* QuickCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5951D4D8D52B6CDB782FE37D /* QuickCaptureView.swift */; };
@@ -130,6 +132,7 @@
 		10E7338673D65A6FAB4F9AF3 /* ContactManagerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContactManagerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotlightIndexer.swift; sourceTree = "<group>"; };
 		2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactsBridge.swift; sourceTree = "<group>"; };
+		25B2B9B4E62C9BAA67FB718B /* ContactBackupPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactBackupPreview.swift; sourceTree = "<group>"; };
 		2623DCD281C3DDAA29BB6B99 /* DefaultGroupPreferenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultGroupPreferenceTests.swift; sourceTree = "<group>"; };
 		279FCAC10E829D7DAC9D8385 /* OpenContactIntentTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenContactIntentTests.swift; sourceTree = "<group>"; };
 		29335D93B2E97B9038F1481A /* ImportProgressView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportProgressView.swift; sourceTree = "<group>"; };
@@ -181,6 +184,7 @@
 		A2C76A783B91BD2AA6D3F70B /* QuickCaptureTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickCaptureTests.swift; path = ContactManagerTests/QuickCaptureTests.swift; sourceTree = "<group>"; };
 		A30CD9D085E7424A79159879 /* ChunkingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChunkingTests.swift; sourceTree = "<group>"; };
 		A37DB6CC43A76261CFF3987D /* PrintableContactView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrintableContactView.swift; sourceTree = "<group>"; };
+		A4B2FF6326B588F81435F358 /* RestoreBackupPreviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RestoreBackupPreviewView.swift; sourceTree = "<group>"; };
 		A5D7E9FD22709F6D14A87952 /* QuickCapture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickCapture.swift; path = ContactManager/Models/QuickCapture.swift; sourceTree = "<group>"; };
 		A7276D515CA167FBF4C47299 /* VCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCard.swift; sourceTree = "<group>"; };
 		ABDED82FFB4B5F039052FFB5 /* Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Birthday.swift; sourceTree = "<group>"; };
@@ -296,6 +300,7 @@
 				B0CF4C47C670B0A8C3B6B384 /* ContactActivity.swift */,
 				66E45011FDD9D571FF1834F5 /* ContactBackup.swift */,
 				937EFD55691DF4EA887DF2CA /* ContactBackupDocument.swift */,
+				25B2B9B4E62C9BAA67FB718B /* ContactBackupPreview.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -337,6 +342,7 @@
 				784AEA3986875E3472052482 /* ContactDetailView+History.swift */,
 				2C83A331432D80A054D0AE94 /* ContentView+FileDialogs.swift */,
 				61C8E57A2BB1F32050119C06 /* ContentView+Backup.swift */,
+				A4B2FF6326B588F81435F358 /* RestoreBackupPreviewView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -601,6 +607,8 @@
 				A04D61E7D5979B59983B7EF9 /* ContactBackupDocument.swift in Sources */,
 				96FB713B5A967D1C076AE445 /* ContentView+FileDialogs.swift in Sources */,
 				E11A07680CCF44C864B95662 /* ContentView+Backup.swift in Sources */,
+				164F9364D1D551BB99D50F13 /* ContactBackupPreview.swift in Sources */,
+				8C03F04FC7178FCE2929E507 /* RestoreBackupPreviewView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Support/ContactBackupPreview.swift
+++ b/ContactManager/Support/ContactBackupPreview.swift
@@ -1,0 +1,68 @@
+//
+//  ContactBackupPreview.swift
+//  ContactManager
+//
+//  Summary data for inspecting a backup before restore.
+//
+
+import Foundation
+
+struct ContactBackupPreview: Equatable {
+    var exportedAt: Date
+    var contactCount: Int
+    var groupCount: Int
+    var emailCount: Int
+    var phoneCount: Int
+    var historyNoteCount: Int
+    var photoCount: Int
+    var sampleContactNames: [String]
+
+    var isEmpty: Bool {
+        contactCount == 0 && groupCount == 0 && historyNoteCount == 0
+    }
+
+    init(backup: ContactBackup) {
+        exportedAt = backup.exportedAt
+        contactCount = backup.contacts.count
+        groupCount = backup.groups.count
+        emailCount = backup.contacts.flatMap(\.fields).filter { $0.kind == .email }.count
+        phoneCount = backup.contacts.flatMap(\.fields).filter { $0.kind == .phone }.count
+        historyNoteCount = backup.contacts.flatMap(\.interactions).count
+        photoCount = backup.contacts.filter { $0.photoData != nil }.count
+        sampleContactNames = backup.contacts
+            .map(\.displayName)
+            .prefix(5)
+            .map(\.self)
+    }
+
+    var summary: String {
+        let parts = [
+            count(contactCount, singular: "contact"),
+            count(groupCount, singular: "group"),
+            count(emailCount, singular: "email"),
+            count(phoneCount, singular: "phone"),
+            count(historyNoteCount, singular: "history note"),
+            count(photoCount, singular: "photo"),
+        ].compactMap(\.self)
+        return parts.isEmpty ? "0 contacts" : parts.joined(separator: ", ")
+    }
+
+    private func count(_ value: Int, singular: String) -> String? {
+        guard value > 0 else { return nil }
+        let label = value == 1 ? singular : "\(singular)s"
+        return "\(value) \(label)"
+    }
+}
+
+private extension ContactBackup.ContactRecord {
+    var displayName: String {
+        let name = [firstName, lastName]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        if !name.isEmpty { return name }
+        let trimmedCompany = company.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedCompany.isEmpty { return trimmedCompany }
+        return "Contact"
+    }
+}

--- a/ContactManager/Views/ContentView+Backup.swift
+++ b/ContactManager/Views/ContentView+Backup.swift
@@ -23,9 +23,31 @@ extension ContentView {
 
             let data = try Data(contentsOf: url)
             let backup = try ContactBackupDocument.decode(data)
-            restoreSummary = try store.restoreBackup(backup)
+            pendingRestoreBackup = backup
+            restorePreview = ContactBackupPreview(backup: backup)
+            isReviewingRestore = true
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+
+    func confirmRestoreBackup() {
+        guard let backup = pendingRestoreBackup else {
+            errorMessage = "Choose a backup before restoring."
+            return
+        }
+
+        do {
+            restoreSummary = try store.restoreBackup(backup)
+            clearPendingRestore()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func clearPendingRestore() {
+        pendingRestoreBackup = nil
+        restorePreview = nil
+        isReviewingRestore = false
     }
 }

--- a/ContactManager/Views/ContentView+FileDialogs.swift
+++ b/ContactManager/Views/ContentView+FileDialogs.swift
@@ -11,7 +11,7 @@ import UniformTypeIdentifiers
 extension ContentView {
     /// The sheets, importers, exporters, and the error alert.
     func handlingFileDialogs(_ content: some View) -> some View {
-        handlingImportAlerts(content
+        let dialogContent = content
             .sheet(isPresented: $showingDuplicates) {
                 DuplicatesView()
             }
@@ -54,11 +54,23 @@ extension ContentView {
                     errorMessage = error.localizedDescription
                 }
             }
+        return handlingImportAlerts(handlingReviewSheets(dialogContent))
+    }
+
+    func handlingReviewSheets(_ content: some View) -> some View {
+        content
             .sheet(isPresented: $isReviewingImport) {
                 ImportReviewView(items: $importReviewItems) { items in
                     Task { await applyImportReview(items) }
                 }
-            })
+            }
+            .sheet(isPresented: $isReviewingRestore, onDismiss: clearPendingRestore) {
+                if let preview = restorePreview {
+                    RestoreBackupPreviewView(preview: preview) {
+                        confirmRestoreBackup()
+                    }
+                }
+            }
     }
 
     func exportSelectedContactAsPDF() {

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -42,6 +42,9 @@ struct ContentView: View {
     @State var isExportingBackup = false
     @State var isRestoringBackup = false
     @State var backupDocument = ContactBackupDocument()
+    @State var pendingRestoreBackup: ContactBackup?
+    @State var restorePreview: ContactBackupPreview?
+    @State var isReviewingRestore = false
     @State var importReviewItems: [ImportReviewItem] = []
     @State var isReviewingImport = false
     @State var importSummary: ImportReviewResult?

--- a/ContactManager/Views/RestoreBackupPreviewView.swift
+++ b/ContactManager/Views/RestoreBackupPreviewView.swift
@@ -1,0 +1,70 @@
+//
+//  RestoreBackupPreviewView.swift
+//  ContactManager
+//
+//  Restore confirmation sheet for decoded backups.
+//
+
+import SwiftUI
+
+struct RestoreBackupPreviewView: View {
+    @Environment(\.dismiss) private var dismiss
+    var preview: ContactBackupPreview
+    var restoreAction: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Backup Contents") {
+                    labeledRow("Exported", value: preview.exportedAt.formatted(date: .abbreviated, time: .shortened))
+                    labeledRow("Summary", value: preview.summary)
+                    labeledRow("Contacts", value: "\(preview.contactCount)")
+                    labeledRow("Groups", value: "\(preview.groupCount)")
+                    labeledRow("Emails", value: "\(preview.emailCount)")
+                    labeledRow("Phones", value: "\(preview.phoneCount)")
+                    labeledRow("History Notes", value: "\(preview.historyNoteCount)")
+                    labeledRow("Photos", value: "\(preview.photoCount)")
+                }
+
+                if !preview.sampleContactNames.isEmpty {
+                    Section("Sample Contacts") {
+                        ForEach(preview.sampleContactNames, id: \.self) { name in
+                            Text(name)
+                        }
+                    }
+                }
+            }
+            .accessibilityIdentifier("restore-backup-preview")
+            .navigationTitle("Review Backup")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(restoreButtonTitle) {
+                        restoreAction()
+                        dismiss()
+                    }
+                    .disabled(preview.isEmpty)
+                    .accessibilityIdentifier("confirm-restore-backup-button")
+                }
+            }
+        }
+        .frame(minWidth: 460, minHeight: 420)
+    }
+
+    private var restoreButtonTitle: String {
+        guard preview.contactCount > 0 else { return "Restore Backup" }
+        return preview.contactCount == 1 ? "Restore 1 Contact" : "Restore \(preview.contactCount) Contacts"
+    }
+
+    private func labeledRow(_ title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+}

--- a/ContactManagerTests/ContactBackupTests.swift
+++ b/ContactManagerTests/ContactBackupTests.swift
@@ -107,6 +107,52 @@ struct ContactBackupTests {
         #expect(result.message == "No contacts, groups, or history notes restored.")
     }
 
+    @Test func backupPreviewSummarizesContentsBeforeRestore() throws {
+        let contact = try makePopulatedContact()
+        let groups = try allGroups()
+        let backup = ContactBackup.make(
+            contacts: [contact],
+            groups: groups,
+            exportedAt: Date(timeIntervalSinceReferenceDate: 42)
+        )
+
+        let preview = ContactBackupPreview(backup: backup)
+
+        #expect(preview.exportedAt == Date(timeIntervalSinceReferenceDate: 42))
+        #expect(preview.contactCount == 1)
+        #expect(preview.groupCount == 1)
+        #expect(preview.emailCount == 1)
+        #expect(preview.phoneCount == 0)
+        #expect(preview.historyNoteCount == 1)
+        #expect(preview.photoCount == 1)
+        #expect(preview.sampleContactNames == ["Ada Lovelace"])
+        #expect(preview.summary == "1 contact, 1 group, 1 email, 1 history note, 1 photo")
+    }
+
+    @Test func emptyBackupPreviewHasAPlainSummary() {
+        let preview = ContactBackupPreview(backup: ContactBackup())
+
+        #expect(preview.contactCount == 0)
+        #expect(preview.groupCount == 0)
+        #expect(preview.isEmpty)
+        #expect(preview.sampleContactNames.isEmpty)
+        #expect(preview.summary == "0 contacts")
+    }
+
+    @Test func groupsOnlyBackupPreviewCanStillRestore() {
+        let group = ContactBackup.GroupRecord(
+            id: "group-1",
+            name: "Friends",
+            createdAt: Date(timeIntervalSinceReferenceDate: 10)
+        )
+        let preview = ContactBackupPreview(backup: ContactBackup(groups: [group]))
+
+        #expect(preview.contactCount == 0)
+        #expect(preview.groupCount == 1)
+        #expect(!preview.isEmpty)
+        #expect(preview.summary == "1 group")
+    }
+
     @discardableResult
     private func makePopulatedContact() throws -> Contact {
         let group = try store.createGroup(named: "Work")


### PR DESCRIPTION
## Summary
Add a restore preview sheet so selecting a backup no longer writes immediately; users review backup contents and confirm before additive restore.

## Changes
- Added ContactBackupPreview summary model for counts, sample names, exported date, and empty-backup detection.
- Added restore review sheet with summary rows, sample contacts, cancel, and confirm action.
- Changed restore file importer to decode into pending preview state, then restore only after confirmation.
- Added unit coverage for populated, empty, and groups-only backup previews.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerTests/ContactBackupTests
  - make check
  - make test

## Screenshots (if applicable)
N/A

## Related Issues
Closes #