### PR TITLE
feat(contacts): add encrypted backups

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -25,7 +25,9 @@
 		3076738411F8C3FA073D1BE0 /* ContactsBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8EC17CBADAAAFFF77E9FDF /* ContactsBridgeTests.swift */; };
 		322103E6FBEAD59C6A2405E6 /* Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDED82FFB4B5F039052FFB5 /* Birthday.swift */; };
 		337B23E02F63EB1A294A5A41 /* ContactHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764B3FB47DAFF8CE837BDE9D /* ContactHistoryTests.swift */; };
+		381FB5EAC1346691AA0349BE /* BackupPasswordPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FA55EA1466B6711EE517B4 /* BackupPasswordPromptView.swift */; };
 		39D33CDF2E0495FCCA8D7E13 /* QuickCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C76A783B91BD2AA6D3F70B /* QuickCaptureTests.swift */; };
+		3DC4EF7EB2977C7CE6492A2E /* EncryptedContactBackupDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D5EEA2101A9DE782A0F000 /* EncryptedContactBackupDocument.swift */; };
 		3EDDAA184C377D9C16AAF08A /* ContactStore+PendingEdits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */; };
 		3FA1770FF1649CC78510AF10 /* ContentView+Alerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0401F25DFDF91CE847706D08 /* ContentView+Alerts.swift */; };
 		42F87AE7D82D2D802D7B670E /* ContactBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E45011FDD9D571FF1834F5 /* ContactBackup.swift */; };
@@ -143,9 +145,11 @@
 		3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinderTests.swift; sourceTree = "<group>"; };
 		399A72E1BB6BEC0B54D356E7 /* ContactEntityQueryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityQueryTests.swift; sourceTree = "<group>"; };
 		3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		40FA55EA1466B6711EE517B4 /* BackupPasswordPromptView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackupPasswordPromptView.swift; sourceTree = "<group>"; };
 		436B4115937E4350EB9A7EF7 /* Chunking.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Chunking.swift; sourceTree = "<group>"; };
 		438C2B20E1C302676594ECCA /* ContactStorePendingEditTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStorePendingEditTests.swift; sourceTree = "<group>"; };
 		45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+PendingEdits.swift"; sourceTree = "<group>"; };
+		47D5EEA2101A9DE782A0F000 /* EncryptedContactBackupDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EncryptedContactBackupDocument.swift; sourceTree = "<group>"; };
 		4A10D26E6D853A5EB462682B /* ContactBackupTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactBackupTests.swift; sourceTree = "<group>"; };
 		4E2F2242E59F2C42DDD0736B /* CSV.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSV.swift; sourceTree = "<group>"; };
 		54C373BD237429970D6A7C86 /* DuplicatesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicatesView.swift; sourceTree = "<group>"; };
@@ -301,6 +305,7 @@
 				66E45011FDD9D571FF1834F5 /* ContactBackup.swift */,
 				937EFD55691DF4EA887DF2CA /* ContactBackupDocument.swift */,
 				25B2B9B4E62C9BAA67FB718B /* ContactBackupPreview.swift */,
+				47D5EEA2101A9DE782A0F000 /* EncryptedContactBackupDocument.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -343,6 +348,7 @@
 				2C83A331432D80A054D0AE94 /* ContentView+FileDialogs.swift */,
 				61C8E57A2BB1F32050119C06 /* ContentView+Backup.swift */,
 				A4B2FF6326B588F81435F358 /* RestoreBackupPreviewView.swift */,
+				40FA55EA1466B6711EE517B4 /* BackupPasswordPromptView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -609,6 +615,8 @@
 				E11A07680CCF44C864B95662 /* ContentView+Backup.swift in Sources */,
 				164F9364D1D551BB99D50F13 /* ContactBackupPreview.swift in Sources */,
 				8C03F04FC7178FCE2929E507 /* RestoreBackupPreviewView.swift in Sources */,
