### PR TITLE
feat(quick-capture): show parsed preview details

### DIFF
--- a/ContactManager/Views/QuickCaptureView.swift
+++ b/ContactManager/Views/QuickCaptureView.swift
@@ -95,28 +95,89 @@ private struct QuickCapturePreview: View {
                 .font(.headline)
                 .lineLimit(1)
                 .accessibilityIdentifier("quick-capture-preview-name")
-            HStack(spacing: 10) {
-                if let email = draft.emails.first?.value {
-                    Label(email, systemImage: "envelope")
+            ScrollView {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(previewItems, id: \.id) { item in
+                        HStack(spacing: 6) {
+                            Image(systemName: item.systemImage)
+                                .accessibilityHidden(true)
+                            Text(item.title)
+                                .lineLimit(1)
+                                .accessibilityIdentifier(item.accessibilityIdentifier)
+                        }
+                    }
                 }
-                if let phone = draft.phones.first?.value {
-                    Label(phone, systemImage: "phone")
-                }
-                if !draft.company.isBlank {
-                    Label(draft.company, systemImage: "building.2")
-                }
-                if let birthday = draft.birthday {
-                    Label(Birthday.formatted(birthday), systemImage: "gift")
-                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
             .font(.subheadline)
             .foregroundStyle(.secondary)
-            .lineLimit(1)
+            .frame(maxHeight: 120, alignment: .top)
+            .accessibilityLabel("Quick capture preview details")
             .accessibilityIdentifier("quick-capture-preview-details")
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 4)
     }
+
+    private var previewItems: [QuickCapturePreviewItem] {
+        var items: [QuickCapturePreviewItem] = []
+        if !draft.company.isBlank {
+            items.append(.init(
+                id: "company",
+                title: draft.company,
+                systemImage: "building.2",
+                accessibilityIdentifier: "quick-capture-preview-company"
+            ))
+        }
+        if let birthday = draft.birthday {
+            items.append(.init(
+                id: "birthday",
+                title: Birthday.formatted(birthday),
+                systemImage: "gift",
+                accessibilityIdentifier: "quick-capture-preview-birthday"
+            ))
+        }
+        items.append(contentsOf: draft.emails.enumerated().map { index, field in
+            .init(
+                id: "email-\(index)",
+                title: "\(field.label.title): \(field.value)",
+                systemImage: "envelope",
+                accessibilityIdentifier: "quick-capture-preview-email-\(index)"
+            )
+        })
+        items.append(contentsOf: draft.phones.enumerated().map { index, field in
+            .init(
+                id: "phone-\(index)",
+                title: "\(field.label.title): \(field.value)",
+                systemImage: "phone",
+                accessibilityIdentifier: "quick-capture-preview-phone-\(index)"
+            )
+        })
+        items.append(contentsOf: draft.tags.enumerated().map { index, tag in
+            .init(
+                id: "tag-\(index)",
+                title: tag,
+                systemImage: "tag",
+                accessibilityIdentifier: "quick-capture-preview-tag-\(index)"
+            )
+        })
+        items.append(contentsOf: draft.groups.enumerated().map { index, group in
+            .init(
+                id: "group-\(index)",
+                title: group,
+                systemImage: "folder",
+                accessibilityIdentifier: "quick-capture-preview-group-\(index)"
+            )
+        })
+        return items
+    }
+}
+
+private struct QuickCapturePreviewItem {
+    var id: String
+    var title: String
+    var systemImage: String
+    var accessibilityIdentifier: String
 }
 
 #Preview {

--- a/ContactManagerTests/QuickCaptureTests.swift
+++ b/ContactManagerTests/QuickCaptureTests.swift
@@ -66,6 +66,20 @@ struct QuickCaptureTests {
         #expect(draft.phones.first?.label == .home)
     }
 
+    @Test func parsesMultiplePreviewDetailKinds() {
+        let draft = QuickCaptureParser.parse(
+            "Ada Lovelace, home email ada@example.com, work email ada@work.example, " +
+                "mobile 555-0101, home phone 555-0102, tag VIP, group Work"
+        )
+
+        #expect(draft.emails.map(\.value) == ["ada@example.com", "ada@work.example"])
+        #expect(draft.emails.map(\.label) == [.home, .work])
+        #expect(draft.phones.map(\.value) == ["555-0101", "555-0102"])
+        #expect(draft.phones.map(\.label) == [.mobile, .home])
+        #expect(draft.tags == ["VIP"])
+        #expect(draft.groups == ["Work"])
+    }
+
     @Test func parsesTagsAndGroups() {
         let draft = QuickCaptureParser.parse(
             "Ada Lovelace, ada@example.com, tag VIP, group Work"

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -185,6 +185,44 @@ final class ContactManagerUITests: XCTestCase {
         )
     }
 
+    /// Verifies the quick-capture preview renders all parsed detail kinds
+    /// before saving, so users can trust what the one-line parser understood.
+    func test_quickCapturePreviewShowsParsedDetails() {
+        let app = bootSeededApp()
+        app.typeKey("n", modifierFlags: [.command, .option])
+
+        let entry = app.textFields["quick-capture-entry-field"]
+        XCTAssertTrue(entry.waitForExistence(timeout: 3))
+        entry.click()
+        entry.typeText(
+            "Preview Person, home email home@example.com, work email work@example.com, " +
+                "mobile 555-0101, home phone 555-0102, tag VIP, group Friends"
+        )
+
+        let details = app.descendants(matching: .any)["quick-capture-preview-details"]
+        XCTAssertTrue(details.waitForExistence(timeout: 3))
+
+        let expectedRows = [
+            ("quick-capture-preview-email-0", "Home: home@example.com"),
+            ("quick-capture-preview-email-1", "Work: work@example.com"),
+            ("quick-capture-preview-phone-0", "Mobile: 555-0101"),
+            ("quick-capture-preview-phone-1", "Home: 555-0102"),
+            ("quick-capture-preview-tag-0", "VIP"),
+            ("quick-capture-preview-group-0", "Friends"),
+        ]
+        for (identifier, expectedText) in expectedRows {
+            let row = app.descendants(matching: .any)[identifier]
+            XCTAssertTrue(row.waitForExistence(timeout: 3), "\(identifier) should render")
+            let accessibleText = [row.label, row.value as? String ?? ""]
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+            XCTAssertTrue(
+                accessibleText.contains(expectedText),
+                "\(identifier) should contain \(expectedText); got \(accessibleText)"
+            )
+        }
+    }
+
     // MARK: - Helpers
 
     /// Launches a fresh app instance with the seeded UI-test container.


### PR DESCRIPTION
## Summary
Improve the Quick Capture preview so it shows every parsed email, phone, tag, and group before saving instead of only the first email/phone summary.

## Changes
- Render parsed quick-capture details as row-level preview items with SF Symbol affordances.
- Keep the preview compact with a capped scroll area for longer parsed entries.
- Add stable accessibility identifiers for each parsed preview row.
- Add parser coverage for multi-detail quick-capture input.
- Add UI coverage proving the preview exposes all parsed detail rows before create.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - make check
  - xcodebuild test -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:ContactManagerUITests/ContactManagerUITests/test_quickCapturePreviewShowsParsedDetails
  - xcodebuild test -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:ContactManagerUITests
  - Pre-commit code review subagent completed with no actionable findings

## Screenshots (if applicable)
N/A

## Related Issues
None