### PR TITLE
feat(tags): add contact tag organization

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0A1D00F612A8791B57B987DC /* QuickCaptureContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3EAA857954C42954E651035 /* QuickCaptureContactIntent.swift */; };
 		0ABBB9962C4AC14A077728FF /* ContactStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03763AB80D45F026EC585490 /* ContactStoreTests.swift */; };
 		0DC8E4BAF454185075119C3A /* ContactStorePendingEditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438C2B20E1C302676594ECCA /* ContactStorePendingEditTests.swift */; };
+		0DDC7707A54114378AB0E1E0 /* ContentView+Tags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0C70519C31EA3869BCECA9 /* ContentView+Tags.swift */; };
 		134F890B4875E8BF294A92B2 /* ContactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617D7B082A403094284FBD38 /* ContactStore.swift */; };
 		14C13B18A26BC44F834915C1 /* ContactModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75D02267D3BC6C014143329 /* ContactModelTests.swift */; };
 		14E0C9EBEF8212F3F9B2777D /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51E6728EF90B1D2BF8EA5AE /* Contact.swift */; };
@@ -45,7 +46,9 @@
 		4748DC4114188B76B5384A8D /* ContactInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9116FC0A7E009E9A806FD48F /* ContactInteraction.swift */; };
 		488CA0C339AD3218073A02E8 /* PrintableContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37DB6CC43A76261CFF3987D /* PrintableContactView.swift */; };
 		48DA73BF161A4ABB5DBE4291 /* QuickCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D7E9FD22709F6D14A87952 /* QuickCapture.swift */; };
+		49951835ECDD188314B2D263 /* ContentView+Groups.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0B4A31EACECB0C22183364 /* ContentView+Groups.swift */; };
 		4B9EAE3500BB10401AEB3746 /* ContactActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CF4C47C670B0A8C3B6B384 /* ContactActivity.swift */; };
+		4DE6F60A4362DB82F555AC90 /* ContactTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EDCC384329D463787C71CEC /* ContactTag.swift */; };
 		4EC36757044377406665E53B /* ContactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E2EBA5EFDEE6888B84E10B /* ContactListView.swift */; };
 		4F1E1A097740ECE3D42E55B8 /* GroupDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964ACD67CC8CB35694497A10 /* GroupDropTests.swift */; };
 		509C184B6FC5C331FCC6FD11 /* ImportReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB522F18FE21A503D7C480AB /* ImportReview.swift */; };
@@ -54,6 +57,7 @@
 		552E226D873AE11781A7F97A /* ContactDetailView+Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CB65D95AFA14C691F0D8C4 /* ContactDetailView+Photo.swift */; };
 		566DF0F6FE6E104AEE7C5302 /* ContactStoreBatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F228309258FF5B6F85FA05 /* ContactStoreBatchTests.swift */; };
 		5FCE54BC89E39D68DE29B360 /* CloudSyncStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE92D38DACB5637AF0E693F /* CloudSyncStatusTests.swift */; };
+		6050F08D99E245F781379499 /* ContactSavedSmartListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10191E5E98799FCA693D661 /* ContactSavedSmartListTests.swift */; };
 		61F22EEDEE6075BD602203D5 /* VCardDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */; };
 		623A5F4AE958EAD5C2757F83 /* CSVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAA25CCEE01127AA64D21D6 /* CSVTests.swift */; };
 		63274FB1580421240D8EB57B /* ContactEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C12246003379D5966F0210 /* ContactEntityTests.swift */; };
@@ -97,10 +101,12 @@
 		AD6426F91D871AE7E1F57251 /* ContactDetailView+QuickInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0DCB1419D1BD49893F8AD /* ContactDetailView+QuickInfo.swift */; };
 		AF36C8E991E2B6C96634FBA0 /* ChunkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30CD9D085E7424A79159879 /* ChunkingTests.swift */; };
 		B1393B1344A7D64B52C4B3D4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9795992CBF553603FD37928 /* SettingsView.swift */; };
+		B7BFE97538D99B970A512F5D /* ContactStore+Tags.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26E7A88DB9D18716C78E4D2 /* ContactStore+Tags.swift */; };
 		BA9738D0812FB7A090DD5D4E /* ContactEntityQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399A72E1BB6BEC0B54D356E7 /* ContactEntityQueryTests.swift */; };
 		BBD79E7FD90E021417B527A9 /* FindContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F6260FE20C27094AFB327A /* FindContactIntent.swift */; };
 		BC3D0CE8272648D0ACEF0C46 /* BirthdayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B040B21B7E2002E00885A9BA /* BirthdayTests.swift */; };
 		C2A11D686722C70868435ACE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303A7F66E428BF3662142C0 /* SidebarView.swift */; };
+		C2EA90DF3685BA76CCFA2C7E /* ContactTagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BEACB78914327E09F4DA17E /* ContactTagTests.swift */; };
 		C378A683EF56824504C580F9 /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D505A1E75ACB938A488465 /* CommandPaletteView.swift */; };
 		CB3B48ECF52D91DC9B4789D7 /* ContactStore+Batch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C169D757A0DE2A58EEC0A32B /* ContactStore+Batch.swift */; };
 		CD70772ECD6A854C66159FFD /* OpenContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B27494A51645ACA6BED8EA8 /* OpenContactIntent.swift */; };
@@ -156,6 +162,8 @@
 		10E7338673D65A6FAB4F9AF3 /* ContactManagerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContactManagerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		114AC8779AF104227C34C18C /* ContactIntentResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactIntentResolver.swift; sourceTree = "<group>"; };
 		1BAB4A7BC31774A5B67A38DC /* SpotlightIndexer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotlightIndexer.swift; sourceTree = "<group>"; };
+		1E0C70519C31EA3869BCECA9 /* ContentView+Tags.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+Tags.swift"; sourceTree = "<group>"; };
+		1EDCC384329D463787C71CEC /* ContactTag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactTag.swift; sourceTree = "<group>"; };
 		21D505A1E75ACB938A488465 /* CommandPaletteView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommandPaletteView.swift; path = Views/CommandPaletteView.swift; sourceTree = "<group>"; };
 		2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactsBridge.swift; sourceTree = "<group>"; };
 		25B2B9B4E62C9BAA67FB718B /* ContactBackupPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactBackupPreview.swift; sourceTree = "<group>"; };
@@ -163,6 +171,7 @@
 		279FCAC10E829D7DAC9D8385 /* OpenContactIntentTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenContactIntentTests.swift; sourceTree = "<group>"; };
 		29335D93B2E97B9038F1481A /* ImportProgressView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportProgressView.swift; sourceTree = "<group>"; };
 		2A7B150B6DB35B8EF10D2135 /* AvatarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
+		2BEACB78914327E09F4DA17E /* ContactTagTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactTagTests.swift; sourceTree = "<group>"; };
 		2C83A331432D80A054D0AE94 /* ContentView+FileDialogs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+FileDialogs.swift"; sourceTree = "<group>"; };
 		2D13D7A4D4AF6172FA6E89AB /* VCardDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardDocument.swift; sourceTree = "<group>"; };
 		34532FC6E64B32F9A27FCDCD /* ContactStore+QuickCapture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ContactStore+QuickCapture.swift"; path = "ContactManager/Models/ContactStore+QuickCapture.swift"; sourceTree = "<group>"; };
@@ -240,6 +249,7 @@
 		C7DCAF444714BC3726B212C4 /* UndoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UndoTests.swift; sourceTree = "<group>"; };
 		C90D71F3F01E29B7C4B739A7 /* ContactStore+ImportReview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+ImportReview.swift"; sourceTree = "<group>"; };
 		C95BBAB51882751053816B2C /* ImportReviewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportReviewTests.swift; sourceTree = "<group>"; };
+		CC0B4A31EACECB0C22183364 /* ContentView+Groups.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+Groups.swift"; sourceTree = "<group>"; };
 		D8BAFEACBC810DF99B8FF3C6 /* ContactSavedSmartList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContactSavedSmartList.swift; path = Models/ContactSavedSmartList.swift; sourceTree = "<group>"; };
 		DB522F18FE21A503D7C480AB /* ImportReview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportReview.swift; sourceTree = "<group>"; };
 		DC3E51B04D43E299C787B243 /* ContactActivityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactActivityTests.swift; sourceTree = "<group>"; };
@@ -252,6 +262,8 @@
 		E3EAA857954C42954E651035 /* QuickCaptureContactIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickCaptureContactIntent.swift; sourceTree = "<group>"; };
 		E788AA97AF3C5715FA19FE5B /* DuplicateFinder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicateFinder.swift; sourceTree = "<group>"; };
 		EBDDA2A3FA3C7375D63CFC55 /* ContactManagerApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactManagerApp.swift; sourceTree = "<group>"; };
+		F10191E5E98799FCA693D661 /* ContactSavedSmartListTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactSavedSmartListTests.swift; sourceTree = "<group>"; };
+		F26E7A88DB9D18716C78E4D2 /* ContactStore+Tags.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactStore+Tags.swift"; sourceTree = "<group>"; };
 		F29DA4C4F45023F1A68A90E3 /* CreateContactIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CreateContactIntent.swift; sourceTree = "<group>"; };
 		F51E6728EF90B1D2BF8EA5AE /* Contact.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Contact.swift; sourceTree = "<group>"; };
 		F76507F3A1E2222FB64D7F31 /* ImageProcessing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessing.swift; sourceTree = "<group>"; };
@@ -319,6 +331,8 @@
 				9116FC0A7E009E9A806FD48F /* ContactInteraction.swift */,
 				7466E6CBC023A24F4365537C /* ContactStore+Interactions.swift */,
 				5BF65D4073AB3F28A3F52005 /* ContactStore+Backup.swift */,
