### PR TITLE
chore(workflow): add pre-pr review agent

### DIFF
--- a/.codex/agents/code-review.toml
+++ b/.codex/agents/code-review.toml
@@ -1,0 +1,41 @@
+# ContactManager code-review subagent.
+name = "code-review"
+description = "Review ContactManager changes before a PR is opened. Use after the implementation is staged/committed and before `gh pr create`; all actionable findings must be fixed and re-reviewed before opening the PR."
+sandbox_mode = "read-only"
+model_reasoning_effort = "high"
+developer_instructions = """
+You are the mandatory pre-PR code-review subagent for ContactManager.
+
+Review the proposed change as a senior Apple-platform engineer. Default to the
+current branch diff against `main`; if the caller explicitly asks for staged
+review, inspect the staged diff. Do not edit files. Do not run destructive
+commands. Use read-only commands such as `git diff`, `git status`, `rg`,
+`sed`, and targeted test-log inspection.
+
+Prioritize findings that could cause correctness bugs, data loss, migration
+failure, SwiftData/CloudKit incompatibility, broken undo/persistence behavior,
+privacy or App Store readiness issues, UI regressions, accessibility gaps, or
+missing tests for changed behavior. Also check repository-specific rules:
+- SwiftData non-optional scalars need inline defaults; to-many relationships
+  need `= []`; avoid `@Attribute(.unique)` and `.deny` delete rules.
+- User-initiated mutations should route through `ContactStore`, save/rollback
+  on failure, surface persistence errors, and preserve undo action names.
+- Views should stay thin; pure logic belongs in `Models/` or `Support/`.
+- New Swift files must be registered in the correct Xcode target.
+- Tests use Swift Testing, not XCTest, and changed behavior needs focused
+  coverage.
+- Keep unrelated local changes, generated junk, secrets, signing settings, and
+  personal configuration out of the PR.
+
+Output format:
+1. If there are findings, start with `Findings` and list them in descending
+   severity. Each finding must include a priority (`P0`-`P3`), file path and
+   line reference when available, the concrete risk, and a suggested fix.
+2. After findings, include `Open Questions` only if needed.
+3. If there are no actionable findings, say exactly:
+   `No actionable findings.`
+   Then add any residual risks or test gaps in one short paragraph.
+
+Do not pad the review with compliments or broad summaries. If you are uncertain,
+state the assumption clearly and explain the risk.
+"""

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+## Changes
+
+## Testing
+- [ ] Unit tests added/updated
+- [ ] Manual testing steps:
+- [ ] `code-review` subagent completed with no remaining actionable findings
+
+## Screenshots (if applicable)
+
+## Related Issues
+Closes #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ agents — keep it readable and idiomatic.
 | Test | `make test` (unit + UI) / `make test-unit` (unit only) |
 | Lint | `make lint` (autofix: `make lint-fix`) |
 | Format | `make format` (check only: `make format-check`) |
-| Pre-PR gate | `make check` (format-check + lint + unit tests) |
+| Pre-PR gate | `make check` + `code-review` subagent |
 | Install tooling | `make bootstrap` (runs `brew bundle`) |
 
 Tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`) — not XCTest.
@@ -88,7 +88,8 @@ pattern), then build to confirm it compiles.
 ## SwiftData
 
 - Top-level models are listed in the `Schema` built in `ContactManagerApp.loadContainer`:
-  `Contact`, `ContactField`, `ContactGroup`.
+  `Contact`, `ContactField`, `ContactGroup`, `ContactInteraction`, `ContactSavedSmartList`,
+  and `ContactTag`.
 - **Migration:** every new *non-optional scalar* attribute MUST have an inline default
   (e.g. `var city: String = ""`), or in-place migration fails (`NSCocoaError 134110`).
   Optional attributes and relationships migrate cleanly. Verify by launching against an
@@ -123,6 +124,12 @@ pattern), then build to confirm it compiles.
   without the UI (see "Code style").
 - **Review before every commit.** Run a code review over the staged diff and fix what it
   finds *before* committing — don't commit unreviewed code.
+- **Run the `code-review` subagent before every PR.** After the change is committed and
+  `make check` passes, spawn the repo-local `.codex/agents/code-review.toml` subagent
+  against the branch diff before `gh pr create`. If it reports any actionable finding
+  (`P0`-`P3`), fix it, rerun the relevant tests/checks, and run the subagent again.
+  Do not open the PR until the subagent returns `No actionable findings.` Record that
+  result in the PR checklist.
 - Ship focused, single-purpose PRs via the GitHub CLI (`gh`). Open the PR, let CI run, and
   **merge once all required checks pass.** Copilot review is no longer a gate — you don't
   need to request it or wait on it before merging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@
    ```shell
    make build       # unsigned compile gate
    make test        # unit + UI tests (Xcode)
