### PR TITLE
feat(sync): add iCloud status

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		509C184B6FC5C331FCC6FD11 /* ImportReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB522F18FE21A503D7C480AB /* ImportReview.swift */; };
 		52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */; };
 		552E226D873AE11781A7F97A /* ContactDetailView+Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */; };
+		5FCE54BC89E39D68DE29B360 /* CloudSyncStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE92D38DACB5637AF0E693F /* CloudSyncStatusTests.swift */; };
 		61F22EEDEE6075BD602203D5 /* VCardDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */; };
 		623A5F4AE958EAD5C2757F83 /* CSVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */; };
 		63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C12246003379D5966F0210 /* ContactEntityTests.swift */; };
@@ -65,6 +66,7 @@
 		8397B67D483997505B17269E /* ContactDetailView+Birthday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */; };
 		847D0CD5B12E83CD53951DA2 /* ContactFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E63AB996E12C5978B4A8F1 /* ContactFieldRow.swift */; };
 		84EC52BD6CC2F06EFFFF0758 /* ContactDetailView+History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784AEA3986875E3472052482 /* ContactDetailView+History.swift */; };
+		8B360EB3A21E4CCADDA865BD /* CloudSyncStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F125D04F06D9B25A250A47B /* CloudSyncStatus.swift */; };
 		8C03F04FC7178FCE2929E507 /* RestoreBackupPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B2FF6326B588F81435F358 /* RestoreBackupPreviewView.swift */; };
 		8C6AC6410FA2258ADB2BF640 /* ContactManagerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001F8DF120EBA372663EC888 /* ContactManagerUITests.swift */; };
 		8DF0A36CE542853FF12BEF1A /* Chunking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436B4115937E4350EB9A7EF7 /* Chunking.swift */; };
@@ -129,6 +131,7 @@
 		08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactListView.swift; sourceTree = "<group>"; };
 		0B27567532AC1A51FF4CC13A /* ContactQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactQuery.swift; sourceTree = "<group>"; };
 		0CFA2237DBD182839EAF04F1 /* ImportReviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportReviewView.swift; sourceTree = "<group>"; };
+		0F125D04F06D9B25A250A47B /* CloudSyncStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CloudSyncStatus.swift; path = Support/CloudSyncStatus.swift; sourceTree = "<group>"; };
 		0F82C8A388E97CC4F1106176 /* SampleData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SampleData.swift; sourceTree = "<group>"; };
 		10E14CB9E9A2442DFE7B0E0B /* ContactManager.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = ContactManager.entitlements; sourceTree = "<group>"; };
 		10E7338673D65A6FAB4F9AF3 /* ContactManagerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContactManagerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -178,6 +181,7 @@
 		833F1AF82CACF7B9E89BADCA /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		83E63AB996E12C5978B4A8F1 /* ContactFieldRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactFieldRow.swift; sourceTree = "<group>"; };
 		874742D7DC5E9C20D3A88459 /* ContactEntityQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityQuery.swift; sourceTree = "<group>"; };
+		8CE92D38DACB5637AF0E693F /* CloudSyncStatusTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudSyncStatusTests.swift; sourceTree = "<group>"; };
 		90E3C45DEC115A2BF7DE83DF /* ContactLink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactLink.swift; sourceTree = "<group>"; };
 		9116FC0A7E009E9A806FD48F /* ContactInteraction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactInteraction.swift; sourceTree = "<group>"; };
 		915AF700C971510D0B642590 /* ContactEntity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntity.swift; sourceTree = "<group>"; };
@@ -391,6 +395,7 @@
 				10E14CB9E9A2442DFE7B0E0B /* ContactManager.entitlements */,
 				76F68BAD5C3290EE7ABF787B /* Localizable.xcstrings */,
 				3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */,
+				0F125D04F06D9B25A250A47B /* CloudSyncStatus.swift */,
 			);
 			path = ContactManager;
 			sourceTree = "<group>";
@@ -422,6 +427,7 @@
 				438C2B20E1C302676594ECCA /* ContactStorePendingEditTests.swift */,
 				764B3FB47DAFF8CE837BDE9D /* ContactHistoryTests.swift */,
 				4A10D26E6D853A5EB462682B /* ContactBackupTests.swift */,
