### PR TITLE
feat(commands): add command palette

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		01001E025DB1348D36342E1C /* OpenContactIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279FCAC10E829D7DAC9D8385 /* OpenContactIntentTests.swift */; };
 		012DFE934E6F0E77278DA1B1 /* ContactBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A10D26E6D853A5EB462682B /* ContactBackupTests.swift */; };
 		02D950C10327393FB2B5BB7E /* ImageProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76507F3A1E2222FB64D7F31 /* ImageProcessing.swift */; };
+		07D11DB16E18E03F9054F6EC /* CommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DEBEEC44A291A5ABA6C5EA4 /* CommandPalette.swift */; };
 		0ABBB9962C4AC14A077728FF /* ContactStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03763AB80D45F026EC585490 /* ContactStoreTests.swift */; };
 		0DC8E4BAF454185075119C3A /* ContactStorePendingEditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438C2B20E1C302676594ECCA /* ContactStorePendingEditTests.swift */; };
 		134F890B4875E8BF294A92B2 /* ContactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617D7B082A403094284FBD38 /* ContactStore.swift */; };
@@ -43,6 +44,7 @@
 		4F1E1A097740ECE3D42E55B8 /* GroupDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964ACD67CC8CB35694497A10 /* GroupDropTests.swift */; };
 		509C184B6FC5C331FCC6FD11 /* ImportReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB522F18FE21A503D7C480AB /* ImportReview.swift */; };
 		52F4C28719253736244342F9 /* SpotlightDeltaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */; };
+		53A6FEF15A8C7A6E9F3EDBE1 /* ContentView+CommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D7B4C2858A6EE928355320 /* ContentView+CommandPalette.swift */; };
 		552E226D873AE11781A7F97A /* ContactDetailView+Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */; };
 		566DF0F6FE6E104AEE7C5302 /* ContactStoreBatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F228309258FF5B6F85FA05 /* ContactStoreBatchTests.swift */; };
 		5FCE54BC89E39D68DE29B360 /* CloudSyncStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE92D38DACB5637AF0E693F /* CloudSyncStatusTests.swift */; };
@@ -91,6 +93,7 @@
 		BBD79E7FD90E021417B527A9 /* FindContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F6260FE20C27094AFB327A /* FindContactIntent.swift */; };
 		BC3D0CE8272648D0ACEF0C46 /* BirthdayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B040B21B7E2002E00885A9BA /* BirthdayTests.swift */; };
 		C2A11D686722C70868435ACE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303A7F66E428BF3662142C0 /* SidebarView.swift */; };
+		C378A683EF56824504C580F9 /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D505A1E75ACB938A488465 /* CommandPaletteView.swift */; };
 		CB3B48ECF52D91DC9B4789D7 /* ContactStore+Batch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C169D757A0DE2A58EEC0A32B /* ContactStore+Batch.swift */; };
 		CD70772ECD6A854C66159FFD /* OpenContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B27494A51645ACA6BED8EA8 /* OpenContactIntent.swift */; };
 		CE55AD882E6631A9541B6106 /* ContactsBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */; };
@@ -106,6 +109,7 @@
 		ECDA4BC68D3FAE4CCF428675 /* ContactDetailView+Saving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */; };
 		FA63688E94483238D7C29FE9 /* DuplicateFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */; };
 		FA702A2E92FAC86D4587641B /* ContactManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDDA2A3FA3C7375D63CFC55 /* ContactManagerApp.swift */; };