+				1EDCC384329D463787C71CEC /* ContactTag.swift */,
+				F26E7A88DB9D18716C78E4D2 /* ContactStore+Tags.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -393,6 +407,8 @@
 				61C8E57A2BB1F32050119C06 /* ContentView+Backup.swift */,
 				A4B2FF6326B588F81435F358 /* RestoreBackupPreviewView.swift */,
 				40FA55EA1466B6711EE517B4 /* BackupPasswordPromptView.swift */,
+				CC0B4A31EACECB0C22183364 /* ContentView+Groups.swift */,
+				1E0C70519C31EA3869BCECA9 /* ContentView+Tags.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -479,6 +495,8 @@
 				8CE92D38DACB5637AF0E693F /* CloudSyncStatusTests.swift */,
 				54F228309258FF5B6F85FA05 /* ContactStoreBatchTests.swift */,
 				C127145D465C7F656FDBD0B6 /* CommandPaletteTests.swift */,
+				2BEACB78914327E09F4DA17E /* ContactTagTests.swift */,
+				F10191E5E98799FCA693D661 /* ContactSavedSmartListTests.swift */,
 			);
 			path = ContactManagerTests;
 			sourceTree = "<group>";
@@ -690,6 +708,10 @@
 				4113C97D0A33F34C52F4C6D3 /* CreateContactIntent.swift in Sources */,
 				202284B72FB98A23D5E6B618 /* AddContactHistoryNoteIntent.swift in Sources */,
 				91DDF6340BA942C58CE4EE84 /* ContactManagerShortcuts.swift in Sources */,
+				4DE6F60A4362DB82F555AC90 /* ContactTag.swift in Sources */,
+				B7BFE97538D99B970A512F5D /* ContactStore+Tags.swift in Sources */,
+				49951835ECDD188314B2D263 /* ContentView+Groups.swift in Sources */,
+				0DDC7707A54114378AB0E1E0 /* ContentView+Tags.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -725,6 +747,8 @@
 				5FCE54BC89E39D68DE29B360 /* CloudSyncStatusTests.swift in Sources */,
 				566DF0F6FE6E104AEE7C5302 /* ContactStoreBatchTests.swift in Sources */,
 				FE0819C468F6487E3777A0B8 /* CommandPaletteTests.swift in Sources */,
