### PR TITLE
feat(contacts): add batch actions

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		509C184B6FC5C331FCC6FD11 /* ImportReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB522F18FE21A503D7C480AB /* ImportReview.swift */; };
 		52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */; };
 		552E226D873AE11781A7F97A /* ContactDetailView+Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */; };
+		566DF0F6FE6E104AEE7C5302 /* ContactStoreBatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F228309258FF5B6F85FA05 /* ContactStoreBatchTests.swift */; };
 		5FCE54BC89E39D68DE29B360 /* CloudSyncStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE92D38DACB5637AF0E693F /* CloudSyncStatusTests.swift */; };
 		61F22EEDEE6075BD602203D5 /* VCardDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */; };
 		623A5F4AE958EAD5C2757F83 /* CSVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */; };
@@ -90,11 +91,13 @@
 		BBD79E7FD90E021417B527A9 /* FindContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F6260FE20C27094AFB327A /* FindContactIntent.swift */; };
 		BC3D0CE8272648D0ACEF0C46 /* BirthdayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B040B21B7E2002E00885A9BA /* BirthdayTests.swift */; };
 		C2A11D686722C70868435ACE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303A7F66E428BF3662142C0 /* SidebarView.swift */; };
+		CB3B48ECF52D91DC9B4789D7 /* ContactStore+Batch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C169D757A0DE2A58EEC0A32B /* ContactStore+Batch.swift */; };
 		CD70772ECD6A854C66159FFD /* OpenContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B27494A51645ACA6BED8EA8 /* OpenContactIntent.swift */; };
 		CE55AD882E6631A9541B6106 /* ContactsBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */; };
 		CEAC8F942C862FADB6C45220 /* SpotlightIndexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */; };
 		CFFC58E9EA162230275F2301 /* ContactEntityQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874742D7DC5E9C20D3A88459 /* ContactEntityQuery.swift */; };
 		D09BB01ED8C135141953AFE7 /* ImportReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFA2237DBD182839EAF04F1 /* ImportReviewView.swift */; };
+		D441204B3FC7CCD54E8AA427 /* ContentView+Batch.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8478B6328610390B341650 /* ContentView+Batch.swift */; };
 		D4431A7BEF48D8A75EFB8DC8 /* ContactStore+QuickCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34532FC6E64B32F9A27FCDCD /* ContactStore+QuickCapture.swift */; };
 		D5255AD7FAD03FD891ECC97B /* ContactStore+Interactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7466E6CBC023A24F4365537C /* ContactStore+Interactions.swift */; };
 		E11A07680CCF44C864B95662 /* ContentView+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C8E57A2BB1F32050119C06 /* ContentView+Backup.swift */; };