+		FE0819C468F6487E3777A0B8 /* CommandPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C127145D465C7F656FDBD0B6 /* CommandPaletteTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -134,11 +138,13 @@
 		08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactListView.swift; sourceTree = "<group>"; };
 		0B27567532AC1A51FF4CC13A /* ContactQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactQuery.swift; sourceTree = "<group>"; };
 		0CFA2237DBD182839EAF04F1 /* ImportReviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportReviewView.swift; sourceTree = "<group>"; };
+		0DEBEEC44A291A5ABA6C5EA4 /* CommandPalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommandPalette.swift; path = Models/CommandPalette.swift; sourceTree = "<group>"; };
 		0F125D04F06D9B25A250A47B /* CloudSyncStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CloudSyncStatus.swift; path = Support/CloudSyncStatus.swift; sourceTree = "<group>"; };
 		0F82C8A388E97CC4F1106176 /* SampleData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SampleData.swift; sourceTree = "<group>"; };
 		10E14CB9E9A2442DFE7B0E0B /* ContactManager.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = ContactManager.entitlements; sourceTree = "<group>"; };
 		10E7338673D65A6FAB4F9AF3 /* ContactManagerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContactManagerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotlightIndexer.swift; sourceTree = "<group>"; };
+		21D505A1E75ACB938A488465 /* CommandPaletteView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommandPaletteView.swift; path = Views/CommandPaletteView.swift; sourceTree = "<group>"; };
 		2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactsBridge.swift; sourceTree = "<group>"; };
 		25B2B9B4E62C9BAA67FB718B /* ContactBackupPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactBackupPreview.swift; sourceTree = "<group>"; };
 		2623DCD281C3DDAA29BB6B99 /* DefaultGroupPreferenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultGroupPreferenceTests.swift; sourceTree = "<group>"; };
@@ -172,6 +178,7 @@
 		66E45011FDD9D571FF1834F5 /* ContactBackup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactBackup.swift; sourceTree = "<group>"; };
 		66F852CE2356ADE83460064B /* ContentView+Import.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+Import.swift"; sourceTree = "<group>"; };
 		6EE79F02FFFD9820269D3725 /* ContactLinkTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactLinkTests.swift; sourceTree = "<group>"; };
+		70D7B4C2858A6EE928355320 /* ContentView+CommandPalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ContentView+CommandPalette.swift"; path = "Views/ContentView+CommandPalette.swift"; sourceTree = "<group>"; };
 		734D363DD0CB0BAA7AE9460B /* LayoutMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LayoutMetrics.swift; sourceTree = "<group>"; };
 		73D22E8B17D14280F44AB0B2 /* ContactDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactDetailView.swift; sourceTree = "<group>"; };
 		7466E6CBC023A24F4365537C /* ContactStore+Interactions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+Interactions.swift"; sourceTree = "<group>"; };
@@ -211,6 +218,7 @@
 		BECE026D8586731B7C590901 /* DefaultGroupPreference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultGroupPreference.swift; sourceTree = "<group>"; };
 		C0255C29CC874D2BA1C064CF /* ContactPDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactPDF.swift; sourceTree = "<group>"; };
 		C0F303B7AE5B9202CDA6D9DA /* ContactPDFTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactPDFTests.swift; sourceTree = "<group>"; };
+		C127145D465C7F656FDBD0B6 /* CommandPaletteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CommandPaletteTests.swift; sourceTree = "<group>"; };
 		C169D757A0DE2A58EEC0A32B /* ContactStore+Batch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ContactStore+Batch.swift"; path = "Models/ContactStore+Batch.swift"; sourceTree = "<group>"; };
 		C7DCAF444714BC3726B212C4 /* UndoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UndoTests.swift; sourceTree = "<group>"; };
 		C90D71F3F01E29B7C4B739A7 /* ContactStore+ImportReview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+ImportReview.swift"; sourceTree = "<group>"; };
@@ -404,6 +412,9 @@
 				0F125D04F06D9B25A250A47B /* CloudSyncStatus.swift */,
 				C169D757A0DE2A58EEC0A32B /* ContactStore+Batch.swift */,
 				DF8478B6328610390B341650 /* ContentView+Batch.swift */,
+				0DEBEEC44A291A5ABA6C5EA4 /* CommandPalette.swift */,
+				21D505A1E75ACB938A488465 /* CommandPaletteView.swift */,
+				70D7B4C2858A6EE928355320 /* ContentView+CommandPalette.swift */,
 			);
 			path = ContactManager;
 			sourceTree = "<group>";
