### PR TITLE
feat(quick-capture): show parse feedback

### DIFF
--- a/ContactManager/Models/QuickCapture.swift
+++ b/ContactManager/Models/QuickCapture.swift
@@ -21,6 +21,7 @@ struct QuickCaptureDraft {
     var phones: [(label: FieldLabel, value: String)] = []
     var tags: [String] = []
     var groups: [String] = []
+    var parseWarnings: [String] = []
 
     var isEmpty: Bool {
         firstName.isBlank
@@ -61,38 +62,20 @@ enum QuickCaptureParser {
     }
 
     private static func apply(_ fragment: String, to draft: inout QuickCaptureDraft) {
+        if applyEmailFragment(fragment, to: &draft) {
+            return
+        }
+
+        if applyPrefixedFragment(fragment, to: &draft) {
+            return
+        }
+
+        if applyPhoneFragment(fragment, to: &draft) {
+            return
+        }
+
         if let email = email(in: fragment) {
             draft.emails.append(email)
-            return
-        }
-
-        if let birthday = birthday(in: fragment) {
-            draft.birthday = birthday
-            return
-        }
-
-        if let value = value(in: fragment, after: ["notes", "note"]) {
-            draft.notes = append(draft.notes, value)
-            return
-        }
-
-        if let value = value(in: fragment, after: ["title", "role"]) {
-            draft.jobTitle = value
-            return
-        }
-
-        if let value = value(in: fragment, after: ["company"]) {
-            draft.company = value
-            return
-        }
-
-        if let value = value(in: fragment, after: ["tag", "tags"]) {
-            appendUnique(value, to: &draft.tags)
-            return
-        }
-
-        if let value = value(in: fragment, after: ["group", "groups"]) {
-            appendUnique(value, to: &draft.groups)
             return
         }
 
@@ -104,6 +87,82 @@ enum QuickCaptureParser {
         applyNameAndCompany(fragment, to: &draft)
     }
 
+    private static func applyEmailFragment(_ fragment: String, to draft: inout QuickCaptureDraft) -> Bool {
+        guard hasKindWord(in: fragment, kindWords: ["email", "mail"], defaultLabel: .home) else {
+            return false
+        }
+        if let email = email(in: fragment) {
+            draft.emails.append(email)
+        } else if let warning = invalidFieldWarning(
+            in: fragment,
+            kindWords: ["email", "mail"],
+            fieldName: "email",
+            defaultLabel: .home
+        ) {
+            draft.parseWarnings.append(warning)
+        }
+        return true
+    }
+
+    private static func applyPrefixedFragment(_ fragment: String, to draft: inout QuickCaptureDraft) -> Bool {
+        if let value = value(in: fragment, after: ["birthday", "bday", "born"]) {
+            applyBirthday(value, fallback: fragment, to: &draft)
+            return true
+        }
+        if let value = value(in: fragment, after: ["notes", "note"]) {
+            if let value = nonBlank(value, emptyWarning: "Ignored empty note", warnings: &draft.parseWarnings) {
+                draft.notes = append(draft.notes, value)
+            }
+            return true
+        }
+        if let value = value(in: fragment, after: ["title", "role"]) {
+            if let value = nonBlank(value, emptyWarning: "Ignored empty title", warnings: &draft.parseWarnings) {
+                draft.jobTitle = value
+            }
+            return true
+        }
+        if let value = value(in: fragment, after: ["company"]) {
+            if let value = nonBlank(value, emptyWarning: "Ignored empty company", warnings: &draft.parseWarnings) {
+                draft.company = value
+            }
+            return true
+        }
+        if let value = value(in: fragment, after: ["tag", "tags"]) {
+            let tag = nonBlank(value, emptyWarning: "Ignored empty tag", warnings: &draft.parseWarnings)
+            appendUnique(tag, to: &draft.tags)
+            return true
+        }
+        if let value = value(in: fragment, after: ["group", "groups"]) {
+            let group = nonBlank(value, emptyWarning: "Ignored empty group", warnings: &draft.parseWarnings)
+            appendUnique(group, to: &draft.groups)
+            return true
+        }
+        return false
+    }
+
+    private static func applyPhoneFragment(_ fragment: String, to draft: inout QuickCaptureDraft) -> Bool {
+        guard hasKindWord(
+            in: fragment,
+            kindWords: ["phone", "tel", "telephone", "number"],
+            defaultLabel: .mobile
+        ) else {
+            return false
+        }
+        if let phone = phone(in: fragment) {
+            draft.phones.append(phone)
+        } else if let warning = invalidFieldWarning(
+            in: fragment,
+            kindWords: ["phone", "tel", "telephone", "number"],
+            fieldName: "phone",
+            defaultLabel: .mobile
+        ) {
+            draft.parseWarnings.append(warning)
+        }
+        return true
+    }
+}
+
+private extension QuickCaptureParser {
     private static func applyNameAndCompany(_ fragment: String, to draft: inout QuickCaptureDraft) {
         let pieces = fragment.components(separatedBy: " at ")
         let name = pieces[0].trimmingCharacters(in: .whitespacesAndNewlines)
@@ -155,8 +214,9 @@ enum QuickCaptureParser {
         in fragment: String,
         kindWords: Set<String>,
         defaultLabel: FieldLabel
-    ) -> (label: FieldLabel, value: String) {
+    ) -> LabeledValue {
         var label = defaultLabel
+        var hasKindWord = false
         var pieces = fragment.split(separator: " ").map(String.init)
         while let first = pieces.first {
             let token = clean(first).lowercased()
@@ -164,12 +224,17 @@ enum QuickCaptureParser {
                 label = parsed
                 pieces.removeFirst()
             } else if kindWords.contains(token) {
+                hasKindWord = true
                 pieces.removeFirst()
             } else {
                 break
             }
         }
-        return (label: label, value: pieces.joined(separator: " "))
+        return LabeledValue(
+            label: label,
+            value: pieces.joined(separator: " "),
+            hasKindWord: hasKindWord
+        )
     }
 
     private static func fieldLabel(_ token: String) -> FieldLabel? {
@@ -187,13 +252,6 @@ enum QuickCaptureParser {
         default:
             nil
         }
-    }
-
-    private static func birthday(in fragment: String) -> Date? {
-        guard let value = value(in: fragment, after: ["birthday", "bday", "born"]) else {
-            return nil
-        }
-        return parseBirthday(value)
     }
 
     private static func parseBirthday(_ value: String) -> Date? {
@@ -229,6 +287,26 @@ enum QuickCaptureParser {
         else { return nil }
         let year = tokens.count >= 3 ? Int(tokens[2].filter(\.isNumber)) : nil
         return Birthday.date(year: year, month: month, day: day)
+    }
+
+    private static func invalidFieldWarning(
+        in fragment: String,
+        kindWords: Set<String>,
+        fieldName: String,
+        defaultLabel: FieldLabel
+    ) -> String? {
+        let field = labeledValue(in: fragment, kindWords: kindWords, defaultLabel: defaultLabel)
+        guard field.hasKindWord else { return nil }
+        if field.value.isBlank { return "Ignored empty \(fieldName)" }
+        return "Ignored \(fieldName): \(field.value)"
+    }
+
+    private static func hasKindWord(
+        in fragment: String,
+        kindWords: Set<String>,
+        defaultLabel: FieldLabel
+    ) -> Bool {
+        labeledValue(in: fragment, kindWords: kindWords, defaultLabel: defaultLabel).hasKindWord
     }
 
     private static func monthNumber(_ token: String) -> Int? {
@@ -271,7 +349,39 @@ enum QuickCaptureParser {
         values.append(trimmed)
     }
 
+    private static func appendUnique(_ value: String?, to values: inout [String]) {
+        guard let value else { return }
+        appendUnique(value, to: &values)
+    }
+
+    private static func applyBirthday(_ value: String, fallback: String, to draft: inout QuickCaptureDraft) {
+        if let birthday = parseBirthday(value) {
+            draft.birthday = birthday
+        } else {
+            draft.parseWarnings.append("Couldn't parse birthday: \(warningValue(value, fallback: fallback))")
+        }
+    }
+
+    private static func nonBlank(_ value: String, emptyWarning: String, warnings: inout [String]) -> String? {
+        if value.isBlank {
+            warnings.append(emptyWarning)
+            return nil
+        }
+        return value
+    }
+
+    private static func warningValue(_ value: String, fallback: String) -> String {
+        let trimmed = clean(value)
+        return trimmed.isBlank ? clean(fallback) : trimmed
+    }
+
     private static func clean(_ value: String) -> String {
         value.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines.union(.punctuationCharacters))
     }
+}
+
+private struct LabeledValue {
+    var label: FieldLabel
+    var value: String
+    var hasKindWord: Bool
 }

--- a/ContactManager/Views/QuickCaptureView.swift
+++ b/ContactManager/Views/QuickCaptureView.swift
@@ -34,6 +34,7 @@ struct QuickCaptureView: View {
                 .onSubmit(createContact)
 
             QuickCapturePreview(draft: draft)
+            QuickCaptureWarnings(warnings: draft.parseWarnings)
 
             HStack {
                 if let createdMessage {
@@ -87,6 +88,8 @@ struct QuickCaptureView: View {
 }
 
 private struct QuickCapturePreview: View {
+    private let maxVisiblePreviewItems = 6
+
     var draft: QuickCaptureDraft
 
     var body: some View {
@@ -95,28 +98,37 @@ private struct QuickCapturePreview: View {
                 .font(.headline)
                 .lineLimit(1)
                 .accessibilityIdentifier("quick-capture-preview-name")
-            ScrollView {
-                VStack(alignment: .leading, spacing: 4) {
-                    ForEach(previewItems, id: \.id) { item in
-                        HStack(spacing: 6) {
-                            Image(systemName: item.systemImage)
-                                .accessibilityHidden(true)
-                            Text(item.title)
-                                .lineLimit(1)
-                                .accessibilityIdentifier(item.accessibilityIdentifier)
-                        }
-                    }
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(visiblePreviewItems, id: \.id) { item in
+                    QuickCapturePreviewRow(item: item)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                if overflowCount > 0 {
+                    HStack(spacing: 6) {
+                        Image(systemName: "ellipsis.circle")
+                            .accessibilityHidden(true)
+                        Text("+\(overflowCount) more")
+                            .lineLimit(1)
+                    }
+                    .accessibilityLabel("+\(overflowCount) more")
+                    .accessibilityIdentifier("quick-capture-preview-overflow")
+                }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .font(.subheadline)
             .foregroundStyle(.secondary)
-            .frame(maxHeight: 120, alignment: .top)
-            .accessibilityLabel("Quick capture preview details")
+            .accessibilityElement(children: .contain)
             .accessibilityIdentifier("quick-capture-preview-details")
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 4)
+    }
+
+    private var visiblePreviewItems: [QuickCapturePreviewItem] {
+        Array(previewItems.prefix(maxVisiblePreviewItems))
+    }
+
+    private var overflowCount: Int {
+        max(0, previewItems.count - maxVisiblePreviewItems)
     }
 
     private var previewItems: [QuickCapturePreviewItem] {
@@ -178,6 +190,67 @@ private struct QuickCapturePreviewItem {
     var title: String
     var systemImage: String
     var accessibilityIdentifier: String
+}
+
+private struct QuickCapturePreviewRow: View {
+    var item: QuickCapturePreviewItem
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: item.systemImage)
+                .accessibilityHidden(true)
+            Text(item.title)
+                .lineLimit(1)
+        }
+        .accessibilityLabel(item.title)
+        .accessibilityIdentifier(item.accessibilityIdentifier)
+    }
+}
+
+private struct QuickCaptureWarnings: View {
+    private let maxVisibleWarnings = 3
+
+    var warnings: [String]
+
+    var body: some View {
+        if !warnings.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(visibleWarnings.enumerated()), id: \.offset) { index, warning in
+                    HStack(spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .accessibilityHidden(true)
+                        Text(warning)
+                            .lineLimit(1)
+                    }
+                    .accessibilityLabel(warning)
+                    .accessibilityIdentifier("quick-capture-warning-\(index)")
+                }
+                if overflowCount > 0 {
+                    HStack(spacing: 6) {
+                        Image(systemName: "ellipsis.circle")
+                            .accessibilityHidden(true)
+                        Text("+\(overflowCount) more warnings")
+                            .lineLimit(1)
+                    }
+                    .accessibilityLabel("+\(overflowCount) more warnings")
+                    .accessibilityIdentifier("quick-capture-warning-overflow")
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.orange)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier("quick-capture-warnings")
+        }
+    }
+
+    private var visibleWarnings: [String] {
+        Array(warnings.prefix(maxVisibleWarnings))
+    }
+
+    private var overflowCount: Int {
+        max(0, warnings.count - maxVisibleWarnings)
+    }
 }
 
 #Preview {

--- a/ContactManagerTests/QuickCaptureTests.swift
+++ b/ContactManagerTests/QuickCaptureTests.swift
@@ -89,6 +89,36 @@ struct QuickCaptureTests {
         #expect(draft.groups == ["Work"])
     }
 
+    @Test func warnsAboutInvalidPrefixedFragments() {
+        let draft = QuickCaptureParser.parse(
+            "Ada Lovelace, birthday someday, email nope, phone 12, tag"
+        )
+
+        #expect(draft.birthday == nil)
+        #expect(draft.emails.isEmpty)
+        #expect(draft.phones.isEmpty)
+        #expect(draft.tags.isEmpty)
+        #expect(draft.parseWarnings == [
+            "Couldn't parse birthday: someday",
+            "Ignored email: nope",
+            "Ignored phone: 12",
+            "Ignored empty tag",
+        ])
+    }
+
+    @Test func explicitFieldKindsDoNotFallThroughToOtherParsers() {
+        let draft = QuickCaptureParser.parse(
+            "Ada Lovelace, email 555-0101, phone ada@example.com"
+        )
+
+        #expect(draft.emails.isEmpty)
+        #expect(draft.phones.isEmpty)
+        #expect(draft.parseWarnings == [
+            "Ignored email: 555-0101",
+            "Ignored phone: ada@example.com",
+        ])
+    }
+
     @Test func parsesNumericBirthdayWithYear() throws {
         let draft = QuickCaptureParser.parse("Katherine Johnson, birthday 1918-08-26")
 

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -223,6 +223,36 @@ final class ContactManagerUITests: XCTestCase {
         }
     }
 
+    /// Verifies long quick-capture input stays compact and surfaces
+    /// parse feedback before saving.
+    func test_quickCapturePreviewShowsWarningsAndOverflow() {
+        let app = bootSeededApp()
+        app.typeKey("n", modifierFlags: [.command, .option])
+
+        let entry = app.textFields["quick-capture-entry-field"]
+        XCTAssertTrue(entry.waitForExistence(timeout: 3))
+        entry.click()
+        entry.typeText(
+            "Overflow Person, home email one@example.com, work email two@example.com, " +
+                "mobile 555-0101, home phone 555-0102, tag VIP, tag Team, " +
+                "group Friends, group Family, email nope"
+        )
+
+        let warning = app.descendants(matching: .any)["quick-capture-warning-0"]
+        XCTAssertTrue(warning.waitForExistence(timeout: 3))
+        let warningText = [warning.label, warning.value as? String ?? ""]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        XCTAssertTrue(warningText.contains("Ignored email: nope"))
+
+        let overflow = app.descendants(matching: .any)["quick-capture-preview-overflow"]
+        XCTAssertTrue(overflow.waitForExistence(timeout: 3))
+        let overflowText = [overflow.label, overflow.value as? String ?? ""]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        XCTAssertTrue(overflowText.contains("+2 more"))
+    }
+
     // MARK: - Helpers
 
     /// Launches a fresh app instance with the seeded UI-test container.


### PR DESCRIPTION
## Summary
Adds parser feedback and compact overflow handling to Quick Capture so users can see invalid fragments before creating a contact.

## Changes
- Track quick-capture parse warnings for invalid explicit email, phone, birthday, and empty prefixed fragments.
- Keep explicit email/phone fragments owned by their declared field kind so they do not fall through to the wrong parser.
- Replace the scrolling preview list with a capped preview plus a +N more overflow row.
- Add warning rows with stable accessibility identifiers.
- Add unit coverage for invalid fragments and cross-kind parser ownership.
- Add UI smoke coverage for warning and overflow rendering.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - make check
  - xcodebuild test -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:ContactManagerUITests
- Code review subagent re-review: no remaining actionable issues.

## Screenshots (if applicable)
Not applicable.

## Related Issues
None