@@ -156,6 +159,7 @@
 		4A10D26E6D853A5EB462682B /* ContactBackupTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactBackupTests.swift; sourceTree = "<group>"; };
 		4E2F2242E59F2C42DDD0736B /* CSV.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CSV.swift; sourceTree = "<group>"; };
 		54C373BD237429970D6A7C86 /* DuplicatesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicatesView.swift; sourceTree = "<group>"; };
+		54F228309258FF5B6F85FA05 /* ContactStoreBatchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStoreBatchTests.swift; sourceTree = "<group>"; };
 		5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingTests.swift; sourceTree = "<group>"; };
 		570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Birthday.swift"; sourceTree = "<group>"; };
 		5951D4D8D52B6CDB782FE37D /* QuickCaptureView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickCaptureView.swift; path = ContactManager/Views/QuickCaptureView.swift; sourceTree = "<group>"; };
@@ -207,6 +211,7 @@
 		BECE026D8586731B7C590901 /* DefaultGroupPreference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultGroupPreference.swift; sourceTree = "<group>"; };
 		C0255C29CC874D2BA1C064CF /* ContactPDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactPDF.swift; sourceTree = "<group>"; };
 		C0F303B7AE5B9202CDA6D9DA /* ContactPDFTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactPDFTests.swift; sourceTree = "<group>"; };
+		C169D757A0DE2A58EEC0A32B /* ContactStore+Batch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ContactStore+Batch.swift"; path = "Models/ContactStore+Batch.swift"; sourceTree = "<group>"; };
 		C7DCAF444714BC3726B212C4 /* UndoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UndoTests.swift; sourceTree = "<group>"; };
 		C90D71F3F01E29B7C4B739A7 /* ContactStore+ImportReview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+ImportReview.swift"; sourceTree = "<group>"; };
 		C95BBAB51882751053816B2C /* ImportReviewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportReviewTests.swift; sourceTree = "<group>"; };
@@ -217,6 +222,7 @@
 		DED8178913A452A900EC3234 /* ContactManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ContactManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DED817AA13A452AA00EC3234 /* ContactManagerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContactManagerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEFCA6D1259AAB9C00DB0749 /* SharedSettings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SharedSettings.xcconfig; sourceTree = "<group>"; };
+		DF8478B6328610390B341650 /* ContentView+Batch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ContentView+Batch.swift"; path = "Views/ContentView+Batch.swift"; sourceTree = "<group>"; };
 		E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinder.swift; sourceTree = "<group>"; };
 		EBDDA2A3FA3C7375D63CFC55 /* ContactManagerApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactManagerApp.swift; sourceTree = "<group>"; };
 		F51E6728EF90B1D2BF8EA5AE /* Contact.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Contact.swift; sourceTree = "<group>"; };
@@ -396,6 +402,8 @@
 				76F68BAD5C3290EE7ABF787B /* Localizable.xcstrings */,
 				3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */,
 				0F125D04F06D9B25A250A47B /* CloudSyncStatus.swift */,
+				C169D757A0DE2A58EEC0A32B /* ContactStore+Batch.swift */,
+				DF8478B6328610390B341650 /* ContentView+Batch.swift */,
 			);
 			path = ContactManager;
 			sourceTree = "<group>";
@@ -428,6 +436,7 @@
 				764B3FB47DAFF8CE837BDE9D /* ContactHistoryTests.swift */,
 				4A10D26E6D853A5EB462682B /* ContactBackupTests.swift */,
 				8CE92D38DACB5637AF0E693F /* CloudSyncStatusTests.swift */,
+				54F228309258FF5B6F85FA05 /* ContactStoreBatchTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -624,6 +633,8 @@
 				3DC4EF7EB2977C7CE6492A2E /* EncryptedContactBackupDocument.swift in Sources */,
 				381FB5EAC1346691AA0349BE /* BackupPasswordPromptView.swift in Sources */,
 				8B360EB3A21E4CCADDA865BD /* CloudSyncStatus.swift in Sources */,
+				CB3B48ECF52D91DC9B4789D7 /* ContactStore+Batch.swift in Sources */,
+				D441204B3FC7CCD54E8AA427 /* ContentView+Batch.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -657,6 +668,7 @@
 				337B23E02F63EB1A294A5A41 /* ContactHistoryTests.swift in Sources */,
 				012DFE934E6F0E77278DA1B1 /* ContactBackupTests.swift in Sources */,
 				5FCE54BC89E39D68DE29B360 /* CloudSyncStatusTests.swift in Sources */,
