### PR TITLE
feat(quick-capture): preserve labeled fields

### DIFF
--- a/ContactManager/Models/QuickCapture.swift
+++ b/ContactManager/Models/QuickCapture.swift
@@ -58,7 +58,7 @@ enum QuickCaptureParser {
 
     private static func apply(_ fragment: String, to draft: inout QuickCaptureDraft) {
         if let email = email(in: fragment) {
-            draft.emails.append((label: .home, value: email))
+            draft.emails.append(email)
             return
         }
 
@@ -113,39 +113,66 @@ enum QuickCaptureParser {
         }
     }
 
-    private static func email(in fragment: String) -> String? {
-        let tokens = fragment.split(separator: " ").map(String.init)
-        return tokens
+    private static func email(in fragment: String) -> (label: FieldLabel, value: String)? {
+        let field = labeledValue(in: fragment, kindWords: ["email", "mail"], defaultLabel: .home)
+        let tokens = field.value.split(separator: " ").map(String.init)
+        guard let value = (tokens
             .map { clean($0) }
             .first { token in
                 token.contains("@") && token.contains(".")
-            }
+            })
+        else { return nil }
+        return (label: field.label, value: value)
     }
 
     private static func phone(in fragment: String) -> (label: FieldLabel, value: String)? {
-        var value = fragment
-        let label = phoneLabel(in: fragment, value: &value)
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let field = labeledValue(
+            in: fragment,
+            kindWords: ["phone", "tel", "telephone", "number"],
+            defaultLabel: .mobile
+        )
+        let value = field.value.trimmingCharacters(in: .whitespacesAndNewlines)
         let digits = value.filter(\.isNumber)
         guard digits.count >= 7 else { return nil }
-        return (label: label, value: value)
+        return (label: field.label, value: value)
     }
 
-    private static func phoneLabel(in fragment: String, value: inout String) -> FieldLabel {
-        let prefixes: [(String, FieldLabel)] = [
-            ("mobile", .mobile),
-            ("cell", .mobile),
-            ("work", .work),
-            ("home", .home),
-            ("phone", .mobile),
-            ("tel", .mobile),
-        ]
-        let lower = fragment.lowercased()
-        for (prefix, label) in prefixes where lower.hasPrefix(prefix + " ") || lower == prefix {
-            value = String(fragment.dropFirst(prefix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
-            return label
+    private static func labeledValue(
+        in fragment: String,
+        kindWords: Set<String>,
+        defaultLabel: FieldLabel
+    ) -> (label: FieldLabel, value: String) {
+        var label = defaultLabel
+        var pieces = fragment.split(separator: " ").map(String.init)
+        while let first = pieces.first {
+            let token = clean(first).lowercased()
+            if let parsed = fieldLabel(token) {
+                label = parsed
+                pieces.removeFirst()
+            } else if kindWords.contains(token) {
+                pieces.removeFirst()
+            } else {
+                break
+            }
         }
-        return .mobile
+        return (label: label, value: pieces.joined(separator: " "))
+    }
+
+    private static func fieldLabel(_ token: String) -> FieldLabel? {
+        switch token {
+        case "home":
+            .home
+        case "work", "office":
+            .work
+        case "mobile", "cell", "cellular":
+            .mobile
+        case "main":
+            .main
+        case "other":
+            .other
+        default:
+            nil
+        }
     }
 
     private static func birthday(in fragment: String) -> Date? {

--- a/ContactManagerTests/QuickCaptureTests.swift
+++ b/ContactManagerTests/QuickCaptureTests.swift
@@ -55,6 +55,17 @@ struct QuickCaptureTests {
         #expect(draft.notes == "COBOL pioneer")
     }
 
+    @Test func parsesLabeledEmailAndPhoneFields() {
+        let draft = QuickCaptureParser.parse(
+            "Ada Lovelace, work email ada@example.com, home phone 555-0100"
+        )
+
+        #expect(draft.emails.map(\.value) == ["ada@example.com"])
+        #expect(draft.emails.first?.label == .work)
+        #expect(draft.phones.map(\.value) == ["555-0100"])
+        #expect(draft.phones.first?.label == .home)
+    }
+
     @Test func parsesNumericBirthdayWithYear() throws {
         let draft = QuickCaptureParser.parse("Katherine Johnson, birthday 1918-08-26")
 
@@ -80,5 +91,21 @@ struct QuickCaptureTests {
         #expect(contact.notes == "Enigma")
         #expect(try context.fetchCount(FetchDescriptor<Contact>()) == 1)
         #expect(try context.fetchCount(FetchDescriptor<ContactField>()) == 2)
+    }
+
+    @Test func createContactFromQuickCaptureDraftPreservesFieldLabels() throws {
+        let draft = QuickCaptureParser.parse(
+            "Katherine Johnson, work email katherine@example.com, home phone 555-0102"
+        )
+
+        let contact = try store.createContact(from: draft)
+
+        let email = try #require(contact.emails.first)
+        #expect(email.label == .work)
+        #expect(email.value == "katherine@example.com")
+
+        let phone = try #require(contact.phones.first)
+        #expect(phone.label == .home)
+        #expect(phone.value == "555-0102")
     }
 }


### PR DESCRIPTION
## Summary
Improve Quick Capture parsing so labeled email and phone prefixes are preserved when creating contacts.

## Changes
- Parse `work email`, `home phone`, and related label/kind prefixes before extracting field values.
- Preserve parsed labels through `ContactStore.createContact(from:)`.
- Add Swift Testing coverage for parser output and persisted field labels.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps: `make test-unit`; `make check`; pre-PR code review subagent reported no actionable findings

## Screenshots (if applicable)
Not applicable; parser/data-layer change only.

## Related Issues
Closes #