+				3DC4EF7EB2977C7CE6492A2E /* EncryptedContactBackupDocument.swift in Sources */,
+				381FB5EAC1346691AA0349BE /* BackupPasswordPromptView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -114,6 +114,9 @@ struct ContactManagerApp: App {
                 Button("Export Backup…") {
                     NotificationCenter.default.post(name: .exportBackupRequested, object: nil)
                 }
+                Button("Export Encrypted Backup…") {
+                    NotificationCenter.default.post(name: .exportEncryptedBackupRequested, object: nil)
+                }
                 Button("Restore Backup…") {
                     NotificationCenter.default.post(name: .restoreBackupRequested, object: nil)
                 }
@@ -298,6 +301,7 @@ extension Notification.Name {
     static let importSystemContactsRequested = Notification.Name("ContactManager.importSystemContactsRequested")
     static let exportVCardRequested = Notification.Name("ContactManager.exportVCardRequested")
     static let exportBackupRequested = Notification.Name("ContactManager.exportBackupRequested")
+    static let exportEncryptedBackupRequested = Notification.Name("ContactManager.exportEncryptedBackupRequested")
     static let restoreBackupRequested = Notification.Name("ContactManager.restoreBackupRequested")
     /// Posted by the Export as PDF / Print commands; handled by `ContentView`
     /// for the selected contact.

--- a/ContactManager/Support/EncryptedContactBackupDocument.swift
+++ b/ContactManager/Support/EncryptedContactBackupDocument.swift
@@ -1,0 +1,179 @@
+//
+//  EncryptedContactBackupDocument.swift
+//  ContactManager
+//
+//  Password-protected backup document using a versioned JSON envelope.
+//
+
+import CommonCrypto
+import CryptoKit
+import Foundation
+import Security
+import SwiftUI
+import UniformTypeIdentifiers
+
+enum ContactBackupEncryptionError: Error, Equatable, LocalizedError {
+    case emptyPassword
+    case invalidFormat
+    case invalidPassword
+    case keyDerivationFailed
+    case randomFailure
+    case encryptionFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyPassword:
+            "Enter a password for the encrypted backup."
+        case .invalidFormat:
+            "That file is not a supported encrypted backup."
+        case .invalidPassword:
+            "The backup password is incorrect."
+        case .keyDerivationFailed:
+            "Couldn't derive an encryption key for the backup."
+        case .randomFailure:
+            "Couldn't create secure random bytes for the backup."
+        case .encryptionFailed:
+            "Couldn't encrypt the backup."
+        }
+    }
+}
+
+struct EncryptedContactBackupDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.json] }
+    static var writableContentTypes: [UTType] { [.json] }
+
+    var data: Data
+
+    init(data: Data = Data()) {
+        self.data = data
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        guard let data = configuration.file.regularFileContents else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        self.data = data
+    }
+
+    func fileWrapper(configuration _: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: data)
+    }
+
+    static func encode(_ backup: ContactBackup, password: String) throws -> Data {
+        guard !password.isEmpty else { throw ContactBackupEncryptionError.emptyPassword }
+        let plaintext = try ContactBackupDocument.encode(backup)
+        let salt = try randomBytes(count: 16)
+        let key = try key(for: password, salt: salt)
+        let box = try AES.GCM.seal(plaintext, using: key)
+        guard let combined = box.combined else {
+            throw ContactBackupEncryptionError.encryptionFailed
+        }
+
+        let envelope = Envelope(salt: salt, sealedData: combined)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(envelope)
+    }
+
+    static func decode(_ data: Data, password: String) throws -> ContactBackup {
+        guard !password.isEmpty else { throw ContactBackupEncryptionError.emptyPassword }
+        let envelope: Envelope
+        do {
+            envelope = try JSONDecoder().decode(Envelope.self, from: data)
+        } catch {
+            throw ContactBackupEncryptionError.invalidFormat
+        }
+        guard envelope.magic == Envelope.magic,
+              envelope.version == 1,
+              envelope.algorithm == "AES.GCM",
+              envelope.kdf == "PBKDF2-HMAC-SHA256"
+        else {
+            throw ContactBackupEncryptionError.invalidFormat
+        }
+
+        let key = try key(for: password, salt: envelope.salt, iterations: envelope.iterations)
+        let box: AES.GCM.SealedBox
+        do {
+            box = try AES.GCM.SealedBox(combined: envelope.sealedData)
+        } catch {
+            throw ContactBackupEncryptionError.invalidFormat
+        }
+
+        do {
+            let plaintext = try AES.GCM.open(box, using: key)
+            return try ContactBackupDocument.decode(plaintext)
+        } catch is DecodingError {
+            throw ContactBackupEncryptionError.invalidFormat
+        } catch {
+            throw ContactBackupEncryptionError.invalidPassword
+        }
+    }
+
+    static func isEncrypted(_ data: Data) -> Bool {
+        guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data) else {
+            return false
+        }
+        return envelope.magic == Envelope.magic
+    }
+
+    private static func key(for password: String, salt: Data, iterations: Int = Envelope.iterations) throws
+        -> SymmetricKey {
+        let passwordData = Data(password.utf8)
+        var keyData = Data(count: 32)
+        let keyLength = keyData.count
+        let status = keyData.withUnsafeMutableBytes { keyBuffer in
+            salt.withUnsafeBytes { saltBuffer in
+                passwordData.withUnsafeBytes { passwordBuffer in
+                    guard let keyAddress = keyBuffer.baseAddress,
+                          let saltAddress = saltBuffer.bindMemory(to: UInt8.self).baseAddress,
+                          let passwordAddress = passwordBuffer.bindMemory(to: Int8.self).baseAddress
+                    else {
+                        return Int32(kCCMemoryFailure)
+                    }
+                    return CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        passwordAddress,
+                        passwordData.count,
+                        saltAddress,
+                        salt.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                        UInt32(iterations),
+                        keyAddress,
+                        keyLength
+                    )
+                }
+            }
+        }
+        guard status == kCCSuccess else {
+            throw ContactBackupEncryptionError.keyDerivationFailed
+        }
+        return SymmetricKey(data: keyData)
+    }
+
+    private static func randomBytes(count: Int) throws -> Data {
+        var data = Data(count: count)
+        let status = data.withUnsafeMutableBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else {
+                return errSecAllocate
+            }
+            return SecRandomCopyBytes(kSecRandomDefault, count, baseAddress)
+        }
+        guard status == errSecSuccess else {
+            throw ContactBackupEncryptionError.randomFailure
+        }
+        return data
+    }
+
+    private struct Envelope: Codable {
+        static let magic = "ContactManagerEncryptedBackup"
+        static let iterations = 210_000
+
+        var magic = Self.magic
+        var version = 1
+        var algorithm = "AES.GCM"
+        var kdf = "PBKDF2-HMAC-SHA256"
+        var iterations = Self.iterations
+        var salt: Data
+        var sealedData: Data
+    }
+}

--- a/ContactManager/Views/BackupPasswordPromptView.swift
+++ b/ContactManager/Views/BackupPasswordPromptView.swift
@@ -1,0 +1,89 @@
+//
+//  BackupPasswordPromptView.swift
+//  ContactManager
+//
+//  Password entry sheet for encrypted backup export and restore.
+//
+
+import SwiftUI
+
+struct BackupPasswordPromptView: View {
+    enum Mode {
+        case export
+        case unlock
+    }
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var password = ""
+    @State private var confirmation = ""
+    @State private var validationMessage: String?
+
+    var mode: Mode
+    var action: (String) -> Bool
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                SecureField("Password", text: $password)
+                    .accessibilityIdentifier("backup-password-field")
+
+                if mode == .export {
+                    SecureField("Confirm Password", text: $confirmation)
+                        .accessibilityIdentifier("backup-confirm-password-field")
+                }
+
+                if let validationMessage {
+                    Text(validationMessage)
+                        .foregroundStyle(.red)
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle(title)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(buttonTitle) {
+                        submit()
+                    }
+                    .disabled(!canSubmit)
+                    .accessibilityIdentifier("backup-password-submit-button")
+                }
+            }
+        }
+        .frame(minWidth: 420, minHeight: 220)
+    }
+
+    private var title: String {
+        switch mode {
+        case .export: "Encrypt Backup"
+        case .unlock: "Unlock Backup"
+        }
+    }
+
+    private var buttonTitle: String {
+        switch mode {
+        case .export: "Export"
+        case .unlock: "Unlock"
+        }
+    }
+
+    private var canSubmit: Bool {
+        switch mode {
+        case .export: !password.isEmpty && !confirmation.isEmpty
+        case .unlock: !password.isEmpty
+        }
+    }
+
+    private func submit() {
+        if mode == .export, password != confirmation {
+            validationMessage = "Passwords do not match."
+            return
+        }
+        validationMessage = nil
+        if action(password) {
+            dismiss()
+        }
+    }
+}

--- a/ContactManager/Views/ContentView+Backup.swift
+++ b/ContactManager/Views/ContentView+Backup.swift
@@ -13,6 +13,20 @@ extension ContentView {
         isExportingBackup = true
     }
 
+    func exportEncryptedBackup(password: String) -> Bool {
+        do {
+            let backup = ContactBackup.make(contacts: contacts, groups: groups)
+            let data = try EncryptedContactBackupDocument.encode(backup, password: password)
+            encryptedBackupDocument = EncryptedContactBackupDocument(data: data)
+            isPreparingEncryptedBackup = false
+            isExportingEncryptedBackup = true
+            return true
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
     func restoreBackup(_ result: Result<URL, Error>) {
         do {
             let url = try result.get()
@@ -22,12 +36,33 @@ extension ContentView {
             }
 
             let data = try Data(contentsOf: url)
+            if EncryptedContactBackupDocument.isEncrypted(data) {
+                pendingEncryptedBackupData = data
+                isUnlockingEncryptedBackup = true
+                return
+            }
             let backup = try ContactBackupDocument.decode(data)
-            pendingRestoreBackup = backup
-            restorePreview = ContactBackupPreview(backup: backup)
-            isReviewingRestore = true
+            reviewBackup(backup)
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+
+    func unlockEncryptedBackup(password: String) -> Bool {
+        guard let data = pendingEncryptedBackupData else {
+            errorMessage = "Choose an encrypted backup before unlocking."
+            return false
+        }
+
+        do {
+            let backup = try EncryptedContactBackupDocument.decode(data, password: password)
+            pendingEncryptedBackupData = nil
+            isUnlockingEncryptedBackup = false
+            reviewBackup(backup)
+            return true
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
         }
     }
 
@@ -49,5 +84,16 @@ extension ContentView {
         pendingRestoreBackup = nil
         restorePreview = nil
         isReviewingRestore = false
+    }
+
+    func clearPendingEncryptedBackup() {
+        pendingEncryptedBackupData = nil
+        isUnlockingEncryptedBackup = false
+    }
+
+    private func reviewBackup(_ backup: ContactBackup) {
+        pendingRestoreBackup = backup
+        restorePreview = ContactBackupPreview(backup: backup)
+        isReviewingRestore = true
     }
 }

--- a/ContactManager/Views/ContentView+FileDialogs.swift
+++ b/ContactManager/Views/ContentView+FileDialogs.swift
@@ -24,6 +24,11 @@ extension ContentView {
             .fileImporter(isPresented: $isRestoringBackup, allowedContentTypes: [.json]) { result in
                 restoreBackup(result)
             }
+        return handlingImportAlerts(handlingReviewSheets(handlingExporters(dialogContent)))
+    }
+
+    func handlingExporters(_ content: some View) -> some View {
+        content
             .fileExporter(
                 isPresented: $isExportingVCard,
                 document: exportDocument,
@@ -45,6 +50,16 @@ extension ContentView {
                 }
             }
             .fileExporter(
+                isPresented: $isExportingEncryptedBackup,
+                document: encryptedBackupDocument,
+                contentType: .json,
+                defaultFilename: "ContactManager Encrypted Backup"
+            ) { result in
+                if case .failure(let error) = result {
+                    errorMessage = error.localizedDescription
+                }
+            }
+            .fileExporter(
                 isPresented: $isExportingPDF,
                 document: pdfDocument,
                 contentType: .pdf,
@@ -54,7 +69,6 @@ extension ContentView {
                     errorMessage = error.localizedDescription
                 }
             }
-        return handlingImportAlerts(handlingReviewSheets(dialogContent))
     }
 
     func handlingReviewSheets(_ content: some View) -> some View {
@@ -62,6 +76,16 @@ extension ContentView {
             .sheet(isPresented: $isReviewingImport) {
                 ImportReviewView(items: $importReviewItems) { items in
                     Task { await applyImportReview(items) }
+                }
+            }
+            .sheet(isPresented: $isPreparingEncryptedBackup) {
+                BackupPasswordPromptView(mode: .export) { password in
+                    exportEncryptedBackup(password: password)
+                }
+            }
+            .sheet(isPresented: $isUnlockingEncryptedBackup, onDismiss: clearPendingEncryptedBackup) {
+                BackupPasswordPromptView(mode: .unlock) { password in
+                    unlockEncryptedBackup(password: password)
                 }
             }
             .sheet(isPresented: $isReviewingRestore, onDismiss: clearPendingRestore) {

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -40,11 +40,16 @@ struct ContentView: View {
     @State var pdfDocument = PDFExportDocument(data: Data())
     @State var pdfFilename = "Contact"
     @State var isExportingBackup = false
+    @State var isPreparingEncryptedBackup = false
+    @State var isExportingEncryptedBackup = false
     @State var isRestoringBackup = false
     @State var backupDocument = ContactBackupDocument()
+    @State var encryptedBackupDocument = EncryptedContactBackupDocument()
     @State var pendingRestoreBackup: ContactBackup?
     @State var restorePreview: ContactBackupPreview?
     @State var isReviewingRestore = false
+    @State var pendingEncryptedBackupData: Data?
+    @State var isUnlockingEncryptedBackup = false
     @State var importReviewItems: [ImportReviewItem] = []
     @State var isReviewingImport = false
     @State var importSummary: ImportReviewResult?
@@ -288,6 +293,9 @@ private extension ContentView {
             }
             .onReceive(NotificationCenter.default.publisher(for: .exportBackupRequested)) { _ in
                 exportBackup()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .exportEncryptedBackupRequested)) { _ in
+                isPreparingEncryptedBackup = true
             }
             .onReceive(NotificationCenter.default.publisher(for: .restoreBackupRequested)) { _ in
                 isRestoringBackup = true

--- a/ContactManagerTests/ContactBackupTests.swift
+++ b/ContactManagerTests/ContactBackupTests.swift
@@ -99,6 +99,38 @@ struct ContactBackupTests {
         #expect(decoded == backup)
     }
 
+    @Test func encryptedBackupDocumentRoundTripsWithPassword() throws {
+        let contact = try makePopulatedContact()
+        let groups = try allGroups()
+        let backup = ContactBackup.make(
+            contacts: [contact],
+            groups: groups,
+            exportedAt: Date(timeIntervalSinceReferenceDate: 42)
+        )
+
+        let data = try EncryptedContactBackupDocument.encode(backup, password: "correct horse battery staple")
+        let decoded = try EncryptedContactBackupDocument.decode(data, password: "correct horse battery staple")
+
+        #expect(EncryptedContactBackupDocument.isEncrypted(data))
+        #expect(!data.contains(Data("Ada".utf8)))
+        #expect(decoded == backup)
+        #expect(try ContactBackupDocument.decode(ContactBackupDocument.encode(backup)) == backup)
+    }
+
+    @Test func encryptedBackupDocumentRejectsWrongPassword() throws {
+        let contact = try makePopulatedContact()
+        let groups = try allGroups()
+        let backup = ContactBackup.make(contacts: [contact], groups: groups)
+        let data = try EncryptedContactBackupDocument.encode(backup, password: "correct")
+
+        do {
+            _ = try EncryptedContactBackupDocument.decode(data, password: "wrong")
+            Issue.record("Expected encrypted backup decode to reject the wrong password.")
+        } catch let error as ContactBackupEncryptionError {
+            #expect(error == .invalidPassword)
+        }
+    }
+
     @Test func emptyRestoreSummaryExplainsNothingWasRestored() throws {
         let result = try store.restoreBackup(ContactBackup())
 

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -64,6 +64,7 @@ final class ContactManagerUITests: XCTestCase {
         XCTAssertTrue(app.menuItems["Import CSV…"].exists)
         XCTAssertTrue(app.menuItems["Export vCard…"].exists)
         XCTAssertTrue(app.menuItems["Export Backup…"].exists)
+        XCTAssertTrue(app.menuItems["Export Encrypted Backup…"].exists)
         XCTAssertTrue(app.menuItems["Restore Backup…"].exists)
         XCTAssertTrue(app.menuItems["Export as PDF…"].exists)
         XCTAssertTrue(app.menuItems["Print…"].exists)


### PR DESCRIPTION
## Summary
Add password-protected ContactManager backups while preserving the existing plain JSON backup flow.

## Changes
- Added a versioned encrypted backup document envelope using AES-GCM and PBKDF2-HMAC-SHA256.
- Added encrypted backup export with password confirmation.
- Added encrypted backup restore detection and password unlock before the existing restore preview.
- Kept legacy JSON backup encode/decode and restore compatibility intact.
- Added unit coverage for encrypted round-trip, wrong-password rejection, and legacy JSON compatibility.
- Added UI smoke coverage for the new File menu command.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerTests/ContactBackupTests
  - make check
  - make test

## Screenshots (if applicable)
N/A

## Related Issues
Closes #