+				C2EA90DF3685BA76CCFA2C7E /* ContactTagTests.swift in Sources */,
+				6050F08D99E245F781379499 /* ContactSavedSmartListTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/App/ContactManagerApp.swift
+++ b/ContactManager/App/ContactManagerApp.swift
@@ -20,6 +20,7 @@ struct ContactManagerApp: App {
         ContactGroup.self,
         ContactInteraction.self,
         ContactSavedSmartList.self,
+        ContactTag.self,
     ]
 
     init() {

--- a/ContactManager/Models/Contact.swift
+++ b/ContactManager/Models/Contact.swift
@@ -46,6 +46,9 @@ final class Contact {
     /// Groups this contact belongs to (many-to-many; inverse on ContactGroup).
     var groups: [ContactGroup] = []
 
+    /// Lightweight labels this contact carries (many-to-many; inverse on ContactTag).
+    var tags: [ContactTag] = []
+
     init(
         firstName: String = "",
         lastName: String = "",
@@ -76,6 +79,7 @@ final class Contact {
         self.createdAt = createdAt
         fields = []
         interactions = []
+        tags = []
     }
 }
 

--- a/ContactManager/Models/ContactStore+Backup.swift
+++ b/ContactManager/Models/ContactStore+Backup.swift
@@ -13,12 +13,20 @@ extension ContactStore {
         try mutate("Restore Backup") {
             var result = BackupRestoreResult()
             var restoredGroups: [String: ContactGroup] = [:]
+            var restoredTags: [String: ContactTag] = [:]
 
             for record in backup.groups {
                 let group = ContactGroup(name: record.name, createdAt: record.createdAt)
                 context.insert(group)
                 restoredGroups[record.id] = group
                 result.groupsRestored += 1
+            }
+
+            for record in backup.tags {
+                let tag = ContactTag(name: record.name, createdAt: record.createdAt)
+                context.insert(tag)
+                restoredTags[record.id] = tag
+                result.tagsRestored += 1
             }
 
             for record in backup.savedSmartLists {
@@ -35,6 +43,7 @@ extension ContactStore {
                 let contact = Contact(record)
                 contact.photoData = record.photoData
                 contact.groups = record.groupIDs.compactMap { restoredGroups[$0] }
+                contact.tags = record.tagIDs.compactMap { restoredTags[$0] }
                 context.insert(contact)
                 restoreFields(record.fields, to: contact)
                 restoreInteractions(record.interactions, to: contact)
@@ -91,6 +100,7 @@ private extension Contact {
 struct BackupRestoreResult {
     var contactsRestored = 0
     var groupsRestored = 0
+    var tagsRestored = 0
     var savedSmartListsRestored = 0
     var interactionsRestored = 0
 
@@ -103,11 +113,12 @@ struct BackupRestoreResult {
         let parts = [
             count(contactsRestored, label: "contacts"),
             count(groupsRestored, label: "groups"),
+            count(tagsRestored, label: "tags"),
             count(savedSmartListsRestored, label: "smart lists"),
             count(interactionsRestored, label: "history notes"),
         ].compactMap(\.self)
         if parts.isEmpty {
-            return "No contacts, groups, smart lists, or history notes restored."
+            return "No contacts, groups, tags, smart lists, or history notes restored."
         }
         return parts.joined(separator: ", ").capitalizedIfFirst + "."
     }

--- a/ContactManager/Models/ContactStore+Tags.swift
+++ b/ContactManager/Models/ContactStore+Tags.swift
@@ -1,0 +1,88 @@
+//
+//  ContactStore+Tags.swift
+//  ContactManager
+//
+//  Durable mutations for contact tags and tag membership.
+//
+
+import Foundation
+import SwiftData
+
+extension ContactStore {
+    @discardableResult
+    func createTag(named name: String = "New Tag") throws -> ContactTag {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return try mutate("New Tag") {
+            let tag = ContactTag(name: trimmed.isEmpty ? "New Tag" : trimmed)
+            context.insert(tag)
+            return tag
+        }
+    }
+
+    func rename(_ tag: ContactTag, to name: String) throws {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        try mutate("Rename Tag") {
+            tag.name = trimmed
+        }
+    }
+
+    func delete(_ tag: ContactTag) throws {
+        try mutate("Delete Tag") {
+            context.delete(tag)
+        }
+    }
+
+    func setMembership(of contact: Contact, in tag: ContactTag, isMember: Bool) throws {
+        let alreadyMember = contact.tags.contains { $0.persistentModelID == tag.persistentModelID }
+        guard isMember != alreadyMember else { return }
+
+        try mutate("Change Tag Membership") {
+            if isMember {
+                contact.tags.append(tag)
+            } else {
+                contact.tags.removeAll { $0.persistentModelID == tag.persistentModelID }
+            }
+        }
+    }
+
+    @discardableResult
+    func addContacts(_ contacts: [Contact], to tag: ContactTag) throws -> Int {
+        let tagID = tag.persistentModelID
+        let toAdd = contacts.filter { contact in
+            !contact.tags.contains { $0.persistentModelID == tagID }
+        }
+        guard !toAdd.isEmpty else { return 0 }
+        return try mutate("Add to Tag") {
+            toAdd.forEach { $0.tags.append(tag) }
+            return toAdd.count
+        }
+    }
+
+    func adoptTags(into primary: Contact, from other: Contact) {
+        let existing = Set(primary.tags.map(\.persistentModelID))
+        for tag in other.tags where !existing.contains(tag.persistentModelID) {
+            primary.tags.append(tag)
+        }
+    }
+
+    /// Adds the contacts named by their encoded `PersistentIdentifier`s to
+    /// `tag` — the data path behind dragging contacts onto a sidebar tag.
+    /// Invalid ids and contacts already carrying the tag are skipped.
+    @discardableResult
+    func addContacts(withEncodedIDs ids: [String], to tag: ContactTag) throws -> Int {
+        let wanted = Set(ids.filter { PersistentIdentifier.decode(stored: $0) != nil })
+        guard !wanted.isEmpty else { return 0 }
+        let tagID = tag.persistentModelID
+        let toAdd = try context.fetch(FetchDescriptor<Contact>()).filter { contact in
+            guard let encoded = contact.persistentModelID.storedString else { return false }
+            return wanted.contains(encoded)
+                && !contact.tags.contains { $0.persistentModelID == tagID }
+        }
+        guard !toAdd.isEmpty else { return 0 }
+        return try mutate("Add to Tag") {
+            toAdd.forEach { $0.tags.append(tag) }
+            return toAdd.count
+        }
+    }
+}

--- a/ContactManager/Models/ContactStore.swift
+++ b/ContactManager/Models/ContactStore.swift
@@ -162,6 +162,7 @@ struct ContactStore {
             for other in others {
                 fillEmptyFields(of: primary, from: other)
                 adoptGroups(into: primary, from: other)
+                adoptTags(into: primary, from: other)
                 adoptInteractions(into: primary, from: other)
             }
             mergeFields(into: primary, from: Array(others))

--- a/ContactManager/Models/ContactTag.swift
+++ b/ContactManager/Models/ContactTag.swift
@@ -1,0 +1,32 @@
+//
+//  ContactTag.swift
+//  ContactManager
+//
+//  A lightweight user-defined label that can be assigned to many contacts.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class ContactTag {
+    var name: String = ""
+    var createdAt: Date = Date.now
+
+    /// Contacts carrying this tag. Deleting a tag nullifies membership rather
+    /// than deleting the contacts themselves.
+    @Relationship(deleteRule: .nullify, inverse: \Contact.tags)
+    var contacts: [Contact] = []
+
+    init(name: String = "", createdAt: Date = .now) {
+        self.name = name
+        self.createdAt = createdAt
+    }
+}
+
+extension ContactTag {
+    var displayName: String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Untitled Tag" : trimmed
+    }
+}

--- a/ContactManager/Support/ContactBackup.swift
+++ b/ContactManager/Support/ContactBackup.swift
@@ -9,11 +9,12 @@ import Foundation
 import SwiftData
 
 struct ContactBackup: Codable, Equatable {
-    static let currentVersion = 2
+    static let currentVersion = 3
 
     var version: Int
     var exportedAt: Date
     var groups: [GroupRecord]
+    var tags: [TagRecord]
     var savedSmartLists: [SavedSmartListRecord]
     var contacts: [ContactRecord]
 
@@ -21,12 +22,14 @@ struct ContactBackup: Codable, Equatable {
         version: Int = Self.currentVersion,
         exportedAt: Date = .now,
         groups: [GroupRecord] = [],
+        tags: [TagRecord] = [],
         savedSmartLists: [SavedSmartListRecord] = [],
         contacts: [ContactRecord] = []
     ) {
         self.version = version
         self.exportedAt = exportedAt
         self.groups = groups
+        self.tags = tags
         self.savedSmartLists = savedSmartLists
         self.contacts = contacts
     }
@@ -34,11 +37,15 @@ struct ContactBackup: Codable, Equatable {
     static func make(
         contacts: [Contact],
         groups: [ContactGroup],
+        tags: [ContactTag] = [],
         savedSmartLists: [ContactSavedSmartList] = [],
         exportedAt: Date = .now
     ) -> ContactBackup {
         let groupIDs = Dictionary(uniqueKeysWithValues: groups.map { group in
             (group.persistentModelID, backupID(for: group))
+        })
+        let tagIDs = Dictionary(uniqueKeysWithValues: tags.map { tag in
+            (tag.persistentModelID, backupID(for: tag))
         })
         return ContactBackup(
             exportedAt: exportedAt,
@@ -48,6 +55,12 @@ struct ContactBackup: Codable, Equatable {
                     return lhs.createdAt < rhs.createdAt
                 }
                 .map { GroupRecord(id: backupID(for: $0), name: $0.name, createdAt: $0.createdAt) },
+            tags: tags
+                .sorted { lhs, rhs in
+                    if lhs.displayName != rhs.displayName { return lhs.displayName < rhs.displayName }
+                    return lhs.createdAt < rhs.createdAt
+                }
+                .map { TagRecord(id: backupID(for: $0), name: $0.name, createdAt: $0.createdAt) },
             savedSmartLists: savedSmartLists
                 .sorted { lhs, rhs in
                     if lhs.displayName != rhs.displayName { return lhs.displayName < rhs.displayName }
@@ -55,7 +68,7 @@ struct ContactBackup: Codable, Equatable {
                 }
                 .map { SavedSmartListRecord(name: $0.name, query: $0.query, createdAt: $0.createdAt) },
             contacts: ContactQuery.sorted(contacts).map { contact in
-                ContactRecord(contact: contact, groupIDs: groupIDs)
+                ContactRecord(contact: contact, groupIDs: groupIDs, tagIDs: tagIDs)
             }
         )
     }
@@ -64,10 +77,15 @@ struct ContactBackup: Codable, Equatable {
         group.persistentModelID.storedString ?? String(describing: group.persistentModelID)
     }
 
+    private static func backupID(for tag: ContactTag) -> String {
+        tag.persistentModelID.storedString ?? String(describing: tag.persistentModelID)
+    }
+
     private enum CodingKeys: String, CodingKey {
         case version
         case exportedAt
         case groups
+        case tags
         case savedSmartLists
         case contacts
     }
@@ -77,6 +95,7 @@ struct ContactBackup: Codable, Equatable {
         version = try container.decode(Int.self, forKey: .version)
         exportedAt = try container.decode(Date.self, forKey: .exportedAt)
         groups = try container.decode([GroupRecord].self, forKey: .groups)
+        tags = try container.decodeIfPresent([TagRecord].self, forKey: .tags) ?? []
         savedSmartLists = try container.decodeIfPresent([SavedSmartListRecord].self, forKey: .savedSmartLists) ?? []
         contacts = try container.decode([ContactRecord].self, forKey: .contacts)
     }
@@ -84,6 +103,12 @@ struct ContactBackup: Codable, Equatable {
 
 extension ContactBackup {
     struct GroupRecord: Codable, Equatable, Identifiable {
+        var id: String
+        var name: String
+        var createdAt: Date
+    }
+
+    struct TagRecord: Codable, Equatable, Identifiable {
         var id: String
         var name: String
         var createdAt: Date
@@ -113,9 +138,14 @@ extension ContactBackup {
         var photoData: Data?
         var fields: [FieldRecord]
         var groupIDs: [String]
+        var tagIDs: [String]
         var interactions: [InteractionRecord]
 
-        init(contact: Contact, groupIDs: [PersistentIdentifier: String]) {
+        init(
+            contact: Contact,
+            groupIDs: [PersistentIdentifier: String],
+            tagIDs: [PersistentIdentifier: String]
+        ) {
             id = contact.persistentModelID.storedString ?? String(describing: contact.persistentModelID)
             firstName = contact.firstName
             lastName = contact.lastName
@@ -138,7 +168,54 @@ extension ContactBackup {
                 }
                 .map(FieldRecord.init(field:))
             self.groupIDs = contact.groups.compactMap { groupIDs[$0.persistentModelID] }.sorted()
+            self.tagIDs = contact.tags.compactMap { tagIDs[$0.persistentModelID] }.sorted()
             interactions = contact.sortedInteractions.map(InteractionRecord.init(interaction:))
+        }
+
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case firstName
+            case lastName
+            case company
+            case jobTitle
+            case street
+            case city
+            case state
+            case postalCode
+            case country
+            case birthday
+            case lastContactedAt
+            case notes
+            case createdAt
+            case photoData
+            case fields
+            case groupIDs
+            case tagIDs
+            case interactions
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(String.self, forKey: .id)
+            firstName = try container.decode(String.self, forKey: .firstName)
+            lastName = try container.decode(String.self, forKey: .lastName)
+            company = try container.decode(String.self, forKey: .company)
+            jobTitle = try container.decode(String.self, forKey: .jobTitle)
+            street = try container.decode(String.self, forKey: .street)
+            city = try container.decode(String.self, forKey: .city)
+            state = try container.decode(String.self, forKey: .state)
+            postalCode = try container.decode(String.self, forKey: .postalCode)
+            country = try container.decode(String.self, forKey: .country)
+            birthday = try container.decodeIfPresent(Date.self, forKey: .birthday)
+            lastContactedAt = try container.decodeIfPresent(Date.self, forKey: .lastContactedAt)
+            notes = try container.decode(String.self, forKey: .notes)
+            createdAt = try container.decode(Date.self, forKey: .createdAt)
+            photoData = try container.decodeIfPresent(Data.self, forKey: .photoData)
+            fields = try container.decode([FieldRecord].self, forKey: .fields)
+            groupIDs = try container.decode([String].self, forKey: .groupIDs)
+            tagIDs = try container.decodeIfPresent([String].self, forKey: .tagIDs) ?? []
+            interactions = try container.decode([InteractionRecord].self, forKey: .interactions)
         }
     }
 

--- a/ContactManager/Support/ContactBackupPreview.swift
+++ b/ContactManager/Support/ContactBackupPreview.swift
@@ -11,6 +11,7 @@ struct ContactBackupPreview: Equatable {
     var exportedAt: Date
     var contactCount: Int
     var groupCount: Int
+    var tagCount: Int
     var savedSmartListCount: Int
     var emailCount: Int
     var phoneCount: Int
@@ -19,13 +20,14 @@ struct ContactBackupPreview: Equatable {
     var sampleContactNames: [String]
 
     var isEmpty: Bool {
-        contactCount == 0 && groupCount == 0 && savedSmartListCount == 0 && historyNoteCount == 0
+        contactCount == 0 && groupCount == 0 && tagCount == 0 && savedSmartListCount == 0 && historyNoteCount == 0
     }
 
     init(backup: ContactBackup) {
         exportedAt = backup.exportedAt
         contactCount = backup.contacts.count
         groupCount = backup.groups.count
+        tagCount = backup.tags.count
         savedSmartListCount = backup.savedSmartLists.count
         emailCount = backup.contacts.flatMap(\.fields).filter { $0.kind == .email }.count
         phoneCount = backup.contacts.flatMap(\.fields).filter { $0.kind == .phone }.count
@@ -41,6 +43,7 @@ struct ContactBackupPreview: Equatable {
         let parts = [
             count(contactCount, singular: "contact"),
             count(groupCount, singular: "group"),
+            count(tagCount, singular: "tag"),
             count(savedSmartListCount, singular: "smart list"),
             count(emailCount, singular: "email"),
             count(phoneCount, singular: "phone"),

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -23,6 +23,7 @@ struct ContactDetailView: View {
     var onNameFieldFocused: () -> Void = {}
     var markContacted: (Contact) -> Void = { _ in }
     @Query(sort: \ContactGroup.name) private var allGroups: [ContactGroup]
+    @Query(sort: \ContactTag.name) private var allTags: [ContactTag]
     @State private var isImportingPhoto = false
     // Not private: the photo handlers in ContactDetailView+Photo.swift read them.
     @State var errorMessage: String?
@@ -120,6 +121,18 @@ struct ContactDetailView: View {
                 } else {
                     ForEach(allGroups) { group in
                         Toggle(group.displayName, isOn: membership(in: group))
+                    }
+                }
+            }
+
+            Section("Tags") {
+                if allTags.isEmpty {
+                    Text("No tags yet. Create one in the sidebar.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(allTags) { tag in
+                        Toggle(tag.displayName, isOn: tagMembership(in: tag))
+                            .accessibilityIdentifier("contact-tag-toggle-\(tag.displayName.normalizedIdentifier)")
                     }
                 }
             }
@@ -287,15 +300,30 @@ struct ContactDetailView: View {
             errorMessage = error.localizedDescription
         }
     }
+}
 
-    // MARK: - Group membership
+private extension ContactDetailView {
+    // MARK: - Organization membership
 
-    private func membership(in group: ContactGroup) -> Binding<Bool> {
+    func membership(in group: ContactGroup) -> Binding<Bool> {
         Binding(
             get: { contact.groups.contains { $0.persistentModelID == group.persistentModelID } },
             set: { isMember in
                 do {
                     try store.setMembership(of: contact, in: group, isMember: isMember)
+                } catch {
+                    errorMessage = error.localizedDescription
+                }
+            }
+        )
+    }
+
+    func tagMembership(in tag: ContactTag) -> Binding<Bool> {
+        Binding(
+            get: { contact.tags.contains { $0.persistentModelID == tag.persistentModelID } },
+            set: { isMember in
+                do {
+                    try store.setMembership(of: contact, in: tag, isMember: isMember)
                 } catch {
                     errorMessage = error.localizedDescription
                 }
@@ -338,6 +366,14 @@ private extension ContactDetailView {
             get: { contact.birthday ?? .now },
             set: { contact.birthday = $0 }
         )
+    }
+}
+
+private extension String {
+    var normalizedIdentifier: String {
+        lowercased()
+            .map { $0.isLetter || $0.isNumber ? String($0) : "-" }
+            .joined()
     }
 }
 

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -19,11 +19,13 @@ struct ContactListView: View {
     @Binding var selection: Contact?
     @Binding var selectionIDs: Set<PersistentIdentifier>
     let groups: [ContactGroup]
+    let tags: [ContactTag]
     var addContact: () -> Void
     var deleteContact: (Contact) -> Void
     var saveCurrentSearch: () -> Void
     var exportSelectedContacts: () -> Void
     var addSelectedContactsToGroup: (ContactGroup) -> Void
+    var addSelectedContactsToTag: (ContactTag) -> Void
     var deleteSelectedContacts: () -> Void
     /// Called when a `.vcf` file is dropped onto the list from Finder.
     var importVCardURLs: ([URL]) -> Void
@@ -126,6 +128,18 @@ struct ContactListView: View {
                         }
                     }
                     .accessibilityIdentifier("batch-add-to-group-menu")
+                    Menu("Add to Tag") {
+                        if tags.isEmpty {
+                            Text("No Tags")
+                        } else {
+                            ForEach(tags) { tag in
+                                Button(tag.displayName) {
+                                    addSelectedContactsToTag(tag)
+                                }
+                            }
+                        }
+                    }
+                    .accessibilityIdentifier("batch-add-to-tag-menu")
                     Divider()
                     Button("Delete", role: .destructive, action: deleteSelectedContacts)
                         .accessibilityIdentifier("batch-delete-button")

--- a/ContactManager/Views/ContentView+Backup.swift
+++ b/ContactManager/Views/ContentView+Backup.swift
@@ -12,6 +12,7 @@ extension ContentView {
         backupDocument = ContactBackupDocument(backup: ContactBackup.make(
             contacts: contacts,
             groups: groups,
+            tags: tags,
             savedSmartLists: savedSmartLists
         ))
         isExportingBackup = true
@@ -19,7 +20,12 @@ extension ContentView {
 
     func exportEncryptedBackup(password: String) -> Bool {
         do {
-            let backup = ContactBackup.make(contacts: contacts, groups: groups, savedSmartLists: savedSmartLists)
+            let backup = ContactBackup.make(
+                contacts: contacts,
+                groups: groups,
+                tags: tags,
+                savedSmartLists: savedSmartLists
+            )
             let data = try EncryptedContactBackupDocument.encode(backup, password: password)
             encryptedBackupDocument = EncryptedContactBackupDocument(data: data)
             isPreparingEncryptedBackup = false

--- a/ContactManager/Views/ContentView+Batch.swift
+++ b/ContactManager/Views/ContentView+Batch.swift
@@ -41,6 +41,14 @@ extension ContentView {
         }
     }
 
+    func addSelectedContacts(to tag: ContactTag) {
+        do {
+            _ = try store.addContacts(selectedContacts, to: tag)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
     private func shouldClearDetail(afterDeleting deleted: [Contact]) -> Bool {
         guard let selectedContact else { return false }
         return deleted.contains { contact in

--- a/ContactManager/Views/ContentView+CommandPalette.swift
+++ b/ContactManager/Views/ContentView+CommandPalette.swift
@@ -53,6 +53,14 @@ extension ContentView {
                 openWindow(id: "quickCapture")
             },
             command(
+                id: "new-tag",
+                title: "New Tag",
+                subtitle: "Create a contact label",
+                keywords: ["label"],
+                systemImage: "tag",
+                action: addTag
+            ),
+            command(
                 id: "find-contacts",
                 title: "Find Contacts",
                 subtitle: "Focus the contact search field",
@@ -189,6 +197,18 @@ extension ContentView {
                 systemImage: "folder"
             ) {
                 sidebarSelection = .group(group.persistentModelID)
+            }
+        })
+
+        entries.append(contentsOf: tags.map { tag in
+            command(
+                id: "nav-tag-\(tag.persistentModelID.storedString ?? tag.displayName)",
+                title: tag.displayName,
+                subtitle: "Open tag",
+                keywords: ["navigate", "tag", "label"],
+                systemImage: "tag"
+            ) {
+                sidebarSelection = .tag(tag.persistentModelID)
             }
         })
 

--- a/ContactManager/Views/ContentView+Groups.swift
+++ b/ContactManager/Views/ContentView+Groups.swift
@@ -1,0 +1,45 @@
+//
+//  ContentView+Groups.swift
+//  ContactManager
+//
+//  Sidebar group mutations.
+//
+
+import SwiftUI
+
+extension ContentView {
+    func addGroup() {
+        do {
+            let group = try store.createGroup()
+            withAnimation(reduceMotion ? nil : .snappy) { sidebarSelection = .group(group.persistentModelID) }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func addContacts(encodedIDs ids: [String], to group: ContactGroup) {
+        do {
+            try store.addContacts(withEncodedIDs: ids, to: group)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func renameGroup(_ group: ContactGroup, to name: String) {
+        do {
+            try store.rename(group, to: name)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func deleteGroup(_ group: ContactGroup) {
+        let wasSelected = sidebarSelection == .group(group.persistentModelID)
+        do {
+            try store.delete(group)
+            if wasSelected { sidebarSelection = .allContacts }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ContactManager/Views/ContentView+Tags.swift
+++ b/ContactManager/Views/ContentView+Tags.swift
@@ -1,0 +1,45 @@
+//
+//  ContentView+Tags.swift
+//  ContactManager
+//
+//  Sidebar tag mutations.
+//
+
+import SwiftUI
+
+extension ContentView {
+    func addTag() {
+        do {
+            let tag = try store.createTag()
+            withAnimation(reduceMotion ? nil : .snappy) { sidebarSelection = .tag(tag.persistentModelID) }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func addContacts(encodedIDs ids: [String], to tag: ContactTag) {
+        do {
+            try store.addContacts(withEncodedIDs: ids, to: tag)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func renameTag(_ tag: ContactTag, to name: String) {
+        do {
+            try store.rename(tag, to: name)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func deleteTag(_ tag: ContactTag) {
+        let wasSelected = sidebarSelection == .tag(tag.persistentModelID)
+        do {
+            try store.delete(tag)
+            if wasSelected { sidebarSelection = .allContacts }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -22,6 +22,8 @@ struct ContentView: View {
 
     @Query(sort: \ContactGroup.name) var groups: [ContactGroup]
 
+    @Query(sort: \ContactTag.name) var tags: [ContactTag]
+
     @Query(sort: \ContactSavedSmartList.createdAt) var savedSmartLists: [ContactSavedSmartList]
 
     @State var sidebarSelection: SidebarItem? = .allContacts
@@ -70,6 +72,11 @@ struct ContentView: View {
         return groups.first { $0.persistentModelID == id }
     }
 
+    private var selectedTag: ContactTag? {
+        guard case .tag(let id) = sidebarSelection else { return nil }
+        return tags.first { $0.persistentModelID == id }
+    }
+
     private var selectedSmartList: ContactSmartList? {
         guard case .smartList(let smartList) = sidebarSelection else { return nil }
         return smartList
@@ -92,12 +99,13 @@ struct ContentView: View {
     private var groupForNewContact: ContactGroup? {
         switch sidebarSelection {
         case .group: selectedGroup
-        case .allContacts, .smartList, .savedSmartList, .none: defaultGroup
+        case .allContacts, .smartList, .savedSmartList, .tag, .none: defaultGroup
         }
     }
 
     private var scopedContacts: [Contact] {
         if let selectedGroup { return selectedGroup.contacts }
+        if let selectedTag { return selectedTag.contacts }
         if let selectedSmartList { return ContactQuery.filtered(contacts, by: selectedSmartList) }
         if let selectedSavedSmartList { return ContactQuery.filtered(contacts, by: selectedSavedSmartList) }
         return contacts
@@ -105,6 +113,7 @@ struct ContentView: View {
 
     private var listTitle: String {
         if let selectedGroup { return selectedGroup.displayName }
+        if let selectedTag { return selectedTag.displayName }
         if let selectedSmartList { return selectedSmartList.title }
         if let selectedSavedSmartList { return selectedSavedSmartList.displayName }
         return "Contacts"
@@ -112,6 +121,7 @@ struct ContentView: View {
 
     private var emptyListTitle: String {
         if selectedGroup != nil { return "No Contacts in Group" }
+        if selectedTag != nil { return "No Contacts with Tag" }
         if selectedSmartList != nil || selectedSavedSmartList != nil { return "No Contacts Match" }
         return "No Contacts"
     }
@@ -156,12 +166,17 @@ struct ContentView: View {
                 savedSmartLists: savedSmartLists,
                 savedSmartListCounts: savedSmartListCounts,
                 groups: groups,
+                tags: tags,
                 addGroup: addGroup,
+                addTag: addTag,
                 renameSavedSmartList: renameSavedSmartList,
                 deleteSavedSmartList: deleteSavedSmartList,
                 renameGroup: renameGroup,
                 deleteGroup: deleteGroup,
-                addContacts: addContacts(encodedIDs:to:)
+                renameTag: renameTag,
+                deleteTag: deleteTag,
+                addContactsToGroup: addContacts(encodedIDs:to:),
+                addContactsToTag: addContacts(encodedIDs:to:)
             )
         } content: {
             ContactListView(
@@ -174,11 +189,13 @@ struct ContentView: View {
                 selection: $selectedContact,
                 selectionIDs: $selectedContactIDs,
                 groups: groups,
+                tags: tags,
                 addContact: addContact,
                 deleteContact: deleteContact,
                 saveCurrentSearch: saveCurrentSearchAsSmartList,
                 exportSelectedContacts: exportSelectedContactsAsVCard,
                 addSelectedContactsToGroup: addSelectedContacts(to:),
+                addSelectedContactsToTag: addSelectedContacts(to:),
                 deleteSelectedContacts: requestDeleteSelectedContacts,
                 importVCardURLs: importVCardURLs
             )
@@ -216,6 +233,9 @@ struct ContentView: View {
     func addContact() {
         do {
             let contact = try store.createContact(in: groupForNewContact)
+            if let selectedTag {
+                try store.setMembership(of: contact, in: selectedTag, isMember: true)
+            }
             if selectedSmartList != nil || selectedSavedSmartList != nil { sidebarSelection = .allContacts }
             contactPendingNameFocus = contact.persistentModelID
             selectedContactIDs = [contact.persistentModelID]
@@ -244,43 +264,6 @@ struct ContentView: View {
         }
     }
 
-    // MARK: - Group actions
-
-    private func addGroup() {
-        do {
-            let group = try store.createGroup()
-            withAnimation(reduceMotion ? nil : .snappy) { sidebarSelection = .group(group.persistentModelID) }
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    private func addContacts(encodedIDs ids: [String], to group: ContactGroup) {
-        do {
-            try store.addContacts(withEncodedIDs: ids, to: group)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    private func renameGroup(_ group: ContactGroup, to name: String) {
-        do {
-            try store.rename(group, to: name)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    private func deleteGroup(_ group: ContactGroup) {
-        let wasSelected = sidebarSelection == .group(group.persistentModelID)
-        do {
-            try store.delete(group)
-            if wasSelected { sidebarSelection = .allContacts }
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
     // MARK: - Open by ID (Spotlight + App Intents)
 
     private func selectContact(byEncodedID encoded: String?) {
@@ -292,6 +275,7 @@ struct ContentView: View {
         // middle column even if the user arrived via Spotlight while a
         // narrower group was active.
         if case .group = sidebarSelection { sidebarSelection = .allContacts }
+        if case .tag = sidebarSelection { sidebarSelection = .allContacts }
         withAnimation(reduceMotion ? nil : .snappy) { selectedContact = contact }
     }
 }
@@ -380,5 +364,6 @@ private extension ContentView {
     ContentView()
         .modelContainer(for: [
             Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self, ContactSavedSmartList.self,
+            ContactTag.self,
         ], inMemory: true)
 }

--- a/ContactManager/Views/QuickCaptureView.swift
+++ b/ContactManager/Views/QuickCaptureView.swift
@@ -122,7 +122,7 @@ private struct QuickCapturePreview: View {
 #Preview {
     QuickCaptureView()
         .modelContainer(
-            for: [Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self],
+            for: [Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self, ContactTag.self],
             inMemory: true
         )
 }

--- a/ContactManager/Views/RestoreBackupPreviewView.swift
+++ b/ContactManager/Views/RestoreBackupPreviewView.swift
@@ -20,6 +20,7 @@ struct RestoreBackupPreviewView: View {
                     labeledRow("Summary", value: preview.summary)
                     labeledRow("Contacts", value: "\(preview.contactCount)")
                     labeledRow("Groups", value: "\(preview.groupCount)")
+                    labeledRow("Tags", value: "\(preview.tagCount)")
                     labeledRow("Smart Lists", value: "\(preview.savedSmartListCount)")
                     labeledRow("Emails", value: "\(preview.emailCount)")
                     labeledRow("Phones", value: "\(preview.phoneCount)")

--- a/ContactManager/Views/SidebarView.swift
+++ b/ContactManager/Views/SidebarView.swift
@@ -14,6 +14,7 @@ enum SidebarItem: Hashable {
     case smartList(ContactSmartList)
     case savedSmartList(PersistentIdentifier)
     case group(PersistentIdentifier)
+    case tag(PersistentIdentifier)
 }
 
 struct SidebarView: View {
@@ -25,15 +26,22 @@ struct SidebarView: View {
     let savedSmartLists: [ContactSavedSmartList]
     let savedSmartListCounts: [PersistentIdentifier: Int]
     let groups: [ContactGroup]
+    let tags: [ContactTag]
     var addGroup: () -> Void
+    var addTag: () -> Void
     var renameSavedSmartList: (ContactSavedSmartList, String) -> Void
     var deleteSavedSmartList: (ContactSavedSmartList) -> Void
     var renameGroup: (ContactGroup, String) -> Void
     var deleteGroup: (ContactGroup) -> Void
+    var renameTag: (ContactTag, String) -> Void
+    var deleteTag: (ContactTag) -> Void
     /// Adds the dropped contacts (by encoded id) to a group — sidebar drag target.
-    var addContacts: ([String], ContactGroup) -> Void
+    var addContactsToGroup: ([String], ContactGroup) -> Void
+    /// Adds the dropped contacts (by encoded id) to a tag — sidebar drag target.
+    var addContactsToTag: ([String], ContactTag) -> Void
 
     @State private var renameTarget: ContactGroup?
+    @State private var renameTagTarget: ContactTag?
     @State private var renameSavedSmartListTarget: ContactSavedSmartList?
     @State private var renameText = ""
 
@@ -90,7 +98,32 @@ struct SidebarView: View {
                             .dropDestination(for: String.self) { ids, _ in
                                 let valid = ids.filter { PersistentIdentifier.decode(stored: $0) != nil }
                                 guard !valid.isEmpty else { return false }
-                                addContacts(valid, group)
+                                addContactsToGroup(valid, group)
+                                return true
+                            }
+                    }
+                }
+            }
+
+            Section("Tags") {
+                if tags.isEmpty {
+                    Text("Use the tag button above to add one.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(tags) { tag in
+                        Label(tag.displayName, systemImage: "tag")
+                            .badge(tag.contacts.count)
+                            .tag(SidebarItem.tag(tag.persistentModelID))
+                            .accessibilityIdentifier("sidebar-tag-row-\(tag.displayName.normalizedIdentifier)")
+                            .contextMenu {
+                                Button("Rename…") { beginRename(tag) }
+                                Button("Delete", role: .destructive) { deleteTag(tag) }
+                            }
+                            .dropDestination(for: String.self) { ids, _ in
+                                let valid = ids.filter { PersistentIdentifier.decode(stored: $0) != nil }
+                                guard !valid.isEmpty else { return false }
+                                addContactsToTag(valid, tag)
                                 return true
                             }
                     }
@@ -111,7 +144,7 @@ struct SidebarView: View {
                 .accessibilityIdentifier("sidebar-sync-status")
             }
         }
-        .navigationTitle("Groups")
+        .navigationTitle("Contacts")
         .navigationSplitViewColumnWidth(
             min: LayoutMetrics.sidebarMinWidth,
             ideal: LayoutMetrics.sidebarIdealWidth,
@@ -121,11 +154,19 @@ struct SidebarView: View {
             // `.primaryAction` keeps + visible at every window width;
             // the default `.automatic` placement lets the chevron eat it.
             ToolbarItem(placement: .primaryAction) {
-                Button(action: addGroup) {
-                    Label("New Group", systemImage: "folder.badge.plus")
+                HStack(spacing: 8) {
+                    Button(action: addGroup) {
+                        Label("New Group", systemImage: "folder.badge.plus")
+                    }
+                    .help("New Group")
+                    .accessibilityIdentifier("new-group-button")
+
+                    Button(action: addTag) {
+                        Label("New Tag", systemImage: "tag")
+                    }
+                    .help("New Tag")
+                    .accessibilityIdentifier("new-tag-button")
                 }
-                .help("New Group")
-                .accessibilityIdentifier("new-group-button")
             }
         }
         .alert("Rename Group", isPresented: Binding(
@@ -152,11 +193,27 @@ struct SidebarView: View {
                 renameSavedSmartListTarget = nil
             }
         }
+        .alert("Rename Tag", isPresented: Binding(
+            get: { renameTagTarget != nil },
+            set: { if !$0 { renameTagTarget = nil } }
+        )) {
+            TextField("Name", text: $renameText)
+            Button("Cancel", role: .cancel) { renameTagTarget = nil }
+            Button("Rename") {
+                if let target = renameTagTarget { renameTag(target, renameText) }
+                renameTagTarget = nil
+            }
+        }
     }
 
     private func beginRename(_ group: ContactGroup) {
         renameText = group.name
         renameTarget = group
+    }
+
+    private func beginRename(_ tag: ContactTag) {
+        renameText = tag.name
+        renameTagTarget = tag
     }
 
     private func beginRename(_ savedList: ContactSavedSmartList) {

--- a/ContactManagerTests/ContactBackupTests.swift
+++ b/ContactManagerTests/ContactBackupTests.swift
@@ -20,7 +20,7 @@ struct ContactBackupTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
-            ContactSavedSmartList.self,
+            ContactSavedSmartList.self, ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)
@@ -38,15 +38,23 @@ struct ContactBackupTests {
         try context.fetch(FetchDescriptor<ContactSavedSmartList>())
     }
 
+    private func allTags() throws -> [ContactTag] {
+        try context.fetch(FetchDescriptor<ContactTag>())
+    }
+
     @Test func backupCapturesContactsGroupsFieldsAndHistory() throws {
         let contact = try makePopulatedContact()
         let savedList = try store.createSavedSmartList(named: "Engine People", query: "engine")
+        let tag = try store.createTag(named: "VIP")
+        try store.setMembership(of: contact, in: tag, isMember: true)
         let contacts = try allContacts()
         let groups = try allGroups()
+        let tags = try allTags()
 
         let backup = ContactBackup.make(
             contacts: contacts,
             groups: groups,
+            tags: tags,
             savedSmartLists: [savedList],
             exportedAt: Date(timeIntervalSinceReferenceDate: 42)
         )
@@ -56,9 +64,11 @@ struct ContactBackupTests {
         #expect(record.firstName == "Ada")
         #expect(record.fields.map(\.value) == ["ada@example.com"])
         #expect(record.groupIDs.count == 1)
+        #expect(record.tagIDs.count == 1)
         #expect(record.interactions.map(\.summary) == ["Met at WWDC."])
         #expect(record.lastContactedAt == contact.lastContactedAt)
         #expect(backup.groups.map(\.name) == ["Work"])
+        #expect(backup.tags.map(\.name) == ["VIP"])
         #expect(backup.savedSmartLists.map(\.name) == ["Engine People"])
         #expect(backup.savedSmartLists.map(\.query) == ["engine"])
     }
@@ -66,10 +76,14 @@ struct ContactBackupTests {
     @Test func restoreBackupRecreatesContactsGroupsFieldsAndHistory() throws {
         let contact = try makePopulatedContact()
         let savedList = try store.createSavedSmartList(named: "Engine People", query: "engine")
+        let tag = try store.createTag(named: "VIP")
+        try store.setMembership(of: contact, in: tag, isMember: true)
         let groups = try allGroups()
+        let tags = try allTags()
         let original = ContactBackup.make(
             contacts: [contact],
             groups: groups,
+            tags: tags,
             savedSmartLists: [savedList],
             exportedAt: Date(timeIntervalSinceReferenceDate: 42)
         )
@@ -77,27 +91,34 @@ struct ContactBackupTests {
         let contactsBeforeRestore = try allContacts()
         let groupsBeforeRestore = try allGroups()
         let savedListsBeforeRestore = try allSavedSmartLists()
+        let tagsBeforeRestore = try allTags()
         let contactBeforeRestore = try #require(contactsBeforeRestore.first)
         let groupBeforeRestore = try #require(groupsBeforeRestore.first)
         let savedListBeforeRestore = try #require(savedListsBeforeRestore.first)
+        let tagBeforeRestore = try #require(tagsBeforeRestore.first)
         try store.delete(contactBeforeRestore)
         try store.delete(groupBeforeRestore)
         try store.delete(savedListBeforeRestore)
+        try store.delete(tagBeforeRestore)
 
         let result = try store.restoreBackup(original)
 
         let restoredContacts = try allContacts()
         let restoredSavedLists = try allSavedSmartLists()
+        let restoredTags = try allTags()
         let restored = try #require(restoredContacts.first)
         #expect(result.contactsRestored == 1)
         #expect(result.groupsRestored == 1)
+        #expect(result.tagsRestored == 1)
         #expect(result.savedSmartListsRestored == 1)
         #expect(result.interactionsRestored == 1)
         #expect(restored.fullName == "Ada Lovelace")
         #expect(restored.lastContactedAt == Date(timeIntervalSinceReferenceDate: 200))
         #expect(restored.emails.map(\.value) == ["ada@example.com"])
         #expect(restored.groups.map(\.displayName) == ["Work"])
+        #expect(restored.tags.map(\.displayName) == ["VIP"])
         #expect(restored.sortedInteractions.map(\.summary) == ["Met at WWDC."])
+        #expect(restoredTags.map(\.displayName) == ["VIP"])
         #expect(restoredSavedLists.map(\.displayName) == ["Engine People"])
         #expect(restoredSavedLists.map(\.query) == ["engine"])
     }
@@ -130,6 +151,7 @@ struct ContactBackupTests {
         let decoded = try ContactBackupDocument.decode(Data(legacyJSON.utf8))
 
         #expect(decoded.version == 1)
+        #expect(decoded.tags.isEmpty)
         #expect(decoded.savedSmartLists.isEmpty)
     }
 
@@ -170,16 +192,20 @@ struct ContactBackupTests {
 
         #expect(result.contactsRestored == 0)
         #expect(result.title == "Restored 0 Contacts")
-        #expect(result.message == "No contacts, groups, smart lists, or history notes restored.")
+        #expect(result.message == "No contacts, groups, tags, smart lists, or history notes restored.")
     }
 
     @Test func backupPreviewSummarizesContentsBeforeRestore() throws {
         let contact = try makePopulatedContact()
         let savedList = try store.createSavedSmartList(named: "Engine People", query: "engine")
+        let tag = try store.createTag(named: "VIP")
+        try store.setMembership(of: contact, in: tag, isMember: true)
         let groups = try allGroups()
+        let tags = try allTags()
         let backup = ContactBackup.make(
             contacts: [contact],
             groups: groups,
+            tags: tags,
             savedSmartLists: [savedList],
             exportedAt: Date(timeIntervalSinceReferenceDate: 42)
         )
@@ -189,13 +215,14 @@ struct ContactBackupTests {
         #expect(preview.exportedAt == Date(timeIntervalSinceReferenceDate: 42))
         #expect(preview.contactCount == 1)
         #expect(preview.groupCount == 1)
+        #expect(preview.tagCount == 1)
         #expect(preview.savedSmartListCount == 1)
         #expect(preview.emailCount == 1)
         #expect(preview.phoneCount == 0)
         #expect(preview.historyNoteCount == 1)
         #expect(preview.photoCount == 1)
         #expect(preview.sampleContactNames == ["Ada Lovelace"])
-        #expect(preview.summary == "1 contact, 1 group, 1 smart list, 1 email, 1 history note, 1 photo")
+        #expect(preview.summary == "1 contact, 1 group, 1 tag, 1 smart list, 1 email, 1 history note, 1 photo")
     }
 
     @Test func emptyBackupPreviewHasAPlainSummary() {
@@ -203,6 +230,7 @@ struct ContactBackupTests {
 
         #expect(preview.contactCount == 0)
         #expect(preview.groupCount == 0)
+        #expect(preview.tagCount == 0)
         #expect(preview.savedSmartListCount == 0)
         #expect(preview.isEmpty)
         #expect(preview.sampleContactNames.isEmpty)

--- a/ContactManagerTests/ContactEntityQueryTests.swift
+++ b/ContactManagerTests/ContactEntityQueryTests.swift
@@ -23,7 +23,7 @@ final class ContactEntityQueryTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
-            ContactSavedSmartList.self,
+            ContactSavedSmartList.self, ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         // The query reads contacts from this process-wide handle.

--- a/ContactManagerTests/ContactHistoryTests.swift
+++ b/ContactManagerTests/ContactHistoryTests.swift
@@ -20,6 +20,7 @@ struct ContactHistoryTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/ContactModelTests.swift
+++ b/ContactManagerTests/ContactModelTests.swift
@@ -22,7 +22,7 @@ struct ContactModelTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
-            ContactSavedSmartList.self,
+            ContactSavedSmartList.self, ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
     }
@@ -75,6 +75,34 @@ struct ContactModelTests {
         #expect(try context.fetchCount(FetchDescriptor<Contact>()) == 1)
         #expect(try context.fetchCount(FetchDescriptor<ContactGroup>()) == 0)
         #expect(contact.groups.isEmpty)
+    }
+
+    @Test func contactTagMembershipIsTracked() throws {
+        let tag = ContactTag(name: "VIP")
+        let contact = Contact(firstName: "Ada", lastName: "Lovelace")
+        contact.tags = [tag]
+        context.insert(tag)
+        context.insert(contact)
+        try context.save()
+
+        #expect(tag.contacts.count == 1)
+        #expect(contact.tags.first?.name == "VIP")
+    }
+
+    @Test func deletingTagKeepsContactsButClearsMembership() throws {
+        let tag = ContactTag(name: "VIP")
+        let contact = Contact(firstName: "Ada", lastName: "Lovelace")
+        contact.tags = [tag]
+        context.insert(tag)
+        context.insert(contact)
+        try context.save()
+
+        context.delete(tag)
+        try context.save()
+
+        #expect(try context.fetchCount(FetchDescriptor<Contact>()) == 1)
+        #expect(try context.fetchCount(FetchDescriptor<ContactTag>()) == 0)
+        #expect(contact.tags.isEmpty)
     }
 
     @Test func deletingContactCascadesToItsFields() throws {

--- a/ContactManagerTests/ContactSavedSmartListTests.swift
+++ b/ContactManagerTests/ContactSavedSmartListTests.swift
@@ -1,0 +1,45 @@
+//
+//  ContactSavedSmartListTests.swift
+//  ContactManagerTests
+//
+//  Covers saved smart-list lifecycle mutations.
+//
+
+@testable import ContactManager
+import SwiftData
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct ContactSavedSmartListTests {
+    let container: ModelContainer
+    let store: ContactStore
+    var context: ModelContext { container.mainContext }
+
+    init() throws {
+        container = try ModelContainer(
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactSavedSmartList.self, ContactTag.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        store = ContactStore(container.mainContext)
+    }
+
+    private func count<T: PersistentModel>(_: T.Type) throws -> Int {
+        try context.fetchCount(FetchDescriptor<T>())
+    }
+
+    @Test func savedSmartListLifecycleTrimsQueryAndName() throws {
+        let savedList = try store.createSavedSmartList(named: "  Engine People  ", query: "  engine  ")
+
+        #expect(savedList.displayName == "Engine People")
+        #expect(savedList.query == "engine")
+        #expect(try count(ContactSavedSmartList.self) == 1)
+
+        try store.rename(savedList, to: "  Machines  ")
+        #expect(savedList.displayName == "Machines")
+
+        try store.delete(savedList)
+        #expect(try count(ContactSavedSmartList.self) == 0)
+    }
+}

--- a/ContactManagerTests/ContactStoreBatchTests.swift
+++ b/ContactManagerTests/ContactStoreBatchTests.swift
@@ -19,6 +19,7 @@ struct ContactStoreBatchTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)
@@ -57,6 +58,23 @@ struct ContactStoreBatchTests {
 
         #expect(added == 2)
         #expect(Set(group.contacts.map(\.persistentModelID)) == [
+            ada.persistentModelID,
+            alan.persistentModelID,
+            grace.persistentModelID,
+        ])
+    }
+
+    @Test func batchAssignAddsSelectedContactsToTag() throws {
+        let tag = try store.createTag(named: "VIP")
+        let ada = try store.createContact()
+        let alan = try store.createContact()
+        let grace = try store.createContact()
+        try store.setMembership(of: alan, in: tag, isMember: true)
+
+        let added = try store.addContacts([ada, alan, grace], to: tag)
+
+        #expect(added == 2)
+        #expect(Set(tag.contacts.map(\.persistentModelID)) == [
             ada.persistentModelID,
             alan.persistentModelID,
             grace.persistentModelID,

--- a/ContactManagerTests/ContactStorePendingEditTests.swift
+++ b/ContactManagerTests/ContactStorePendingEditTests.swift
@@ -19,6 +19,7 @@ struct ContactStorePendingEditTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/ContactStoreTests.swift
+++ b/ContactManagerTests/ContactStoreTests.swift
@@ -24,7 +24,7 @@ struct ContactStoreTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
-            ContactSavedSmartList.self,
+            ContactSavedSmartList.self, ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)
@@ -117,20 +117,6 @@ struct ContactStoreTests {
         let group = try store.createGroup(named: "Work")
         try store.rename(group, to: "   ")
         #expect(group.name == "Work")
-    }
-
-    @Test func savedSmartListLifecycleTrimsQueryAndName() throws {
-        let savedList = try store.createSavedSmartList(named: "  Engine People  ", query: "  engine  ")
-
-        #expect(savedList.displayName == "Engine People")
-        #expect(savedList.query == "engine")
-        #expect(try count(ContactSavedSmartList.self) == 1)
-
-        try store.rename(savedList, to: "  Machines  ")
-        #expect(savedList.displayName == "Machines")
-
-        try store.delete(savedList)
-        #expect(try count(ContactSavedSmartList.self) == 0)
     }
 
     // MARK: - Journey: set and clear a contact photo
@@ -245,22 +231,28 @@ struct ContactStoreTests {
         #expect(merged.company == "Analytical")
     }
 
-    @Test func mergeUnionsGroupsAndAdoptsMissingPhoto() throws {
+    @Test func mergeUnionsGroupsTagsAndAdoptsMissingPhoto() throws {
         let work = try store.createGroup(named: "Work")
         let friends = try store.createGroup(named: "Friends")
+        let vip = try store.createTag(named: "VIP")
+        let followUp = try store.createTag(named: "Follow Up")
 
         let primary = try store.createContact(in: work)
         primary.firstName = "Ada"
+        try store.setMembership(of: primary, in: vip, isMember: true)
         let other = try store.createContact(in: friends)
         other.firstName = "Ada"
+        try store.setMembership(of: other, in: followUp, isMember: true)
         try store.setPhotoData(Data([0x01, 0x02, 0x03]), on: other)
         try context.save()
 
         let merged = try store.merge([primary, other])
         #expect(Set(merged.groups.map(\.name)) == ["Work", "Friends"])
+        #expect(Set(merged.tags.map(\.name)) == ["VIP", "Follow Up"])
         #expect(merged.photoData != nil) // adopted from the other contact
         #expect(try count(Contact.self) == 1)
         #expect(try count(ContactGroup.self) == 2) // groups themselves survive
+        #expect(try count(ContactTag.self) == 2) // tags themselves survive
     }
 
     @Test func mergeDropsBlankFields() throws {

--- a/ContactManagerTests/ContactTagTests.swift
+++ b/ContactManagerTests/ContactTagTests.swift
@@ -1,0 +1,60 @@
+//
+//  ContactTagTests.swift
+//  ContactManagerTests
+//
+//  Covers tag lifecycle mutations.
+//
+
+@testable import ContactManager
+import SwiftData
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct ContactTagTests {
+    let container: ModelContainer
+    let store: ContactStore
+    var context: ModelContext { container.mainContext }
+
+    init() throws {
+        container = try ModelContainer(
+            for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactTag.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        store = ContactStore(container.mainContext)
+    }
+
+    private func count<T: PersistentModel>(_: T.Type) throws -> Int {
+        try context.fetchCount(FetchDescriptor<T>())
+    }
+
+    @Test func tagMembershipScopesContactsAndDeleteClearsIt() throws {
+        let tag = try store.createTag(named: "  VIP  ")
+        let ada = try store.createContact()
+        let alan = try store.createContact()
+
+        #expect(tag.displayName == "VIP")
+        try store.setMembership(of: ada, in: tag, isMember: true)
+        #expect(tag.contacts.map(\.persistentModelID) == [ada.persistentModelID])
+
+        // Toggling membership on again is a no-op (no duplicates).
+        try store.setMembership(of: ada, in: tag, isMember: true)
+        #expect(tag.contacts.count == 1)
+
+        try store.rename(tag, to: "  Priority  ")
+        #expect(tag.displayName == "Priority")
+
+        try store.delete(tag)
+        #expect(try count(ContactTag.self) == 0)
+        #expect(try count(Contact.self) == 2)
+        #expect(ada.tags.isEmpty)
+        #expect(alan.tags.isEmpty)
+    }
+
+    @Test func blankTagRenameIsIgnored() throws {
+        let tag = try store.createTag(named: "VIP")
+        try store.rename(tag, to: "   ")
+        #expect(tag.name == "VIP")
+    }
+}

--- a/ContactManagerTests/DefaultGroupPreferenceTests.swift
+++ b/ContactManagerTests/DefaultGroupPreferenceTests.swift
@@ -21,6 +21,7 @@ struct DefaultGroupPreferenceTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/GroupDropTests.swift
+++ b/ContactManagerTests/GroupDropTests.swift
@@ -3,7 +3,7 @@
 //  ContactManagerTests
 //
 //  Covers `ContactStore.addContacts(withEncodedIDs:to:)` — the data path
-//  behind dragging contacts from the list onto a sidebar group.
+//  behind dragging contacts from the list onto a sidebar group or tag.
 //
 
 @testable import ContactManager
@@ -20,6 +20,7 @@ struct GroupDropTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)
@@ -52,5 +53,16 @@ struct GroupDropTests {
     @Test func isANoOpForEmptyInput() throws {
         let group = try store.createGroup(named: "Work")
         #expect(try store.addContacts(withEncodedIDs: [], to: group) == 0)
+    }
+
+    @Test func addsDroppedContactsToTheTag() throws {
+        let tag = try store.createTag(named: "VIP")
+        let ada = try store.createContact()
+        let alan = try store.createContact()
+        let ids = try [ada, alan].map { try #require($0.persistentModelID.storedString) }
+
+        let added = try store.addContacts(withEncodedIDs: ids, to: tag)
+        #expect(added == 2)
+        #expect(Set(tag.contacts.map(\.persistentModelID)) == [ada.persistentModelID, alan.persistentModelID])
     }
 }

--- a/ContactManagerTests/ImportReviewTests.swift
+++ b/ContactManagerTests/ImportReviewTests.swift
@@ -21,6 +21,7 @@ struct ImportReviewTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/QuickCaptureTests.swift
+++ b/ContactManagerTests/QuickCaptureTests.swift
@@ -21,6 +21,7 @@ struct QuickCaptureTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/SpotlightDeltaTests.swift
+++ b/ContactManagerTests/SpotlightDeltaTests.swift
@@ -23,6 +23,7 @@ struct SpotlightDeltaTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         store = ContactStore(container.mainContext)

--- a/ContactManagerTests/UndoTests.swift
+++ b/ContactManagerTests/UndoTests.swift
@@ -22,6 +22,7 @@ struct UndoTests {
     init() throws {
         container = try ModelContainer(
             for: Contact.self, ContactField.self, ContactGroup.self, ContactInteraction.self,
+            ContactTag.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
         undoManager = UndoManager()


### PR DESCRIPTION
## Summary
Add first-class contact tags so users can label contacts independently of groups, filter by tag, and preserve tag organization across backup/restore.

## Changes
- Added the SwiftData ContactTag model and durable ContactStore mutations for tag create, rename, delete, membership, drag/drop, batch assignment, and merge preservation.
- Added sidebar tag navigation, detail-view membership toggles, batch Add to Tag actions, and command-palette entries.
- Extended JSON/encrypted backups and restore previews/results to include tags with legacy decode compatibility.
- Updated app/test schemas and added focused unit coverage for tag lifecycle, batch assignment, drag/drop, backup/restore, model relationships, and merge behavior.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - make check
  - make test

## Screenshots (if applicable)
Not applicable.

## Related Issues
Closes #