+				566DF0F6FE6E104AEE7C5302 /* ContactStoreBatchTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Models/ContactStore+Batch.swift
+++ b/ContactManager/Models/ContactStore+Batch.swift
@@ -1,0 +1,30 @@
+//
+//  ContactStore+Batch.swift
+//  ContactManager
+//
+//  Multi-contact mutations used by batch actions.
+//
+
+extension ContactStore {
+    @discardableResult
+    func delete(_ contacts: [Contact]) throws -> Int {
+        guard !contacts.isEmpty else { return 0 }
+        return try mutate("Delete Contacts") {
+            contacts.forEach(context.delete)
+            return contacts.count
+        }
+    }
+
+    @discardableResult
+    func addContacts(_ contacts: [Contact], to group: ContactGroup) throws -> Int {
+        let groupID = group.persistentModelID
+        let toAdd = contacts.filter { contact in
+            !contact.groups.contains { $0.persistentModelID == groupID }
+        }
+        guard !toAdd.isEmpty else { return 0 }
+        return try mutate("Add to Group") {
+            toAdd.forEach { $0.groups.append(group) }
+            return toAdd.count
+        }
+    }
+}

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -6,6 +6,7 @@
 //  plus the sort and add/delete toolbar affordances.
 //
 
+import SwiftData
 import SwiftUI
 
 struct ContactListView: View {
@@ -16,8 +17,13 @@ struct ContactListView: View {
     @Binding var searchText: String
     @Binding var sortOrder: ContactSortOrder
     @Binding var selection: Contact?
+    @Binding var selectionIDs: Set<PersistentIdentifier>
+    let groups: [ContactGroup]
     var addContact: () -> Void
     var deleteContact: (Contact) -> Void
+    var exportSelectedContacts: () -> Void
+    var addSelectedContactsToGroup: (ContactGroup) -> Void
+    var deleteSelectedContacts: () -> Void
     /// Called when a `.vcf` file is dropped onto the list from Finder.
     var importVCardURLs: ([URL]) -> Void
 
@@ -30,12 +36,12 @@ struct ContactListView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        List(selection: $selection) {
+        List(selection: $selectionIDs) {
             ForEach(sections) { section in
                 Section(section.title) {
                     ForEach(section.contacts) { contact in
                         ContactRow(contact: contact)
-                            .tag(contact)
+                            .tag(contact.persistentModelID)
                             .accessibilityIdentifier(contact.accessibilityRowIdentifier)
                             // Drag a row to Finder to write `<Name>.vcf`.
                             .draggable(transfer(for: contact))
@@ -58,6 +64,13 @@ struct ContactListView: View {
         .onReceive(NotificationCenter.default.publisher(for: .focusSearchRequested)) { _ in
             searchFocused = true
         }
+        .onChange(of: selectionIDs) { _, newValue in
+            selection = contacts(in: newValue).first
+        }
+        .onChange(of: selection?.persistentModelID) { _, newValue in
+            guard let newValue, !selectionIDs.contains(newValue) else { return }
+            selectionIDs = [newValue]
+        }
         .overlay { emptyState }
         // Accept `.vcf` drops from Finder. Filtering on extension keeps
         // arbitrary file drops from triggering a no-op import.
@@ -68,7 +81,11 @@ struct ContactListView: View {
             return true
         }
         .onDeleteCommand {
-            if let selection { deleteContact(selection) }
+            if selectionIDs.count > 1 {
+                deleteSelectedContacts()
+            } else if let selection {
+                deleteContact(selection)
+            }
         }
         .toolbar {
             // One cohesive trailing group so sort and add render as a single
@@ -87,6 +104,30 @@ struct ContactListView: View {
                 }
                 .help("Sort Order")
 
+                Menu {
+                    Button("Export vCard…", action: exportSelectedContacts)
+                    Menu("Add to Group") {
+                        if groups.isEmpty {
+                            Text("No Groups")
+                        } else {
+                            ForEach(groups) { group in
+                                Button(group.displayName) {
+                                    addSelectedContactsToGroup(group)
+                                }
+                            }
+                        }
+                    }
+                    .accessibilityIdentifier("batch-add-to-group-menu")
+                    Divider()
+                    Button("Delete", role: .destructive, action: deleteSelectedContacts)
+                        .accessibilityIdentifier("batch-delete-button")
+                } label: {
+                    Label("Batch Actions", systemImage: "checklist")
+                        .accessibilityIdentifier("batch-actions-menu")
+                }
+                .disabled(selectionIDs.isEmpty)
+                .help("Batch Actions")
+
                 Button(action: addContact) {
                     Label("New Contact", systemImage: "plus")
                 }
@@ -94,6 +135,10 @@ struct ContactListView: View {
                 .accessibilityIdentifier("new-contact-button")
             }
         }
+    }
+
+    private func contacts(in ids: Set<PersistentIdentifier>) -> [Contact] {
+        sections.flatMap(\.contacts).filter { ids.contains($0.persistentModelID) }
     }
 
     private func transfer(for contact: Contact) -> VCardTransfer {

--- a/ContactManager/Views/ContentView+Alerts.swift
+++ b/ContactManager/Views/ContentView+Alerts.swift
@@ -37,5 +37,13 @@ extension ContentView {
             } message: { summary in
                 Text(summary.message)
             }
+            .alert("Delete Selected Contacts?", isPresented: $isConfirmingBatchDelete) {
+                Button("Cancel", role: .cancel) {}
+                Button("Delete", role: .destructive) {
+                    confirmDeleteSelectedContacts()
+                }
+            } message: {
+                Text("This will delete \(selectedContacts.count) contacts.")
+            }
     }
 }

--- a/ContactManager/Views/ContentView+Batch.swift
+++ b/ContactManager/Views/ContentView+Batch.swift
@@ -1,0 +1,50 @@
+//
+//  ContentView+Batch.swift
+//  ContactManager
+//
+//  Batch contact actions split out of ContentView's main body.
+//
+
+import SwiftUI
+
+extension ContentView {
+    func requestDeleteSelectedContacts() {
+        let selected = selectedContacts
+        guard !selected.isEmpty else { return }
+        if selected.count == 1, let contact = selected.first {
+            deleteContact(contact)
+        } else {
+            isConfirmingBatchDelete = true
+        }
+    }
+
+    func confirmDeleteSelectedContacts() {
+        let selected = selectedContacts
+        guard !selected.isEmpty else { return }
+        do {
+            try store.delete(selected)
+            selectedContactIDs.subtract(selected.map(\.persistentModelID))
+            if shouldClearDetail(afterDeleting: selected) {
+                selectedContact = nil
+            }
+            isConfirmingBatchDelete = false
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func addSelectedContacts(to group: ContactGroup) {
+        do {
+            _ = try store.addContacts(selectedContacts, to: group)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func shouldClearDetail(afterDeleting deleted: [Contact]) -> Bool {
+        guard let selectedContact else { return false }
+        return deleted.contains { contact in
+            contact.persistentModelID == selectedContact.persistentModelID
+        }
+    }
+}

--- a/ContactManager/Views/ContentView+FileDialogs.swift
+++ b/ContactManager/Views/ContentView+FileDialogs.swift
@@ -111,6 +111,16 @@ extension ContentView {
         isExportingPDF = true
     }
 
+    func exportSelectedContactsAsVCard() {
+        let selected = selectedContacts
+        guard !selected.isEmpty else {
+            errorMessage = "Select one or more contacts to export."
+            return
+        }
+        exportDocument = VCardDocument(text: store.exportVCards(selected))
+        isExportingVCard = true
+    }
+
     func printSelectedContact() {
         guard let contact = selectedContact else {
             errorMessage = "Select a contact to print."

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -23,8 +23,10 @@ struct ContentView: View {
 
     @State private var sidebarSelection: SidebarItem? = .allContacts
     @State var selectedContact: Contact?
+    @State var selectedContactIDs: Set<PersistentIdentifier> = []
     @State private var contactPendingNameFocus: PersistentIdentifier?
     @State var errorMessage: String?
+    @State var isConfirmingBatchDelete = false
     @State var importProgress: ImportProgress?
     @State private var searchText = ""
     @State private var debouncedSearchText = ""
@@ -75,6 +77,10 @@ struct ContentView: View {
 
     private var defaultGroup: ContactGroup? {
         DefaultGroupPreference.group(stored: defaultGroupID, in: groups)
+    }
+
+    var selectedContacts: [Contact] {
+        contacts.filter { selectedContactIDs.contains($0.persistentModelID) }
     }
 
     private var groupForNewContact: ContactGroup? {
@@ -154,8 +160,13 @@ struct ContentView: View {
                 searchText: $searchText,
                 sortOrder: $sortOrder,
                 selection: $selectedContact,
+                selectionIDs: $selectedContactIDs,
+                groups: groups,
                 addContact: addContact,
                 deleteContact: deleteContact,
+                exportSelectedContacts: exportSelectedContactsAsVCard,
+                addSelectedContactsToGroup: addSelectedContacts(to:),
+                deleteSelectedContacts: requestDeleteSelectedContacts,
                 importVCardURLs: importVCardURLs
             )
         } detail: {
@@ -194,16 +205,18 @@ struct ContentView: View {
             let contact = try store.createContact(in: groupForNewContact)
             if selectedSmartList != nil { sidebarSelection = .allContacts }
             contactPendingNameFocus = contact.persistentModelID
+            selectedContactIDs = [contact.persistentModelID]
             withAnimation(reduceMotion ? nil : .snappy) { selectedContact = contact }
         } catch {
             errorMessage = error.localizedDescription
         }
     }
 
-    private func deleteContact(_ contact: Contact) {
+    func deleteContact(_ contact: Contact) {
         let wasSelected = selectedContact?.persistentModelID == contact.persistentModelID
         do {
             try store.delete(contact)
+            selectedContactIDs.remove(contact.persistentModelID)
             if wasSelected { selectedContact = nil }
         } catch {
             errorMessage = error.localizedDescription

--- a/ContactManagerTests/ContactStoreBatchTests.swift
+++ b/ContactManagerTests/ContactStoreBatchTests.swift
@@ -1,0 +1,65 @@
+//
+//  ContactStoreBatchTests.swift
+//  ContactManagerTests
+//
+//  Covers multi-contact operations behind the batch action UI.
+//
+
+@testable import ContactManager
+import SwiftData
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct ContactStoreBatchTests {
+    let container: ModelContainer
+    let store: ContactStore
+    var context: ModelContext { container.mainContext }
+
+    init() throws {
+        container = try ModelContainer(
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        store = ContactStore(container.mainContext)
+    }
+
+    @Test func batchDeleteRemovesAllSelectedContacts() throws {
+        let ada = try store.createContact()
+        let alan = try store.createContact()
+        _ = try store.createContact()
+
+        let deleted = try store.delete([ada, alan])
+
+        let contacts = try context.fetch(FetchDescriptor<Contact>())
+        #expect(deleted == 2)
+        #expect(contacts.count == 1)
+        #expect(!contacts.contains { $0.persistentModelID == ada.persistentModelID })
+        #expect(!contacts.contains { $0.persistentModelID == alan.persistentModelID })
+    }
+
+    @Test func batchDeleteIsANoOpForEmptySelection() throws {
+        _ = try store.createContact()
+
+        let deleted = try store.delete([Contact]())
+
+        #expect(deleted == 0)
+        #expect(try context.fetch(FetchDescriptor<Contact>()).count == 1)
+    }
+
+    @Test func batchAssignAddsSelectedContactsToGroup() throws {
+        let group = try store.createGroup(named: "Work")
+        let ada = try store.createContact()
+        let alan = try store.createContact(in: group)
+        let grace = try store.createContact()
+
+        let added = try store.addContacts([ada, alan, grace], to: group)
+
+        #expect(added == 2)
+        #expect(Set(group.contacts.map(\.persistentModelID)) == [
+            ada.persistentModelID,
+            alan.persistentModelID,
+            grace.persistentModelID,
+        ])
+    }
+}

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -54,6 +54,12 @@ final class ContactManagerUITests: XCTestCase {
             app.descendants(matching: .any)["sidebar-sync-status"].waitForExistence(timeout: 3),
             "Sidebar sync status should render"
         )
+        app.typeKey("n", modifierFlags: .command)
+        XCTAssertTrue(app.textFields["contact-first-name-field"].waitForExistence(timeout: 3))
+        XCTAssertTrue(
+            app.menuButtons["batch-actions-menu"].waitForExistence(timeout: 3),
+            "Batch actions menu should render"
+        )
     }
 
     /// Verifies the File menu wires the Import / Export commands the


### PR DESCRIPTION
## Summary
Add multi-select batch actions for common contact management work.

## Changes
- Added ContactStore batch delete and batch group-assignment paths through the existing mutate/save/undo pipeline.
- Added multi-select contact list state while preserving the primary detail selection.
- Added a Batch Actions toolbar menu for selected contacts.
- Added batch vCard export, add-to-group, and multi-contact delete confirmation.
- Added unit coverage for batch delete, empty batch delete, and batch group assignment.
- Added UI smoke coverage for the batch actions toolbar control.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - `xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerUITests/ContactManagerUITests/test_appLaunchesWithMainWindow`
  - `make check`
  - `make test`

## Screenshots (if applicable)
N/A

## Related Issues
Closes #