-   make check       # format-check + lint + unit tests (pre-PR gate)
+   make check       # format-check + lint + unit tests
    ```
    Or open `ContactManager.xcodeproj` and press `Cmd + R`.
 
@@ -34,6 +34,9 @@ Optional iCloud sync setup is documented in the [README](README.md#icloud-sync-o
 
 - Branch per focused change; keep each PR scoped to one logical feature/fix/chore.
 - Write tests first (TDD) and run `make check` before committing.
+- Before opening a PR, run the repo-local `code-review` subagent on the branch
+  diff. Fix every actionable finding and rerun the subagent until it reports
+  `No actionable findings.`
 - Open a PR against `main` and **merge once all required checks pass** (Lint & Format +
   Build & Test). Copilot review isn't a gate — no need to request it or wait on it.
 - **Squash merge** and delete the branch; a successful merge auto-tags and publishes a release.

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ A `Makefile` wraps the common tasks (install tooling once with `make bootstrap`,
 | Test | `make test` (unit + UI) · `make test-unit` (unit only) |
 | Lint | `make lint` (autofix: `make lint-fix`) |
 | Format | `make format` (check only: `make format-check`) |
-| Pre-PR gate | `make check` (format-check + lint + unit tests) |
+| Pre-PR gate | `make check` + `code-review` subagent |
 
-Tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`); `make build`/`make test` disable code signing (compile + test gates — a signed build for distribution is done from Xcode), so they run identically locally and in CI. Linting and formatting are **SwiftLint** + **SwiftFormat**. CI (`.github/workflows/ci.yml`) runs two jobs on every PR: **Lint & Format** (`swiftformat --lint` + `swiftlint --strict`) and **Build & Test** (`make build` + `make test-unit` on a macOS 26 runner). The XCUITest smoke suite (`make test`) is run from Xcode, not CI. After CI passes on `main`, a **Release** workflow auto-bumps the version patch + build number, tags `v{version}`, and publishes a GitHub release with generated notes (bump the major/minor by hand when it's warranted). Contributor and agent conventions live in `AGENTS.md`.
+Tests use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`); `make build`/`make test` disable code signing (compile + test gates — a signed build for distribution is done from Xcode), so they run identically locally and in CI. Linting and formatting are **SwiftLint** + **SwiftFormat**. Before opening a PR, run `make check` and the repo-local `code-review` subagent; fix any actionable review findings and rerun it until it reports no remaining findings. CI (`.github/workflows/ci.yml`) runs two jobs on every PR: **Lint & Format** (`swiftformat --lint` + `swiftlint --strict`) and **Build & Test** (`make build` + `make test-unit` on a macOS 26 runner). The XCUITest smoke suite (`make test`) is run from Xcode, not CI. After CI passes on `main`, a **Release** workflow auto-bumps the version patch + build number, tags `v{version}`, and publishes a GitHub release with generated notes (bump the major/minor by hand when it's warranted). Contributor and agent conventions live in `AGENTS.md`.
 
 ### Building & Running
 


### PR DESCRIPTION
## Summary
Add a repo-local Codex code-review subagent and make it a mandatory pre-PR gate.

## Changes
- Added .codex/agents/code-review.toml with read-only senior-review instructions and strict findings/no-findings output.
- Added a pull request template with a code-review subagent checklist item.
- Updated AGENTS.md, CONTRIBUTING.md, and README.md so contributors and agents run the review subagent after make check and before gh pr create.
- Refreshed the AGENTS.md SwiftData model list while editing the guide.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - make check
  - git diff --cached --check
- [x] code-review subagent completed with no remaining actionable findings

## Screenshots (if applicable)
Not applicable.

## Related Issues
Closes #