### PR TITLE
feat(lists): add saved smart lists

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -28,9 +28,12 @@
 		337B23E02F63EB1A294A5A41 /* ContactHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764B3FB47DAFF8CE837BDE9D /* ContactHistoryTests.swift */; };
 		381FB5EAC1346691AA0349BE /* BackupPasswordPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FA55EA1466B6711EE517B4 /* BackupPasswordPromptView.swift */; };
 		39D33CDF2E0495FCCA8D7E13 /* QuickCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C76A783B91BD2AA6D3F70B /* QuickCaptureTests.swift */; };
+		3AC47032325005D9EABD5392 /* ContactSavedSmartList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BAFEACBC810DF99B8FF3C6 /* ContactSavedSmartList.swift */; };
 		3DC4EF7EB2977C7CE6492A2E /* EncryptedContactBackupDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D5EEA2101A9DE782A0F000 /* EncryptedContactBackupDocument.swift */; };
 		3EDDAA184C377D9C16AAF08A /* ContactStore+PendingEdits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A0DA8645E9D2AA36D9D28E /* ContactStore+PendingEdits.swift */; };
+		3F4A5ABEE3FB4E56C578D00D /* ContentView+SavedSmartLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E9EC2BF0BB563A687FB4F /* ContentView+SavedSmartLists.swift */; };
 		3FA1770FF1649CC78510AF10 /* ContentView+Alerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0401F25DFDF91CE847706D08 /* ContentView+Alerts.swift */; };
+		4287C737AA6235E660318237 /* ContactStore+SavedSmartLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AFEE833481781C252FE8A5 /* ContactStore+SavedSmartLists.swift */; };
 		42F87AE7D82D2D802D7B670E /* ContactBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E45011FDD9D571FF1834F5 /* ContactBackup.swift */; };
 		442122E49889F5A9CA174B12 /* ContactActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */; };
 		444B949F37F7FF7DD98A4C6B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */; };
@@ -107,6 +110,7 @@
 		E5EB465B5CE3964197D29ADF /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F82C8A388E97CC4F1106176 /* SampleData.swift */; };
 		ECB7FDD8D0C3091EA0D42917 /* UndoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DCAF444714BC3726B212C4 /* UndoTests.swift */; };
 		ECDA4BC68D3FAE4CCF428675 /* ContactDetailView+Saving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */; };
+		F6F24513C06A755D761B5008 /* ContactStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355894A3A1D1AA4B8E238E64 /* ContactStoreError.swift */; };
 		FA63688E94483238D7C29FE9 /* DuplicateFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */; };
 		FA702A2E92FAC86D4587641B /* ContactManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDDA2A3FA3C7375D63CFC55 /* ContactManagerApp.swift */; };
 		FE0819C468F6487E3777A0B8 /* CommandPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C127145D465C7F656FDBD0B6 /* CommandPaletteTests.swift */; };
@@ -136,6 +140,7 @@
 		05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Photo.swift"; sourceTree = "<group>"; };
 		05F6260FE20C27094AFB327A /* FindContactIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FindContactIntent.swift; sourceTree = "<group>"; };
 		08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactListView.swift; sourceTree = "<group>"; };
+		0A1E9EC2BF0BB563A687FB4F /* ContentView+SavedSmartLists.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ContentView+SavedSmartLists.swift"; path = "Views/ContentView+SavedSmartLists.swift"; sourceTree = "<group>"; };
 		0B27567532AC1A51FF4CC13A /* ContactQuery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactQuery.swift; sourceTree = "<group>"; };
 		0CFA2237DBD182839EAF04F1 /* ImportReviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportReviewView.swift; sourceTree = "<group>"; };
 		0DEBEEC44A291A5ABA6C5EA4 /* CommandPalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommandPalette.swift; path = Models/CommandPalette.swift; sourceTree = "<group>"; };
@@ -154,6 +159,7 @@
 		2C83A331432D80A054D0AE94 /* ContentView+FileDialogs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+FileDialogs.swift"; sourceTree = "<group>"; };
 		2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardDocument.swift; sourceTree = "<group>"; };
 		34532FC6E64B32F9A27FCDCD /* ContactStore+QuickCapture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ContactStore+QuickCapture.swift"; path = "ContactManager/Models/ContactStore+QuickCapture.swift"; sourceTree = "<group>"; };
+		355894A3A1D1AA4B8E238E64 /* ContactStoreError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContactStoreError.swift; path = Models/ContactStoreError.swift; sourceTree = "<group>"; };
 		3628F70C39D4CE2FAA596291 /* DuplicateFinderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinderTests.swift; sourceTree = "<group>"; };
 		399A72E1BB6BEC0B54D356E7 /* ContactEntityQueryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactEntityQueryTests.swift; sourceTree = "<group>"; };
 		3AAEF99A1E41370C57D675A5 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -168,6 +174,7 @@
 		54F228309258FF5B6F85FA05 /* ContactStoreBatchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStoreBatchTests.swift; sourceTree = "<group>"; };
 		5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingTests.swift; sourceTree = "<group>"; };
 		570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Birthday.swift"; sourceTree = "<group>"; };
+		58AFEE833481781C252FE8A5 /* ContactStore+SavedSmartLists.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ContactStore+SavedSmartLists.swift"; path = "Models/ContactStore+SavedSmartLists.swift"; sourceTree = "<group>"; };
 		5951D4D8D52B6CDB782FE37D /* QuickCaptureView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickCaptureView.swift; path = ContactManager/Views/QuickCaptureView.swift; sourceTree = "<group>"; };
 		5BF65D4073AB3F28A3F52005 /* ContactStore+Backup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+Backup.swift"; sourceTree = "<group>"; };
 		604FB090CB5671DB6927238C /* SpotlightDeltaTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotlightDeltaTests.swift; sourceTree = "<group>"; };
@@ -223,6 +230,7 @@
 		C7DCAF444714BC3726B212C4 /* UndoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UndoTests.swift; sourceTree = "<group>"; };
 		C90D71F3F01E29B7C4B739A7 /* ContactStore+ImportReview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+ImportReview.swift"; sourceTree = "<group>"; };
 		C95BBAB51882751053816B2C /* ImportReviewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportReviewTests.swift; sourceTree = "<group>"; };
+		D8BAFEACBC810DF99B8FF3C6 /* ContactSavedSmartList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContactSavedSmartList.swift; path = Models/ContactSavedSmartList.swift; sourceTree = "<group>"; };
 		DB522F18FE21A503D7C480AB /* ImportReview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportReview.swift; sourceTree = "<group>"; };
 		DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactActivityTests.swift; sourceTree = "<group>"; };
 		DC69A4C348D4BBEF0D8F1330 /* PDFExportDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFExportDocument.swift; sourceTree = "<group>"; };
@@ -415,6 +423,10 @@
 				0DEBEEC44A291A5ABA6C5EA4 /* CommandPalette.swift */,
 				21D505A1E75ACB938A488465 /* CommandPaletteView.swift */,
 				70D7B4C2858A6EE928355320 /* ContentView+CommandPalette.swift */,
