### PR TITLE
feat(quick-capture): assign groups and tags

### DIFF
--- a/ContactManager/Models/ContactStore+QuickCapture.swift
+++ b/ContactManager/Models/ContactStore+QuickCapture.swift
@@ -6,10 +6,15 @@
 //  Spotlight-notification pipeline as the rest of ContactStore.
 //
 
+import Foundation
+import SwiftData
+
 extension ContactStore {
     @discardableResult
     func createContact(from draft: QuickCaptureDraft) throws -> Contact {
         try mutate("Quick Capture") {
+            let groups = try groups(named: draft.groups)
+            let tags = try tags(named: draft.tags)
             let contact = Contact(
                 firstName: draft.firstName,
                 lastName: draft.lastName,
@@ -18,6 +23,8 @@ extension ContactStore {
                 birthday: draft.birthday,
                 notes: draft.notes
             )
+            contact.groups = groups
+            contact.tags = tags
             context.insert(contact)
             insert(draft.emails, kind: .email, into: contact)
             insert(draft.phones, kind: .phone, into: contact)
@@ -40,5 +47,54 @@ extension ContactStore {
             model.contact = contact
             context.insert(model)
         }
+    }
+
+    private func groups(named names: [String]) throws -> [ContactGroup] {
+        var existing = try context.fetch(FetchDescriptor<ContactGroup>())
+        return uniqueNames(names).compactMap { name in
+            namedModel(
+                name,
+                existing: &existing,
+                displayName: \.displayName
+            ) { ContactGroup(name: $0) }
+        }
+    }
+
+    private func tags(named names: [String]) throws -> [ContactTag] {
+        var existing = try context.fetch(FetchDescriptor<ContactTag>())
+        return uniqueNames(names).compactMap { name in
+            namedModel(
+                name,
+                existing: &existing,
+                displayName: \.displayName
+            ) { ContactTag(name: $0) }
+        }
+    }
+
+    private func uniqueNames(_ names: [String]) -> [String] {
+        var seen: Set<String> = []
+        return names.compactMap { name in
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            let normalized = trimmed.lowercased()
+            guard seen.insert(normalized).inserted else { return nil }
+            return trimmed
+        }
+    }
+
+    private func namedModel<Model: PersistentModel>(
+        _ name: String,
+        existing: inout [Model],
+        displayName: KeyPath<Model, String>,
+        create: (String) -> Model
+    ) -> Model? {
+        let normalized = name.lowercased()
+        if let match = existing.first(where: { $0[keyPath: displayName].lowercased() == normalized }) {
+            return match
+        }
+        let model = create(name)
+        existing.append(model)
+        context.insert(model)
+        return model
     }
 }

--- a/ContactManager/Models/QuickCapture.swift
+++ b/ContactManager/Models/QuickCapture.swift
@@ -5,7 +5,7 @@
 //  Pure parsing for the quick-entry window. It intentionally accepts a small,
 //  memorable grammar instead of trying to be a chatbot: comma/semicolon/newline
 //  fragments, obvious emails/phones, `birthday ...`, `at ...`, `title ...`,
-//  and `notes ...`.
+//  `tag ...`, `group ...`, and `notes ...`.
 //
 
 import Foundation
@@ -19,6 +19,8 @@ struct QuickCaptureDraft {
     var notes = ""
     var emails: [(label: FieldLabel, value: String)] = []
     var phones: [(label: FieldLabel, value: String)] = []
+    var tags: [String] = []
+    var groups: [String] = []
 
     var isEmpty: Bool {
         firstName.isBlank
@@ -29,6 +31,8 @@ struct QuickCaptureDraft {
             && notes.isBlank
             && emails.isEmpty
             && phones.isEmpty
+            && tags.isEmpty
+            && groups.isEmpty
     }
 
     var displayName: String {
@@ -79,6 +83,16 @@ enum QuickCaptureParser {
 
         if let value = value(in: fragment, after: ["company"]) {
             draft.company = value
+            return
+        }
+
+        if let value = value(in: fragment, after: ["tag", "tags"]) {
+            appendUnique(value, to: &draft.tags)
+            return
+        }
+
+        if let value = value(in: fragment, after: ["group", "groups"]) {
+            appendUnique(value, to: &draft.groups)
             return
         }
 
@@ -247,6 +261,14 @@ enum QuickCaptureParser {
         if existing.isBlank { return value }
         if value.isBlank { return existing }
         return "\(existing)\n\(value)"
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String]) {
+        let trimmed = clean(value)
+        guard !trimmed.isBlank else { return }
+        let normalized = trimmed.lowercased()
+        guard !values.contains(where: { $0.lowercased() == normalized }) else { return }
+        values.append(trimmed)
     }
 
     private static func clean(_ value: String) -> String {

--- a/ContactManagerTests/QuickCaptureTests.swift
+++ b/ContactManagerTests/QuickCaptureTests.swift
@@ -66,6 +66,15 @@ struct QuickCaptureTests {
         #expect(draft.phones.first?.label == .home)
     }
 
+    @Test func parsesTagsAndGroups() {
+        let draft = QuickCaptureParser.parse(
+            "Ada Lovelace, ada@example.com, tag VIP, group Work"
+        )
+
+        #expect(draft.tags == ["VIP"])
+        #expect(draft.groups == ["Work"])
+    }
+
     @Test func parsesNumericBirthdayWithYear() throws {
         let draft = QuickCaptureParser.parse("Katherine Johnson, birthday 1918-08-26")
 
@@ -107,5 +116,39 @@ struct QuickCaptureTests {
         let phone = try #require(contact.phones.first)
         #expect(phone.label == .home)
         #expect(phone.value == "555-0102")
+    }
+
+    @Test func createContactFromQuickCaptureDraftAssignsGroupsAndTags() throws {
+        let existingGroup = ContactGroup(name: "Work")
+        let existingTag = ContactTag(name: "VIP")
+        context.insert(existingGroup)
+        context.insert(existingTag)
+        try context.save()
+
+        let draft = QuickCaptureParser.parse(
+            "Hedy Lamarr, hedy@example.com, tag vip, group work"
+        )
+
+        let contact = try store.createContact(from: draft)
+
+        #expect(contact.groups.map(\.displayName) == ["Work"])
+        #expect(contact.tags.map(\.displayName) == ["VIP"])
+        #expect(existingGroup.contacts.map(\.fullName) == ["Hedy Lamarr"])
+        #expect(existingTag.contacts.map(\.fullName) == ["Hedy Lamarr"])
+        #expect(try context.fetchCount(FetchDescriptor<ContactGroup>()) == 1)
+        #expect(try context.fetchCount(FetchDescriptor<ContactTag>()) == 1)
+    }
+
+    @Test func createContactFromQuickCaptureDraftCreatesMissingGroupsAndTags() throws {
+        let draft = QuickCaptureParser.parse(
+            "Dorothy Vaughan, dorothy@example.com, tag VIP, group Work"
+        )
+
+        let contact = try store.createContact(from: draft)
+
+        #expect(contact.groups.map(\.displayName) == ["Work"])
+        #expect(contact.tags.map(\.displayName) == ["VIP"])
+        #expect(try context.fetchCount(FetchDescriptor<ContactGroup>()) == 1)
+        #expect(try context.fetchCount(FetchDescriptor<ContactTag>()) == 1)
     }
 }


### PR DESCRIPTION
## Summary
Add explicit group and tag support to Quick Capture so natural entries can organize contacts as they are created.

## Changes
- Parse `tag ...` / `tags ...` and `group ...` / `groups ...` fragments into `QuickCaptureDraft`.
- Persist parsed memberships through the existing `ContactStore.createContact(from:)` mutation.
- Reuse existing groups/tags case-insensitively, create missing ones, and dedupe repeated names.
- Add Swift Testing coverage for parsing, existing reuse, and missing group/tag creation.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps: confirmed TDD red before implementation; `make test-unit`; `make check`; pre-PR code review subagent feedback addressed and re-review reported no remaining actionable findings

## Screenshots (if applicable)
Not applicable; parser/data-layer change only.

## Related Issues
Closes #