@@ -437,6 +448,7 @@
 				4A10D26E6D853A5EB462682B /* ContactBackupTests.swift */,
 				8CE92D38DACB5637AF0E693F /* CloudSyncStatusTests.swift */,
 				54F228309258FF5B6F85FA05 /* ContactStoreBatchTests.swift */,
+				C127145D465C7F656FDBD0B6 /* CommandPaletteTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -635,6 +647,9 @@
 				8B360EB3A21E4CCADDA865BD /* CloudSyncStatus.swift in Sources */,
 				CB3B48ECF52D91DC9B4789D7 /* ContactStore+Batch.swift in Sources */,
 				D441204B3FC7CCD54E8AA427 /* ContentView+Batch.swift in Sources */,
+				07D11DB16E18E03F9054F6EC /* CommandPalette.swift in Sources */,
+				C378A683EF56824504C580F9 /* CommandPaletteView.swift in Sources */,
+				53A6FEF15A8C7A6E9F3EDBE1 /* ContentView+CommandPalette.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -669,6 +684,7 @@
 				012DFE934E6F0E77278DA1B1 /* ContactBackupTests.swift in Sources */,
 				5FCE54BC89E39D68DE29B360 /* CloudSyncStatusTests.swift in Sources */,
 				566DF0F6FE6E104AEE7C5302 /* ContactStoreBatchTests.swift in Sources */,