+				D8BAFEACBC810DF99B8FF3C6 /* ContactSavedSmartList.swift */,
+				58AFEE833481781C252FE8A5 /* ContactStore+SavedSmartLists.swift */,
+				0A1E9EC2BF0BB563A687FB4F /* ContentView+SavedSmartLists.swift */,
+				355894A3A1D1AA4B8E238E64 /* ContactStoreError.swift */,
 			);
 			path = ContactManager;
 			sourceTree = "<group>";
@@ -650,6 +662,10 @@
 				07D11DB16E18E03F9054F6EC /* CommandPalette.swift in Sources */,
 				C378A683EF56824504C580F9 /* CommandPaletteView.swift in Sources */,
 				53A6FEF15A8C7A6E9F3EDBE1 /* ContentView+CommandPalette.swift in Sources */,
+				3AC47032325005D9EABD5392 /* ContactSavedSmartList.swift in Sources */,
+				4287C737AA6235E660318237 /* ContactStore+SavedSmartLists.swift in Sources */,
+				3F4A5ABEE3FB4E56C578D00D /* ContentView+SavedSmartLists.swift in Sources */,
+				F6F24513C06A755D761B5008 /* ContactStoreError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -14,6 +14,13 @@ import SwiftUI
 struct ContactManagerApp: App {
     @Environment(\.openWindow) private var openWindow
     @State private var loadState: ContainerLoadState
+    private static let modelTypes: [any PersistentModel.Type] = [
+        Contact.self,
+        ContactField.self,
+        ContactGroup.self,
+        ContactInteraction.self,
+        ContactSavedSmartList.self,
+    ]
 
     init() {
         _loadState = State(initialValue: Self.loadContainer())
@@ -169,7 +176,7 @@ struct ContactManagerApp: App {
             deleteDefaultStore()
         }
 
-        let schema = Schema([Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self])
+        let schema = Schema(modelTypes)
 
         // UI-test mode uses an in-memory, CloudKit-disabled container so
         // tests are deterministic and can't sync sample contacts to a

--- a/ContactManager/Models/ContactQuery.swift
+++ b/ContactManager/Models/ContactQuery.swift
@@ -120,6 +120,10 @@ enum ContactQuery {
         }
     }
 
+    static func filtered(_ contacts: [Contact], by savedSmartList: ContactSavedSmartList) -> [Contact] {
+        filtered(contacts, matching: savedSmartList.query)
+    }
+
     /// Groups contacts into alphabetical sections by their initial, sorted
     /// within each section. Names that don't start with a letter land in a
     /// trailing "#" section.

--- a/ContactManager/Models/ContactSavedSmartList.swift
+++ b/ContactManager/Models/ContactSavedSmartList.swift
@@ -1,0 +1,32 @@
+//
+//  ContactSavedSmartList.swift
+//  ContactManager
+//
+//  A user-saved contact search that stays live as contacts change.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class ContactSavedSmartList {
+    var name: String = ""
+    var query: String = ""
+    var createdAt: Date = Date.now
+
+    init(name: String = "", query: String = "", createdAt: Date = .now) {
+        self.name = name
+        self.query = query
+        self.createdAt = createdAt
+    }
+}
+
+extension ContactSavedSmartList {
+    var displayName: String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedQuery.isEmpty ? "Untitled Smart List" : trimmedQuery
+    }
+}

--- a/ContactManager/Models/ContactStore+Backup.swift
+++ b/ContactManager/Models/ContactStore+Backup.swift
@@ -21,6 +21,16 @@ extension ContactStore {
                 result.groupsRestored += 1
             }
 
+            for record in backup.savedSmartLists {
+                let savedList = ContactSavedSmartList(
+                    name: record.name,
+                    query: record.query,
+                    createdAt: record.createdAt
+                )
+                context.insert(savedList)
+                result.savedSmartListsRestored += 1
+            }
+
             for record in backup.contacts {
                 let contact = Contact(record)
                 contact.photoData = record.photoData
@@ -81,6 +91,7 @@ private extension Contact {
 struct BackupRestoreResult {
     var contactsRestored = 0
     var groupsRestored = 0
+    var savedSmartListsRestored = 0
     var interactionsRestored = 0
 
     var title: String {
@@ -92,10 +103,11 @@ struct BackupRestoreResult {
         let parts = [
             count(contactsRestored, label: "contacts"),
             count(groupsRestored, label: "groups"),
+            count(savedSmartListsRestored, label: "smart lists"),
             count(interactionsRestored, label: "history notes"),
         ].compactMap(\.self)
         if parts.isEmpty {
-            return "No contacts, groups, or history notes restored."
+            return "No contacts, groups, smart lists, or history notes restored."
         }
         return parts.joined(separator: ", ").capitalizedIfFirst + "."
     }

--- a/ContactManager/Models/ContactStore+SavedSmartLists.swift
+++ b/ContactManager/Models/ContactStore+SavedSmartLists.swift
@@ -1,0 +1,37 @@
+//
+//  ContactStore+SavedSmartLists.swift
+//  ContactManager
+//
+//  Durable mutations for user-saved contact searches.
+//
+
+import Foundation
+
+extension ContactStore {
+    @discardableResult
+    func createSavedSmartList(named name: String? = nil, query: String) throws -> ContactSavedSmartList {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty else { throw ContactStoreError.blankSavedSmartListQuery }
+
+        let trimmedName = (name ?? trimmedQuery).trimmingCharacters(in: .whitespacesAndNewlines)
+        return try mutate("New Smart List") {
+            let savedList = ContactSavedSmartList(name: trimmedName, query: trimmedQuery)
+            context.insert(savedList)
+            return savedList
+        }
+    }
+
+    func rename(_ savedList: ContactSavedSmartList, to name: String) throws {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        try mutate("Rename Smart List") {
+            savedList.name = trimmed
+        }
+    }
+
+    func delete(_ savedList: ContactSavedSmartList) throws {
+        try mutate("Delete Smart List") {
+            context.delete(savedList)
+        }
+    }
+}

--- a/ContactManager/Models/ContactStore.swift
+++ b/ContactManager/Models/ContactStore.swift
@@ -387,13 +387,3 @@ struct PendingContactChange {
         return ContactChange(updatedIDs: updatedIDs, deletedIDs: deletedIDs)
     }
 }
-
-enum ContactStoreError: LocalizedError {
-    case nothingToMerge
-
-    var errorDescription: String? {
-        switch self {
-        case .nothingToMerge: "There were no contacts to merge."
-        }
-    }
-}

--- a/ContactManager/Models/ContactStoreError.swift
+++ b/ContactManager/Models/ContactStoreError.swift
@@ -1,0 +1,20 @@
+//
+//  ContactStoreError.swift
+//  ContactManager
+//
+//  User-facing errors thrown by ContactStore mutations.
+//
+
+import Foundation
+
+enum ContactStoreError: LocalizedError {
+    case blankSavedSmartListQuery
+    case nothingToMerge
+
+    var errorDescription: String? {
+        switch self {
+        case .blankSavedSmartListQuery: "Enter a search before saving it as a smart list."
+        case .nothingToMerge: "There were no contacts to merge."
+        }
+    }
+}

--- a/ContactManager/Support/ContactBackup.swift
+++ b/ContactManager/Support/ContactBackup.swift
@@ -9,28 +9,32 @@ import Foundation
 import SwiftData
 
 struct ContactBackup: Codable, Equatable {
-    static let currentVersion = 1
+    static let currentVersion = 2
 
     var version: Int
     var exportedAt: Date
     var groups: [GroupRecord]
+    var savedSmartLists: [SavedSmartListRecord]
     var contacts: [ContactRecord]
 
     init(
         version: Int = Self.currentVersion,
         exportedAt: Date = .now,
         groups: [GroupRecord] = [],
+        savedSmartLists: [SavedSmartListRecord] = [],
         contacts: [ContactRecord] = []
     ) {
         self.version = version
         self.exportedAt = exportedAt
         self.groups = groups
+        self.savedSmartLists = savedSmartLists
         self.contacts = contacts
     }
 
     static func make(
         contacts: [Contact],
         groups: [ContactGroup],
+        savedSmartLists: [ContactSavedSmartList] = [],
         exportedAt: Date = .now
     ) -> ContactBackup {
         let groupIDs = Dictionary(uniqueKeysWithValues: groups.map { group in
@@ -44,6 +48,12 @@ struct ContactBackup: Codable, Equatable {
                     return lhs.createdAt < rhs.createdAt
                 }
                 .map { GroupRecord(id: backupID(for: $0), name: $0.name, createdAt: $0.createdAt) },
+            savedSmartLists: savedSmartLists
+                .sorted { lhs, rhs in
+                    if lhs.displayName != rhs.displayName { return lhs.displayName < rhs.displayName }
+                    return lhs.createdAt < rhs.createdAt
+                }
+                .map { SavedSmartListRecord(name: $0.name, query: $0.query, createdAt: $0.createdAt) },
             contacts: ContactQuery.sorted(contacts).map { contact in
                 ContactRecord(contact: contact, groupIDs: groupIDs)
             }
@@ -53,12 +63,35 @@ struct ContactBackup: Codable, Equatable {
     private static func backupID(for group: ContactGroup) -> String {
         group.persistentModelID.storedString ?? String(describing: group.persistentModelID)
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case exportedAt
+        case groups
+        case savedSmartLists
+        case contacts
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decode(Int.self, forKey: .version)
+        exportedAt = try container.decode(Date.self, forKey: .exportedAt)
+        groups = try container.decode([GroupRecord].self, forKey: .groups)
+        savedSmartLists = try container.decodeIfPresent([SavedSmartListRecord].self, forKey: .savedSmartLists) ?? []
+        contacts = try container.decode([ContactRecord].self, forKey: .contacts)
+    }
 }
 
 extension ContactBackup {
     struct GroupRecord: Codable, Equatable, Identifiable {
         var id: String
         var name: String
+        var createdAt: Date
+    }
+
+    struct SavedSmartListRecord: Codable, Equatable {
+        var name: String
+        var query: String
         var createdAt: Date
     }
 

--- a/ContactManager/Support/ContactBackupPreview.swift
+++ b/ContactManager/Support/ContactBackupPreview.swift
@@ -11,6 +11,7 @@ struct ContactBackupPreview: Equatable {
     var exportedAt: Date
     var contactCount: Int
     var groupCount: Int
+    var savedSmartListCount: Int
     var emailCount: Int
     var phoneCount: Int
     var historyNoteCount: Int
@@ -18,13 +19,14 @@ struct ContactBackupPreview: Equatable {
     var sampleContactNames: [String]
 
     var isEmpty: Bool {
-        contactCount == 0 && groupCount == 0 && historyNoteCount == 0
+        contactCount == 0 && groupCount == 0 && savedSmartListCount == 0 && historyNoteCount == 0
     }
 
     init(backup: ContactBackup) {
         exportedAt = backup.exportedAt
         contactCount = backup.contacts.count
         groupCount = backup.groups.count
+        savedSmartListCount = backup.savedSmartLists.count
         emailCount = backup.contacts.flatMap(\.fields).filter { $0.kind == .email }.count
         phoneCount = backup.contacts.flatMap(\.fields).filter { $0.kind == .phone }.count
         historyNoteCount = backup.contacts.flatMap(\.interactions).count
@@ -39,6 +41,7 @@ struct ContactBackupPreview: Equatable {
         let parts = [
             count(contactCount, singular: "contact"),
             count(groupCount, singular: "group"),
+            count(savedSmartListCount, singular: "smart list"),
             count(emailCount, singular: "email"),
             count(phoneCount, singular: "phone"),
             count(historyNoteCount, singular: "history note"),

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -21,6 +21,7 @@ struct ContactListView: View {
     let groups: [ContactGroup]
     var addContact: () -> Void
     var deleteContact: (Contact) -> Void
+    var saveCurrentSearch: () -> Void
     var exportSelectedContacts: () -> Void
     var addSelectedContactsToGroup: (ContactGroup) -> Void
     var deleteSelectedContacts: () -> Void
@@ -103,6 +104,13 @@ struct ContactListView: View {
                     Label("Sort", systemImage: "arrow.up.arrow.down")
                 }
                 .help("Sort Order")
+
+                Button(action: saveCurrentSearch) {
+                    Label("Save Search", systemImage: "line.3.horizontal.decrease.circle")
+                }
+                .disabled(searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .help("Save Search")
+                .accessibilityIdentifier("save-search-button")
 
                 Menu {
                     Button("Export vCard…", action: exportSelectedContacts)

--- a/ContactManager/Views/ContentView+Backup.swift
+++ b/ContactManager/Views/ContentView+Backup.swift
@@ -9,13 +9,17 @@ import Foundation
 
 extension ContentView {
     func exportBackup() {
-        backupDocument = ContactBackupDocument(backup: ContactBackup.make(contacts: contacts, groups: groups))
+        backupDocument = ContactBackupDocument(backup: ContactBackup.make(
+            contacts: contacts,
+            groups: groups,
+            savedSmartLists: savedSmartLists
+        ))
         isExportingBackup = true
     }
 
     func exportEncryptedBackup(password: String) -> Bool {
         do {
-            let backup = ContactBackup.make(contacts: contacts, groups: groups)
+            let backup = ContactBackup.make(contacts: contacts, groups: groups, savedSmartLists: savedSmartLists)
             let data = try EncryptedContactBackupDocument.encode(backup, password: password)
             encryptedBackupDocument = EncryptedContactBackupDocument(data: data)
             isPreparingEncryptedBackup = false

--- a/ContactManager/Views/ContentView+CommandPalette.swift
+++ b/ContactManager/Views/ContentView+CommandPalette.swift
@@ -168,6 +168,18 @@ extension ContentView {
             }
         })
 
+        entries.append(contentsOf: savedSmartLists.map { savedList in
+            command(
+                id: "nav-saved-smart-\(savedList.persistentModelID.storedString ?? savedList.displayName)",
+                title: savedList.displayName,
+                subtitle: "Open saved smart list",
+                keywords: ["navigate", "filter", savedList.query],
+                systemImage: "line.3.horizontal.decrease.circle"
+            ) {
+                sidebarSelection = .savedSmartList(savedList.persistentModelID)
+            }
+        })
+
         entries.append(contentsOf: groups.map { group in
             command(
                 id: "nav-group-\(group.persistentModelID.storedString ?? group.displayName)",

--- a/ContactManager/Views/ContentView+SavedSmartLists.swift
+++ b/ContactManager/Views/ContentView+SavedSmartLists.swift
@@ -1,0 +1,51 @@
+//
+//  ContentView+SavedSmartLists.swift
+//  ContactManager
+//
+//  Saved-search selection and mutation actions.
+//
+
+import SwiftData
+import SwiftUI
+
+extension ContentView {
+    var selectedSavedSmartList: ContactSavedSmartList? {
+        guard case .savedSmartList(let id) = sidebarSelection else { return nil }
+        return savedSmartLists.first { $0.persistentModelID == id }
+    }
+
+    var savedSmartListCounts: [PersistentIdentifier: Int] {
+        Dictionary(uniqueKeysWithValues: savedSmartLists.map { savedList in
+            (savedList.persistentModelID, ContactQuery.filtered(contacts, by: savedList).count)
+        })
+    }
+
+    func saveCurrentSearchAsSmartList() {
+        do {
+            let savedList = try store.createSavedSmartList(query: searchText)
+            withAnimation(reduceMotion ? nil : .snappy) {
+                sidebarSelection = .savedSmartList(savedList.persistentModelID)
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func renameSavedSmartList(_ savedList: ContactSavedSmartList, to name: String) {
+        do {
+            try store.rename(savedList, to: name)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func deleteSavedSmartList(_ savedList: ContactSavedSmartList) {
+        let wasSelected = sidebarSelection == .savedSmartList(savedList.persistentModelID)
+        do {
+            try store.delete(savedList)
+            if wasSelected { sidebarSelection = .allContacts }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -14,13 +14,15 @@ import SwiftUI
 struct ContentView: View {
     @Environment(\.modelContext) private var context
     @Environment(\.undoManager) private var undoManager
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceMotion) var reduceMotion
     @Environment(\.openWindow) var openWindow
 
     @Query(sort: [SortDescriptor(\Contact.lastName), SortDescriptor(\Contact.firstName)])
     var contacts: [Contact]
 
     @Query(sort: \ContactGroup.name) var groups: [ContactGroup]
+
+    @Query(sort: \ContactSavedSmartList.createdAt) var savedSmartLists: [ContactSavedSmartList]
 
     @State var sidebarSelection: SidebarItem? = .allContacts
     @State var selectedContact: Contact?
@@ -32,7 +34,7 @@ struct ContentView: View {
     @State var commandPaletteQuery = ""
     @State var pendingCommandPaletteAction: (() -> Void)?
     @State var importProgress: ImportProgress?
-    @State private var searchText = ""
+    @State var searchText = ""
     @State private var debouncedSearchText = ""
     @AppStorage("contactSortOrder") private var sortOrder: ContactSortOrder = .lastName
     @AppStorage("defaultGroupID") private var defaultGroupID: String = ""
@@ -90,25 +92,27 @@ struct ContentView: View {
     private var groupForNewContact: ContactGroup? {
         switch sidebarSelection {
         case .group: selectedGroup
-        case .allContacts, .smartList, .none: defaultGroup
+        case .allContacts, .smartList, .savedSmartList, .none: defaultGroup
         }
     }
 
     private var scopedContacts: [Contact] {
         if let selectedGroup { return selectedGroup.contacts }
         if let selectedSmartList { return ContactQuery.filtered(contacts, by: selectedSmartList) }
+        if let selectedSavedSmartList { return ContactQuery.filtered(contacts, by: selectedSavedSmartList) }
         return contacts
     }
 
     private var listTitle: String {
         if let selectedGroup { return selectedGroup.displayName }
         if let selectedSmartList { return selectedSmartList.title }
+        if let selectedSavedSmartList { return selectedSavedSmartList.displayName }
         return "Contacts"
     }
 
     private var emptyListTitle: String {
         if selectedGroup != nil { return "No Contacts in Group" }
-        if selectedSmartList != nil { return "No Contacts Match" }
+        if selectedSmartList != nil || selectedSavedSmartList != nil { return "No Contacts Match" }
         return "No Contacts"
     }
 
@@ -149,8 +153,12 @@ struct ContentView: View {
                 selection: $sidebarSelection,
                 contactCount: contacts.count,
                 smartListCounts: smartListCounts,
+                savedSmartLists: savedSmartLists,
+                savedSmartListCounts: savedSmartListCounts,
                 groups: groups,
                 addGroup: addGroup,
+                renameSavedSmartList: renameSavedSmartList,
+                deleteSavedSmartList: deleteSavedSmartList,
                 renameGroup: renameGroup,
                 deleteGroup: deleteGroup,
                 addContacts: addContacts(encodedIDs:to:)
@@ -168,6 +176,7 @@ struct ContentView: View {
                 groups: groups,
                 addContact: addContact,
                 deleteContact: deleteContact,
+                saveCurrentSearch: saveCurrentSearchAsSmartList,
                 exportSelectedContacts: exportSelectedContactsAsVCard,
                 addSelectedContactsToGroup: addSelectedContacts(to:),
                 deleteSelectedContacts: requestDeleteSelectedContacts,
@@ -207,7 +216,7 @@ struct ContentView: View {
     func addContact() {
         do {
             let contact = try store.createContact(in: groupForNewContact)
-            if selectedSmartList != nil { sidebarSelection = .allContacts }
+            if selectedSmartList != nil || selectedSavedSmartList != nil { sidebarSelection = .allContacts }
             contactPendingNameFocus = contact.persistentModelID
             selectedContactIDs = [contact.persistentModelID]
             withAnimation(reduceMotion ? nil : .snappy) { selectedContact = contact }
@@ -370,6 +379,6 @@ private extension ContentView {
 #Preview {
     ContentView()
         .modelContainer(for: [
-            Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self, ContactSavedSmartList.self,
         ], inMemory: true)
 }

--- a/ContactManager/Views/RestoreBackupPreviewView.swift
+++ b/ContactManager/Views/RestoreBackupPreviewView.swift
@@ -20,6 +20,7 @@ struct RestoreBackupPreviewView: View {
                     labeledRow("Summary", value: preview.summary)
                     labeledRow("Contacts", value: "\(preview.contactCount)")
                     labeledRow("Groups", value: "\(preview.groupCount)")
+                    labeledRow("Smart Lists", value: "\(preview.savedSmartListCount)")
                     labeledRow("Emails", value: "\(preview.emailCount)")
                     labeledRow("Phones", value: "\(preview.phoneCount)")
                     labeledRow("History Notes", value: "\(preview.historyNoteCount)")

--- a/ContactManager/Views/SidebarView.swift
+++ b/ContactManager/Views/SidebarView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 enum SidebarItem: Hashable {
     case allContacts
     case smartList(ContactSmartList)
+    case savedSmartList(PersistentIdentifier)
     case group(PersistentIdentifier)
 }
 
@@ -21,14 +22,19 @@ struct SidebarView: View {
     @Binding var selection: SidebarItem?
     let contactCount: Int
     let smartListCounts: [ContactSmartList: Int]
+    let savedSmartLists: [ContactSavedSmartList]
+    let savedSmartListCounts: [PersistentIdentifier: Int]
     let groups: [ContactGroup]
     var addGroup: () -> Void
+    var renameSavedSmartList: (ContactSavedSmartList, String) -> Void
+    var deleteSavedSmartList: (ContactSavedSmartList) -> Void
     var renameGroup: (ContactGroup, String) -> Void
     var deleteGroup: (ContactGroup) -> Void
     /// Adds the dropped contacts (by encoded id) to a group — sidebar drag target.
     var addContacts: ([String], ContactGroup) -> Void
 
     @State private var renameTarget: ContactGroup?
+    @State private var renameSavedSmartListTarget: ContactSavedSmartList?
     @State private var renameText = ""
 
     var body: some View {
@@ -46,6 +52,19 @@ struct SidebarView: View {
                         .badge(smartListCounts[smartList] ?? 0)
                         .tag(SidebarItem.smartList(smartList))
                         .accessibilityIdentifier("sidebar-smart-list-row-\(smartList.rawValue)")
+                }
+
+                ForEach(savedSmartLists) { savedList in
+                    Label(savedList.displayName, systemImage: "line.3.horizontal.decrease.circle")
+                        .badge(savedSmartListCounts[savedList.persistentModelID] ?? 0)
+                        .tag(SidebarItem.savedSmartList(savedList.persistentModelID))
+                        .accessibilityIdentifier(
+                            "sidebar-saved-smart-list-row-\(savedList.displayName.normalizedIdentifier)"
+                        )
+                        .contextMenu {
+                            Button("Rename…") { beginRename(savedList) }
+                            Button("Delete", role: .destructive) { deleteSavedSmartList(savedList) }
+                        }
                 }
             }
 
@@ -120,11 +139,29 @@ struct SidebarView: View {
                 renameTarget = nil
             }
         }
+        .alert("Rename Smart List", isPresented: Binding(
+            get: { renameSavedSmartListTarget != nil },
+            set: { if !$0 { renameSavedSmartListTarget = nil } }
+        )) {
+            TextField("Name", text: $renameText)
+            Button("Cancel", role: .cancel) { renameSavedSmartListTarget = nil }
+            Button("Rename") {
+                if let target = renameSavedSmartListTarget {
+                    renameSavedSmartList(target, renameText)
+                }
+                renameSavedSmartListTarget = nil
+            }
+        }
     }
 
     private func beginRename(_ group: ContactGroup) {
         renameText = group.name
         renameTarget = group
+    }
+
+    private func beginRename(_ savedList: ContactSavedSmartList) {
+        renameText = savedList.displayName
+        renameSavedSmartListTarget = savedList
     }
 }
 

--- a/ContactManagerTests/ContactBackupTests.swift
+++ b/ContactManagerTests/ContactBackupTests.swift
@@ -20,6 +20,7 @@ struct ContactBackupTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactSavedSmartList.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)
@@ -33,14 +34,20 @@ struct ContactBackupTests {
         try context.fetch(FetchDescriptor<ContactGroup>())
     }
 
+    private func allSavedSmartLists() throws -> [ContactSavedSmartList] {
+        try context.fetch(FetchDescriptor<ContactSavedSmartList>())
+    }
+
     @Test func backupCapturesContactsGroupsFieldsAndHistory() throws {
         let contact = try makePopulatedContact()
+        let savedList = try store.createSavedSmartList(named: "Engine People", query: "engine")
         let contacts = try allContacts()
         let groups = try allGroups()
 
         let backup = ContactBackup.make(
             contacts: contacts,
             groups: groups,
+            savedSmartLists: [savedList],
             exportedAt: Date(timeIntervalSinceReferenceDate: 42)
         )
 
@@ -52,36 +59,47 @@ struct ContactBackupTests {
         #expect(record.interactions.map(\.summary) == ["Met at WWDC."])
         #expect(record.lastContactedAt == contact.lastContactedAt)
         #expect(backup.groups.map(\.name) == ["Work"])
+        #expect(backup.savedSmartLists.map(\.name) == ["Engine People"])
+        #expect(backup.savedSmartLists.map(\.query) == ["engine"])
     }
 
     @Test func restoreBackupRecreatesContactsGroupsFieldsAndHistory() throws {
         let contact = try makePopulatedContact()
+        let savedList = try store.createSavedSmartList(named: "Engine People", query: "engine")
         let groups = try allGroups()
         let original = ContactBackup.make(
             contacts: [contact],
             groups: groups,
+            savedSmartLists: [savedList],
             exportedAt: Date(timeIntervalSinceReferenceDate: 42)
         )
 
         let contactsBeforeRestore = try allContacts()
         let groupsBeforeRestore = try allGroups()
+        let savedListsBeforeRestore = try allSavedSmartLists()
         let contactBeforeRestore = try #require(contactsBeforeRestore.first)
         let groupBeforeRestore = try #require(groupsBeforeRestore.first)
+        let savedListBeforeRestore = try #require(savedListsBeforeRestore.first)
         try store.delete(contactBeforeRestore)
         try store.delete(groupBeforeRestore)
+        try store.delete(savedListBeforeRestore)
 
         let result = try store.restoreBackup(original)
 
         let restoredContacts = try allContacts()
+        let restoredSavedLists = try allSavedSmartLists()
         let restored = try #require(restoredContacts.first)
         #expect(result.contactsRestored == 1)
         #expect(result.groupsRestored == 1)
+        #expect(result.savedSmartListsRestored == 1)
         #expect(result.interactionsRestored == 1)
         #expect(restored.fullName == "Ada Lovelace")
         #expect(restored.lastContactedAt == Date(timeIntervalSinceReferenceDate: 200))
         #expect(restored.emails.map(\.value) == ["ada@example.com"])
         #expect(restored.groups.map(\.displayName) == ["Work"])
         #expect(restored.sortedInteractions.map(\.summary) == ["Met at WWDC."])
+        #expect(restoredSavedLists.map(\.displayName) == ["Engine People"])
+        #expect(restoredSavedLists.map(\.query) == ["engine"])
     }
 
     @Test func backupDocumentRoundTripsJSON() throws {
@@ -97,6 +115,22 @@ struct ContactBackupTests {
         let decoded = try ContactBackupDocument.decode(data)
 
         #expect(decoded == backup)
+    }
+
+    @Test func backupDocumentDecodesLegacyBackupsWithoutSavedSmartLists() throws {
+        let legacyJSON = """
+        {
+          "contacts" : [],
+          "exportedAt" : 42,
+          "groups" : [],
+          "version" : 1
+        }
+        """
+
+        let decoded = try ContactBackupDocument.decode(Data(legacyJSON.utf8))
+
+        #expect(decoded.version == 1)
+        #expect(decoded.savedSmartLists.isEmpty)
     }
 
     @Test func encryptedBackupDocumentRoundTripsWithPassword() throws {
@@ -136,15 +170,17 @@ struct ContactBackupTests {
 
         #expect(result.contactsRestored == 0)
         #expect(result.title == "Restored 0 Contacts")
-        #expect(result.message == "No contacts, groups, or history notes restored.")
+        #expect(result.message == "No contacts, groups, smart lists, or history notes restored.")
     }
 
     @Test func backupPreviewSummarizesContentsBeforeRestore() throws {
         let contact = try makePopulatedContact()
+        let savedList = try store.createSavedSmartList(named: "Engine People", query: "engine")
         let groups = try allGroups()
         let backup = ContactBackup.make(
             contacts: [contact],
             groups: groups,
+            savedSmartLists: [savedList],
             exportedAt: Date(timeIntervalSinceReferenceDate: 42)
         )
 
@@ -153,12 +189,13 @@ struct ContactBackupTests {
         #expect(preview.exportedAt == Date(timeIntervalSinceReferenceDate: 42))
         #expect(preview.contactCount == 1)
         #expect(preview.groupCount == 1)
+        #expect(preview.savedSmartListCount == 1)
         #expect(preview.emailCount == 1)
         #expect(preview.phoneCount == 0)
         #expect(preview.historyNoteCount == 1)
         #expect(preview.photoCount == 1)
         #expect(preview.sampleContactNames == ["Ada Lovelace"])
-        #expect(preview.summary == "1 contact, 1 group, 1 email, 1 history note, 1 photo")
+        #expect(preview.summary == "1 contact, 1 group, 1 smart list, 1 email, 1 history note, 1 photo")
     }
 
     @Test func emptyBackupPreviewHasAPlainSummary() {
@@ -166,6 +203,7 @@ struct ContactBackupTests {
 
         #expect(preview.contactCount == 0)
         #expect(preview.groupCount == 0)
+        #expect(preview.savedSmartListCount == 0)
         #expect(preview.isEmpty)
         #expect(preview.sampleContactNames.isEmpty)
         #expect(preview.summary == "0 contacts")

--- a/ContactManagerTests/ContactModelTests.swift
+++ b/ContactManagerTests/ContactModelTests.swift
@@ -22,6 +22,7 @@ struct ContactModelTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactSavedSmartList.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
     }
@@ -257,6 +258,17 @@ struct ContactModelTests {
         #expect(recentNames == ["Recent"])
         #expect(followUpNames == ["Old", "No Email"])
         #expect(noEmailNames == ["No Email"])
+    }
+
+    @Test func savedSmartListsFilterBySavedQuery() {
+        let savedList = ContactSavedSmartList(name: "Engine People", query: "engine")
+        let ada = Contact(firstName: "Ada", lastName: "Lovelace", company: "Analytical Engine")
+        let alan = Contact(firstName: "Alan", lastName: "Turing", notes: "Enigma")
+        let contacts = [ada, alan]
+
+        let matches = ContactQuery.filtered(contacts, by: savedList)
+
+        #expect(matches.map(\.firstName) == ["Ada"])
     }
 
     @Test func birthdaysSoonIgnoresStoredYearAndWrapsAcrossYearEnd() throws {

--- a/ContactManagerTests/ContactStoreTests.swift
+++ b/ContactManagerTests/ContactStoreTests.swift
@@ -24,6 +24,7 @@ struct ContactStoreTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactSavedSmartList.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)
@@ -116,6 +117,20 @@ struct ContactStoreTests {
         let group = try store.createGroup(named: "Work")
         try store.rename(group, to: "   ")
         #expect(group.name == "Work")
+    }
+
+    @Test func savedSmartListLifecycleTrimsQueryAndName() throws {
+        let savedList = try store.createSavedSmartList(named: "  Engine People  ", query: "  engine  ")
+
+        #expect(savedList.displayName == "Engine People")
+        #expect(savedList.query == "engine")
+        #expect(try count(ContactSavedSmartList.self) == 1)
+
+        try store.rename(savedList, to: "  Machines  ")
+        #expect(savedList.displayName == "Machines")
+
+        try store.delete(savedList)
+        #expect(try count(ContactSavedSmartList.self) == 0)
     }
 
     // MARK: - Journey: set and clear a contact photo

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -150,6 +150,18 @@ final class ContactManagerUITests: XCTestCase {
         let historyNote = app.descendants(matching: .any)["interaction-summary-field"]
         XCTAssertTrue(historyNote.waitForExistence(timeout: 3))
         XCTAssertTrue(app.buttons["add-interaction-button"].exists)
+
+        app.typeKey("f", modifierFlags: .command)
+        let search = app.searchFields.firstMatch
+        XCTAssertTrue(search.waitForExistence(timeout: 3))
+        search.typeText("Ada")
+        let saveSearch = app.buttons["save-search-button"]
+        XCTAssertTrue(saveSearch.waitForExistence(timeout: 3))
+        saveSearch.click()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["sidebar-saved-smart-list-row-ada"].waitForExistence(timeout: 3),
+            "Saving a search should add a saved smart-list row"
+        )
     }
 
     /// Verifies the quick-capture command opens a focused capture window and


### PR DESCRIPTION
## Summary
Add persisted saved smart lists backed by saved contact searches.

## Changes
- Added a SwiftData ContactSavedSmartList model with live query filtering.
- Added ContactStore create, rename, and delete mutations for saved smart lists.
- Added saved smart-list rows to the sidebar with counts, rename, and delete.
- Added a Save Search toolbar action and command-palette navigation for saved lists.
- Included saved smart lists in plain/encrypted backup export, restore, and restore preview.
- Preserved legacy backup decode compatibility when savedSmartLists is absent.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - make check
  - xcodebuild -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test -only-testing:ContactManagerUITests/ContactManagerUITests/test_smartListsAndMarkContactedControlsRender
  - make test

## Screenshots (if applicable)
N/A

## Related Issues
Closes #