+				8CE92D38DACB5637AF0E693F /* CloudSyncStatusTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -617,6 +623,7 @@
 				8C03F04FC7178FCE2929E507 /* RestoreBackupPreviewView.swift in Sources */,
 				3DC4EF7EB2977C7CE6492A2E /* EncryptedContactBackupDocument.swift in Sources */,
 				381FB5EAC1346691AA0349BE /* BackupPasswordPromptView.swift in Sources */,
+				8B360EB3A21E4CCADDA865BD /* CloudSyncStatus.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -649,6 +656,7 @@
 				39D33CDF2E0495FCCA8D7E13 /* QuickCaptureTests.swift in Sources */,
 				337B23E02F63EB1A294A5A41 /* ContactHistoryTests.swift in Sources */,
 				012DFE934E6F0E77278DA1B1 /* ContactBackupTests.swift in Sources */,
+				5FCE54BC89E39D68DE29B360 /* CloudSyncStatusTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -22,9 +22,10 @@ struct ContactManagerApp: App {
     var body: some Scene {
         WindowGroup {
             switch loadState {
-            case .ready(let container):
+            case .ready(let container, let syncStatus):
                 ContentView()
                     .modelContainer(container)
+                    .environment(\.cloudSyncStatus, syncStatus)
             case .testing:
                 EmptyView()
             case .failed(let message):
@@ -39,9 +40,10 @@ struct ContactManagerApp: App {
         // `OpenWindowAction` and SwiftUI's window-restoration store.
         WindowGroup(id: "contact", for: String.self) { $encodedID in
             switch loadState {
-            case .ready(let container):
+            case .ready(let container, let syncStatus):
                 ContactWindowView(encodedID: encodedID)
                     .modelContainer(container)
+                    .environment(\.cloudSyncStatus, syncStatus)
             case .testing, .failed:
                 EmptyView()
             }
@@ -49,9 +51,10 @@ struct ContactManagerApp: App {
         .defaultSize(width: 520, height: 640)
         WindowGroup(id: "quickCapture") {
             switch loadState {
-            case .ready(let container):
+            case .ready(let container, let syncStatus):
                 QuickCaptureView()
                     .modelContainer(container)
+                    .environment(\.cloudSyncStatus, syncStatus)
             case .testing, .failed:
                 EmptyView()
             }
@@ -63,9 +66,10 @@ struct ContactManagerApp: App {
             // hasn't loaded we point the user back to the main window
             // instead of showing an empty preferences pane.
             switch loadState {
-            case .ready(let container):
+            case .ready(let container, let syncStatus):
                 SettingsView()
                     .modelContainer(container)
+                    .environment(\.cloudSyncStatus, syncStatus)
             case .testing, .failed:
                 Text("Open ContactManager to manage preferences.")
                     .padding()
@@ -214,7 +218,11 @@ struct ContactManagerApp: App {
         // and kick off an initial Spotlight reindex.
         EntityModelContainer.shared = container
         Task.detached { await SpotlightIndexer.shared.reindex() }
-        return .ready(container)
+        let syncStatus = CloudSyncStatus.resolved(
+            hasCloudKitEntitlement: cloudKitEnabled,
+            didFallBackToLocal: didFallBackToLocal
+        )
+        return .ready(container, syncStatus)
     }
 
     /// Whether the app was built with an iCloud container in its entitlements
@@ -245,7 +253,11 @@ struct ContactManagerApp: App {
                 print("ContactManager: sample data seeding skipped — \(error)")
             }
             EntityModelContainer.shared = container
-            return .ready(container)
+            return .ready(container, .resolved(
+                hasCloudKitEntitlement: false,
+                didFallBackToLocal: false,
+                isUITestMode: true
+            ))
         } catch {
             return .failed(error.localizedDescription)
         }
@@ -267,7 +279,7 @@ struct ContactManagerApp: App {
 }
 
 private enum ContainerLoadState {
-    case ready(ModelContainer)
+    case ready(ModelContainer, CloudSyncStatus)
     case testing
     case failed(String)
 }

--- a/ContactManager/Support/CloudSyncStatus.swift
+++ b/ContactManager/Support/CloudSyncStatus.swift
@@ -1,0 +1,85 @@
+//
+//  CloudSyncStatus.swift
+//  ContactManager
+//
+//  User-facing sync status derived from the CloudKit container load path.
+//
+
+import SwiftUI
+
+struct CloudSyncStatus: Equatable {
+    enum Kind: Equatable {
+        case localOnly
+        case cloudKit
+        case fallbackToLocal
+        case testing
+    }
+
+    var kind: Kind
+
+    static func resolved(
+        hasCloudKitEntitlement: Bool,
+        didFallBackToLocal: Bool,
+        isUITestMode: Bool = false
+    ) -> CloudSyncStatus {
+        if isUITestMode { return CloudSyncStatus(kind: .testing) }
+        if didFallBackToLocal { return CloudSyncStatus(kind: .fallbackToLocal) }
+        if hasCloudKitEntitlement { return CloudSyncStatus(kind: .cloudKit) }
+        return CloudSyncStatus(kind: .localOnly)
+    }
+
+    var title: String {
+        switch kind {
+        case .localOnly: "Local Only"
+        case .cloudKit: "iCloud Sync Enabled"
+        case .fallbackToLocal: "Fallback to Local"
+        case .testing: "Testing Store"
+        }
+    }
+
+    var shortMessage: String {
+        switch kind {
+        case .localOnly:
+            "Stored on this Mac"
+        case .cloudKit:
+            "Using the app's iCloud container"
+        case .fallbackToLocal:
+            "iCloud unavailable for this launch"
+        case .testing:
+            "Using isolated test data"
+        }
+    }
+
+    var detailMessage: String {
+        switch kind {
+        case .localOnly:
+            "Contacts are stored on this Mac. They do not sync to iCloud unless this build has an iCloud container."
+        case .cloudKit:
+            "Contacts are stored in the app's private CloudKit container and can sync through your iCloud account."
+        case .fallbackToLocal:
+            "The app could not open the CloudKit-backed store, so this launch is using the local store instead."
+        case .testing:
+            "Automation runs use an isolated in-memory store so real contacts never sync during UI tests."
+        }
+    }
+
+    var systemImage: String {
+        switch kind {
+        case .localOnly: "internaldrive"
+        case .cloudKit: "icloud"
+        case .fallbackToLocal: "icloud.slash"
+        case .testing: "testtube.2"
+        }
+    }
+}
+
+private struct CloudSyncStatusKey: EnvironmentKey {
+    static let defaultValue = CloudSyncStatus(kind: .localOnly)
+}
+
+extension EnvironmentValues {
+    var cloudSyncStatus: CloudSyncStatus {
+        get { self[CloudSyncStatusKey.self] }
+        set { self[CloudSyncStatusKey.self] = newValue }
+    }
+}

--- a/ContactManager/Views/SettingsView.swift
+++ b/ContactManager/Views/SettingsView.swift
@@ -11,6 +11,8 @@ import SwiftData
 import SwiftUI
 
 struct SettingsView: View {
+    @Environment(\.cloudSyncStatus) private var cloudSyncStatus
+
     @AppStorage("contactSortOrder") private var sortOrder: ContactSortOrder = .lastName
     /// JSON-encoded `PersistentIdentifier` of the default group, or "" for
     /// "no group". Storing the PID (not the group's name) means renaming the
@@ -42,6 +44,20 @@ struct SettingsView: View {
                 .help("When the sidebar is on All Contacts, new contacts join this group.")
             }
 
+            Section("Sync") {
+                Label {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(cloudSyncStatus.title)
+                        Text(cloudSyncStatus.detailMessage)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } icon: {
+                    Image(systemName: cloudSyncStatus.systemImage)
+                }
+                .accessibilityIdentifier("settings-sync-status")
+            }
+
             Section {
                 Button("Restore Defaults", role: .destructive) {
                     sortOrder = .lastName
@@ -50,7 +66,7 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 440, height: 240)
+        .frame(width: 440, height: 320)
         // Prune the preference if its target group was renamed (the encoded
         // PID stays valid) or deleted (the lookup now misses) — keeps the
         // picker's selection consistent with what's actually on disk.

--- a/ContactManager/Views/SidebarView.swift
+++ b/ContactManager/Views/SidebarView.swift
@@ -16,6 +16,8 @@ enum SidebarItem: Hashable {
 }
 
 struct SidebarView: View {
+    @Environment(\.cloudSyncStatus) private var cloudSyncStatus
+
     @Binding var selection: SidebarItem?
     let contactCount: Int
     let smartListCounts: [ContactSmartList: Int]
@@ -74,6 +76,20 @@ struct SidebarView: View {
                             }
                     }
                 }
+            }
+
+            Section("Sync") {
+                Label {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(cloudSyncStatus.title)
+                        Text(cloudSyncStatus.shortMessage)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } icon: {
+                    Image(systemName: cloudSyncStatus.systemImage)
+                }
+                .accessibilityIdentifier("sidebar-sync-status")
             }
         }
         .navigationTitle("Groups")

--- a/ContactManagerTests/CloudSyncStatusTests.swift
+++ b/ContactManagerTests/CloudSyncStatusTests.swift
@@ -1,0 +1,57 @@
+//
+//  CloudSyncStatusTests.swift
+//  ContactManagerTests
+//
+//  Covers the user-facing sync state derived from the app's CloudKit
+//  entitlement/container decisions.
+//
+
+@testable import ContactManager
+import Testing
+
+struct CloudSyncStatusTests {
+    @Test func localOnlyWhenNoCloudKitEntitlementIsPresent() {
+        let status = CloudSyncStatus.resolved(
+            hasCloudKitEntitlement: false,
+            didFallBackToLocal: false
+        )
+
+        #expect(status.kind == .localOnly)
+        #expect(status.title == "Local Only")
+        #expect(status.systemImage == "internaldrive")
+    }
+
+    @Test func cloudKitWhenEntitlementLoadsWithoutFallback() {
+        let status = CloudSyncStatus.resolved(
+            hasCloudKitEntitlement: true,
+            didFallBackToLocal: false
+        )
+
+        #expect(status.kind == .cloudKit)
+        #expect(status.title == "iCloud Sync Enabled")
+        #expect(status.systemImage == "icloud")
+    }
+
+    @Test func fallbackWhenCloudKitLoadFallsBackToLocalStore() {
+        let status = CloudSyncStatus.resolved(
+            hasCloudKitEntitlement: true,
+            didFallBackToLocal: true
+        )
+
+        #expect(status.kind == .fallbackToLocal)
+        #expect(status.title == "Fallback to Local")
+        #expect(status.systemImage == "icloud.slash")
+    }
+
+    @Test func uiTestsReportAnIsolatedLocalStore() {
+        let status = CloudSyncStatus.resolved(
+            hasCloudKitEntitlement: true,
+            didFallBackToLocal: false,
+            isUITestMode: true
+        )
+
+        #expect(status.kind == .testing)
+        #expect(status.title == "Testing Store")
+        #expect(status.systemImage == "testtube.2")
+    }
+}

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -50,6 +50,10 @@ final class ContactManagerUITests: XCTestCase {
             app.searchFields.firstMatch.waitForExistence(timeout: 3),
             "Contact-list search field should render"
         )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["sidebar-sync-status"].waitForExistence(timeout: 3),
+            "Sidebar sync status should render"
+        )
     }
 
     /// Verifies the File menu wires the Import / Export commands the


### PR DESCRIPTION
## Summary
Add an observable iCloud sync/storage status so users can see whether ContactManager is local-only, CloudKit-backed, using a local fallback, or running isolated UI-test storage.

## Changes
- Added a pure CloudSyncStatus model derived from the existing CloudKit entitlement/fallback decisions.
- Threaded sync status through the app's SwiftUI environment for windows and Settings.
- Added a compact sidebar sync row and a fuller Settings sync/privacy status section.
- Added unit coverage for local-only, iCloud-enabled, fallback-to-local, and UI-test statuses.
- Added UI smoke coverage for the sidebar sync-status row.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerTests/CloudSyncStatusTests
  - make check
  - make test

## Screenshots (if applicable)
N/A

## Related Issues
Closes #