+				FE0819C468F6487E3777A0B8 /* CommandPaletteTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -88,6 +88,10 @@ struct ContactManagerApp: App {
                 .keyboardShortcut("n", modifiers: [.command, .option])
             }
             CommandGroup(after: .textEditing) {
+                Button("Command Palette…") {
+                    NotificationCenter.default.post(name: .commandPaletteRequested, object: nil)
+                }
+                .keyboardShortcut("k", modifiers: .command)
                 Button("Find") {
                     NotificationCenter.default.post(name: .focusSearchRequested, object: nil)
                 }
@@ -320,6 +324,7 @@ extension Notification.Name {
     static let exportPDFRequested = Notification.Name("ContactManager.exportPDFRequested")
     static let printContactRequested = Notification.Name("ContactManager.printContactRequested")
     static let findDuplicatesRequested = Notification.Name("ContactManager.findDuplicatesRequested")
+    static let commandPaletteRequested = Notification.Name("ContactManager.commandPaletteRequested")
     /// Posted by the Find menu command (⌘F); focuses the contact search field.
     static let focusSearchRequested = Notification.Name("ContactManager.focusSearchRequested")
     /// Posted by App Intents (and `Spotlight` taps via `ContentView`'s

--- a/ContactManager/Models/CommandPalette.swift
+++ b/ContactManager/Models/CommandPalette.swift
@@ -1,0 +1,32 @@
+//
+//  CommandPalette.swift
+//  ContactManager
+//
+//  Pure command-palette filtering helpers.
+//
+
+struct CommandPaletteItem: Identifiable, Equatable {
+    let id: String
+    var title: String
+    var subtitle: String
+    var keywords: [String] = []
+    var systemImage: String = "command"
+    var isDestructive = false
+
+    var searchText: String {
+        ([title, subtitle] + keywords).joined(separator: " ").lowercased()
+    }
+}
+
+enum CommandPalette {
+    static func filtered(_ items: [CommandPaletteItem], matching query: String) -> [CommandPaletteItem] {
+        let tokens = query
+            .lowercased()
+            .split { $0.isWhitespace || $0 == "," }
+            .map(String.init)
+        guard !tokens.isEmpty else { return items }
+        return items.filter { item in
+            tokens.allSatisfy { item.searchText.contains($0) }
+        }
+    }
+}

--- a/ContactManager/Views/CommandPaletteView.swift
+++ b/ContactManager/Views/CommandPaletteView.swift
@@ -1,0 +1,112 @@
+//
+//  CommandPaletteView.swift
+//  ContactManager
+//
+//  Keyboard-first command launcher.
+//
+
+import SwiftUI
+
+struct CommandPaletteAction: Identifiable {
+    var item: CommandPaletteItem
+    var perform: () -> Void
+
+    var id: String { item.id }
+}
+
+struct CommandPaletteView: View {
+    @Binding var query: String
+    var entries: [CommandPaletteAction]
+    var perform: (CommandPaletteAction) -> Void
+
+    @FocusState private var searchFocused: Bool
+
+    private var filteredEntries: [CommandPaletteAction] {
+        let filteredIDs = Set(CommandPalette.filtered(entries.map(\.item), matching: query).map(\.id))
+        return entries.filter { filteredIDs.contains($0.id) }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TextField("Search commands", text: $query)
+                .textFieldStyle(.plain)
+                .font(.title3)
+                .padding(14)
+                .focused($searchFocused)
+                .onSubmit(runFirstMatch)
+                .accessibilityIdentifier("command-palette-search-field")
+
+            Divider()
+
+            List(filteredEntries) { entry in
+                Button {
+                    perform(entry)
+                } label: {
+                    CommandPaletteRow(item: entry.item)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("command-palette-row-\(entry.id)")
+            }
+            .listStyle(.plain)
+            .frame(minHeight: 280)
+            .overlay {
+                if filteredEntries.isEmpty {
+                    ContentUnavailableView("No Commands", systemImage: "command")
+                }
+            }
+        }
+        .frame(width: 520, height: 420)
+        .onAppear {
+            searchFocused = true
+        }
+    }
+
+    private func runFirstMatch() {
+        guard let entry = filteredEntries.first else { return }
+        perform(entry)
+    }
+}
+
+private struct CommandPaletteRow: View {
+    var item: CommandPaletteItem
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: item.systemImage)
+                .frame(width: 24)
+                .foregroundStyle(item.isDestructive ? .red : .secondary)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .foregroundStyle(item.isDestructive ? .red : .primary)
+                if !item.subtitle.isEmpty {
+                    Text(item.subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+        }
+        .contentShape(Rectangle())
+        .padding(.vertical, 6)
+    }
+}
+
+#Preview {
+    CommandPaletteView(
+        query: .constant(""),
+        entries: [
+            CommandPaletteAction(
+                item: CommandPaletteItem(
+                    id: "new",
+                    title: "New Contact",
+                    subtitle: "Create a blank contact",
+                    systemImage: "person.badge.plus"
+                ),
+                perform: {}
+            ),
+        ],
+        perform: { _ in }
+    )
+}

--- a/ContactManager/Views/ContentView+CommandPalette.swift
+++ b/ContactManager/Views/ContentView+CommandPalette.swift
@@ -1,0 +1,272 @@
+//
+//  ContentView+CommandPalette.swift
+//  ContactManager
+//
+//  Command palette presentation and action wiring.
+//
+
+import AppKit
+import SwiftUI
+
+extension ContentView {
+    func handlingCommandPalette(_ content: some View) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .commandPaletteRequested)) { _ in
+                isShowingCommandPalette = true
+            }
+            .sheet(isPresented: $isShowingCommandPalette, onDismiss: finishCommandPaletteDismissal) {
+                CommandPaletteView(
+                    query: $commandPaletteQuery,
+                    entries: commandPaletteEntries
+                ) { entry in
+                    pendingCommandPaletteAction = entry.perform
+                    isShowingCommandPalette = false
+                    commandPaletteQuery = ""
+                }
+            }
+    }
+
+    var commandPaletteEntries: [CommandPaletteAction] {
+        var entries = coreCommandPaletteEntries
+        entries.append(contentsOf: navigationCommandPaletteEntries)
+        entries.append(contentsOf: selectedContactCommandPaletteEntries)
+        return entries
+    }
+
+    private var coreCommandPaletteEntries: [CommandPaletteAction] {
+        [
+            command(
+                id: "new-contact",
+                title: "New Contact",
+                subtitle: "Create a blank contact",
+                keywords: ["add", "person"],
+                systemImage: "person.badge.plus",
+                action: addContact
+            ),
+            command(
+                id: "quick-capture",
+                title: "Quick Capture",
+                subtitle: "Open the quick-entry window",
+                keywords: ["natural language", "capture"],
+                systemImage: "bolt.fill"
+            ) {
+                openWindow(id: "quickCapture")
+            },
+            command(
+                id: "find-contacts",
+                title: "Find Contacts",
+                subtitle: "Focus the contact search field",
+                keywords: ["search"],
+                systemImage: "magnifyingglass"
+            ) {
+                NotificationCenter.default.post(name: .focusSearchRequested, object: nil)
+            },
+            command(
+                id: "find-duplicates",
+                title: "Find Duplicates",
+                subtitle: "Review likely duplicate contacts",
+                keywords: ["merge"],
+                systemImage: "person.2.badge.gearshape"
+            ) {
+                showingDuplicates = true
+            },
+            command(
+                id: "import-contacts",
+                title: "Import from Contacts",
+                subtitle: "Review contacts from the system Contacts app",
+                keywords: ["system", "address book"],
+                systemImage: "person.crop.circle.badge.plus",
+                action: importSystemContacts
+            ),
+            command(
+                id: "import-vcard",
+                title: "Import vCard",
+                subtitle: "Review contacts from a .vcf file",
+                keywords: ["vcf"],
+                systemImage: "square.and.arrow.down"
+            ) {
+                isImportingVCard = true
+            },
+            command(
+                id: "import-csv",
+                title: "Import CSV",
+                subtitle: "Review contacts from a CSV file",
+                keywords: ["spreadsheet"],
+                systemImage: "tablecells"
+            ) {
+                isImportingCSV = true
+            },
+            command(
+                id: "export-vcard",
+                title: "Export vCard",
+                subtitle: "Export all contacts as .vcf",
+                keywords: ["vcf"],
+                systemImage: "square.and.arrow.up"
+            ) {
+                exportDocument = VCardDocument(text: store.exportVCards(contacts))
+                isExportingVCard = true
+            },
+            command(
+                id: "export-backup",
+                title: "Export Backup",
+                subtitle: "Save a JSON backup",
+                keywords: ["archive"],
+                systemImage: "externaldrive",
+                action: exportBackup
+            ),
+            command(
+                id: "export-encrypted-backup",
+                title: "Export Encrypted Backup",
+                subtitle: "Save a password-protected backup",
+                keywords: ["privacy", "secure", "archive"],
+                systemImage: "lock.shield"
+            ) {
+                isPreparingEncryptedBackup = true
+            },
+            command(
+                id: "restore-backup",
+                title: "Restore Backup",
+                subtitle: "Review and restore a backup",
+                keywords: ["import", "json"],
+                systemImage: "arrow.counterclockwise"
+            ) {
+                isRestoringBackup = true
+            },
+            command(
+                id: "settings",
+                title: "Settings",
+                subtitle: "Open app preferences",
+                keywords: ["preferences"],
+                systemImage: "gearshape",
+                action: openSettings
+            ),
+        ]
+    }
+
+    private var navigationCommandPaletteEntries: [CommandPaletteAction] {
+        var entries: [CommandPaletteAction] = [
+            command(
+                id: "nav-all-contacts",
+                title: "All Contacts",
+                subtitle: "Show every contact",
+                keywords: ["navigate"],
+                systemImage: "person.3"
+            ) {
+                sidebarSelection = .allContacts
+            },
+        ]
+
+        entries.append(contentsOf: ContactSmartList.allCases.map { smartList in
+            command(
+                id: "nav-smart-\(smartList.rawValue)",
+                title: smartList.title,
+                subtitle: "Open smart list",
+                keywords: ["navigate", "filter"],
+                systemImage: smartList.systemImage
+            ) {
+                sidebarSelection = .smartList(smartList)
+            }
+        })
+
+        entries.append(contentsOf: groups.map { group in
+            command(
+                id: "nav-group-\(group.persistentModelID.storedString ?? group.displayName)",
+                title: group.displayName,
+                subtitle: "Open group",
+                keywords: ["navigate", "group"],
+                systemImage: "folder"
+            ) {
+                sidebarSelection = .group(group.persistentModelID)
+            }
+        })
+
+        return entries
+    }
+
+    private var selectedContactCommandPaletteEntries: [CommandPaletteAction] {
+        guard selectedContact != nil || !selectedContactIDs.isEmpty else { return [] }
+        var entries = [
+            command(
+                id: "selected-export-vcard",
+                title: "Export Selected vCard",
+                subtitle: "Export selected contacts as .vcf",
+                keywords: ["batch", "vcf"],
+                systemImage: "square.and.arrow.up",
+                action: exportSelectedContactsAsVCard
+            ),
+            command(
+                id: "selected-delete",
+                title: "Delete Selected Contacts",
+                subtitle: "Delete the current selection",
+                keywords: ["remove", "batch"],
+                systemImage: "trash",
+                isDestructive: true,
+                action: requestDeleteSelectedContacts
+            ),
+        ]
+
+        if let selectedContact {
+            entries.insert(
+                command(
+                    id: "selected-mark-contacted",
+                    title: "Mark Contacted Today",
+                    subtitle: selectedContact.fullName,
+                    keywords: ["history", "follow up"],
+                    systemImage: "checkmark.circle"
+                ) {
+                    markContacted(selectedContact)
+                },
+                at: 0
+            )
+            entries.append(
+                command(
+                    id: "selected-export-pdf",
+                    title: "Export Selected as PDF",
+                    subtitle: selectedContact.fullName,
+                    keywords: ["print"],
+                    systemImage: "doc.richtext",
+                    action: exportSelectedContactAsPDF
+                )
+            )
+        }
+
+        return entries
+    }
+
+    private func command(
+        id: String,
+        title: String,
+        subtitle: String,
+        keywords: [String] = [],
+        systemImage: String,
+        isDestructive: Bool = false,
+        action: @escaping () -> Void
+    ) -> CommandPaletteAction {
+        CommandPaletteAction(
+            item: CommandPaletteItem(
+                id: id,
+                title: title,
+                subtitle: subtitle,
+                keywords: keywords,
+                systemImage: systemImage,
+                isDestructive: isDestructive
+            ),
+            perform: action
+        )
+    }
+
+    private func finishCommandPaletteDismissal() {
+        let action = pendingCommandPaletteAction
+        pendingCommandPaletteAction = nil
+        clearCommandPalette()
+        action?()
+    }
+
+    private func clearCommandPalette() {
+        commandPaletteQuery = ""
+    }
+
+    private func openSettings() {
+        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+    }
+}

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -15,18 +15,22 @@ struct ContentView: View {
     @Environment(\.modelContext) private var context
     @Environment(\.undoManager) private var undoManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.openWindow) var openWindow
 
     @Query(sort: [SortDescriptor(\Contact.lastName), SortDescriptor(\Contact.firstName)])
     var contacts: [Contact]
 
     @Query(sort: \ContactGroup.name) var groups: [ContactGroup]
 
-    @State private var sidebarSelection: SidebarItem? = .allContacts
+    @State var sidebarSelection: SidebarItem? = .allContacts
     @State var selectedContact: Contact?
     @State var selectedContactIDs: Set<PersistentIdentifier> = []
     @State private var contactPendingNameFocus: PersistentIdentifier?
     @State var errorMessage: String?
     @State var isConfirmingBatchDelete = false
+    @State var isShowingCommandPalette = false
+    @State var commandPaletteQuery = ""
+    @State var pendingCommandPaletteAction: (() -> Void)?
     @State var importProgress: ImportProgress?
     @State private var searchText = ""
     @State private var debouncedSearchText = ""
@@ -135,7 +139,7 @@ struct ContentView: View {
             .onChange(of: undoManager) { _, new in
                 context.undoManager = new
             }
-        return handlingFileDialogs(handlingHandoff(handlingMenuCommands(scene)))
+        return handlingCommandPalette(handlingFileDialogs(handlingHandoff(handlingMenuCommands(scene))))
     }
 
     /// The three-column split view, window frame, and the import overlay.
@@ -200,7 +204,7 @@ struct ContentView: View {
 
     // MARK: - Contact actions
 
-    private func addContact() {
+    func addContact() {
         do {
             let contact = try store.createContact(in: groupForNewContact)
             if selectedSmartList != nil { sidebarSelection = .allContacts }
@@ -223,7 +227,7 @@ struct ContentView: View {
         }
     }
 
-    private func markContacted(_ contact: Contact) {
+    func markContacted(_ contact: Contact) {
         do {
             try store.markContacted(contact)
         } catch {

--- a/ContactManagerTests/CommandPaletteTests.swift
+++ b/ContactManagerTests/CommandPaletteTests.swift
@@ -1,0 +1,50 @@
+//
+//  CommandPaletteTests.swift
+//  ContactManagerTests
+//
+//  Covers the pure filtering logic behind the command palette UI.
+//
+
+@testable import ContactManager
+import Testing
+
+struct CommandPaletteTests {
+    private let items = [
+        CommandPaletteItem(
+            id: "new",
+            title: "New Contact",
+            subtitle: "Create a blank contact",
+            keywords: ["add", "person"]
+        ),
+        CommandPaletteItem(
+            id: "duplicates",
+            title: "Find Duplicates",
+            subtitle: "Review likely duplicate contacts",
+            keywords: ["merge"]
+        ),
+        CommandPaletteItem(
+            id: "backup",
+            title: "Export Backup",
+            subtitle: "Save a JSON backup",
+            keywords: ["archive", "restore"]
+        ),
+    ]
+
+    @Test func emptyQueryReturnsAllItemsInOrder() {
+        #expect(CommandPalette.filtered(items, matching: "").map(\.id) == [
+            "new", "duplicates", "backup",
+        ])
+    }
+
+    @Test func filteringMatchesTitleSubtitleAndKeywordsCaseInsensitively() {
+        #expect(CommandPalette.filtered(items, matching: "person").map(\.id) == ["new"])
+        #expect(CommandPalette.filtered(items, matching: "duplicate").map(\.id) == ["duplicates"])
+        #expect(CommandPalette.filtered(items, matching: "json").map(\.id) == ["backup"])
+        #expect(CommandPalette.filtered(items, matching: "MERGE").map(\.id) == ["duplicates"])
+    }
+
+    @Test func filteringRequiresEveryQueryTokenToMatch() {
+        #expect(CommandPalette.filtered(items, matching: "find contacts").map(\.id) == ["duplicates"])
+        #expect(CommandPalette.filtered(items, matching: "find json").isEmpty)
+    }
+}

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -60,6 +60,11 @@ final class ContactManagerUITests: XCTestCase {
             app.menuButtons["batch-actions-menu"].waitForExistence(timeout: 3),
             "Batch actions menu should render"
         )
+        app.typeKey("k", modifierFlags: .command)
+        XCTAssertTrue(
+            app.textFields["command-palette-search-field"].waitForExistence(timeout: 3),
+            "Command palette should open from ⌘K"
+        )
     }
 
     /// Verifies the File menu wires the Import / Export commands the


### PR DESCRIPTION
## Summary
Add a keyboard-first command palette for common app actions and navigation.

## Changes
- Added pure command-palette filtering logic with unit coverage.
- Added a Cmd-K command palette sheet with focused search and Return-to-run-first behavior.
- Wired palette actions to existing create/import/export/backup/restore/find/settings flows.
- Added navigation commands for All Contacts, smart lists, and groups.
- Added selected-contact commands for mark contacted, selected vCard export, PDF export, and delete.
- Added UI smoke coverage for opening the palette with Cmd-K.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerTests/CommandPaletteTests
  - xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerUITests/ContactManagerUITests/test_appLaunchesWithMainWindow
  - make check
  - make test

## Screenshots (if applicable)
N/A

## Related Issues
Closes #