### PR TITLE
feat(quick-capture): add duplicate awareness

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		E11A07680CCF44C864B95662 /* ContentView+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C8E57A2BB1F32050119C06 /* ContentView+Backup.swift */; };
 		E25066845A3200CDD0F2979E /* ContactIntentResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114AC8779AF104227C34C18C /* ContactIntentResolver.swift */; };
 		E5EB465B5CE3964197D29ADF /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F82C8A388E97CC4F1106176 /* SampleData.swift */; };
+		EBB44EB6D2563E1407989522 /* QuickCaptureMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE23F835008276E4DEDC486B /* QuickCaptureMatcher.swift */; };
 		ECB7FDD8D0C3091EA0D42917 /* UndoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DCAF444714BC3726B212C4 /* UndoTests.swift */; };
 		ECDA4BC68D3FAE4CCF428675 /* ContactDetailView+Saving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92613887B145F037F1E3AB58 /* ContactDetailView+Saving.swift */; };
 		F6F24513C06A755D761B5008 /* ContactStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355894A3A1D1AA4B8E238E64 /* ContactStoreError.swift */; };
@@ -234,6 +235,7 @@
 		A7276D515CA167FBF4C47299 /* VCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCard.swift; sourceTree = "<group>"; };
 		ABDED82FFB4B5F039052FFB5 /* Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Birthday.swift; sourceTree = "<group>"; };
 		AC2AA1D7BB15FC01B9CBA3B3 /* EntityModelContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityModelContainer.swift; sourceTree = "<group>"; };
+		AE23F835008276E4DEDC486B /* QuickCaptureMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickCaptureMatcher.swift; path = ContactManager/Models/QuickCaptureMatcher.swift; sourceTree = "<group>"; };
 		B033A5B8DABE71E4CCF6A8E9 /* VCardTransfer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VCardTransfer.swift; sourceTree = "<group>"; };
 		B040B21B7E2002E00885A9BA /* BirthdayTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BirthdayTests.swift; sourceTree = "<group>"; };
 		B0CF4C47C670B0A8C3B6B384 /* ContactActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactActivity.swift; sourceTree = "<group>"; };
@@ -425,6 +427,7 @@
 				5951D4D8D52B6CDB782FE37D /* QuickCaptureView.swift */,
 				A2C76A783B91BD2AA6D3F70B /* QuickCaptureTests.swift */,
 				0401F25DFDF91CE847706D08 /* ContentView+Alerts.swift */,
+				AE23F835008276E4DEDC486B /* QuickCaptureMatcher.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -712,6 +715,7 @@
 				B7BFE97538D99B970A512F5D /* ContactStore+Tags.swift in Sources */,
 				49951835ECDD188314B2D263 /* ContentView+Groups.swift in Sources */,
 				0DDC7707A54114378AB0E1E0 /* ContentView+Tags.swift in Sources */,
+				EBB44EB6D2563E1407989522 /* QuickCaptureMatcher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Models/ContactStore+QuickCapture.swift
+++ b/ContactManager/Models/ContactStore+QuickCapture.swift
@@ -32,6 +32,25 @@ extension ContactStore {
         }
     }
 
+    func updateContact(_ contact: Contact, from draft: QuickCaptureDraft) throws {
+        try mutate("Quick Capture Update") {
+            fillEmptyScalars(of: contact, from: draft)
+            try adoptGroups(named: draft.groups, into: contact)
+            try adoptTags(named: draft.tags, into: contact)
+            insertMissing(draft.emails, kind: .email, into: contact)
+            insertMissing(draft.phones, kind: .phone, into: contact)
+        }
+    }
+
+    private func fillEmptyScalars(of contact: Contact, from draft: QuickCaptureDraft) {
+        if contact.firstName.isBlank { contact.firstName = draft.firstName }
+        if contact.lastName.isBlank { contact.lastName = draft.lastName }
+        if contact.company.isBlank { contact.company = draft.company }
+        if contact.jobTitle.isBlank { contact.jobTitle = draft.jobTitle }
+        if contact.notes.isBlank { contact.notes = draft.notes }
+        if contact.birthday == nil { contact.birthday = draft.birthday }
+    }
+
     private func insert(
         _ fields: [(label: FieldLabel, value: String)],
         kind: FieldKind,
@@ -46,6 +65,53 @@ extension ContactStore {
             )
             model.contact = contact
             context.insert(model)
+        }
+    }
+
+    private func insertMissing(
+        _ fields: [(label: FieldLabel, value: String)],
+        kind: FieldKind,
+        into contact: Contact
+    ) {
+        var existing = Set(contact.fields(of: kind).map { normalized($0.value, kind: kind) })
+        var nextIndex = (contact.fields(of: kind).map(\.sortIndex).max() ?? -1) + 1
+
+        for field in fields where !field.value.isBlank {
+            let normalizedValue = normalized(field.value, kind: kind)
+            guard !normalizedValue.isEmpty, existing.insert(normalizedValue).inserted else { continue }
+
+            let model = ContactField(
+                kind: kind,
+                label: field.label,
+                value: field.value,
+                sortIndex: nextIndex
+            )
+            nextIndex += 1
+            model.contact = contact
+            context.insert(model)
+        }
+    }
+
+    private func adoptGroups(named names: [String], into contact: Contact) throws {
+        var existingIDs = Set(contact.groups.map(\.persistentModelID))
+        for group in try groups(named: names) where existingIDs.insert(group.persistentModelID).inserted {
+            contact.groups.append(group)
+        }
+    }
+
+    private func adoptTags(named names: [String], into contact: Contact) throws {
+        var existingIDs = Set(contact.tags.map(\.persistentModelID))
+        for tag in try tags(named: names) where existingIDs.insert(tag.persistentModelID).inserted {
+            contact.tags.append(tag)
+        }
+    }
+
+    private func normalized(_ value: String, kind: FieldKind) -> String {
+        switch kind {
+        case .email:
+            value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        case .phone:
+            String(value.filter(\.isNumber))
         }
     }
 

--- a/ContactManager/Models/ImportReview.swift
+++ b/ContactManager/Models/ImportReview.swift
@@ -143,7 +143,7 @@ extension ContactMatchKey {
     }
 }
 
-private extension ContactMatchKey {
+extension ContactMatchKey {
     var isStrongMatch: Bool {
         isEmail || isPhone
     }

--- a/ContactManager/Models/QuickCaptureMatcher.swift
+++ b/ContactManager/Models/QuickCaptureMatcher.swift
@@ -1,0 +1,86 @@
+//
+//  QuickCaptureMatcher.swift
+//  ContactManager
+//
+//  Duplicate awareness for Quick Capture. It shares normalized identity keys
+//  with import review and duplicate finding so those flows agree on matches.
+//
+
+import Foundation
+
+struct QuickCaptureMatch {
+    var contact: Contact
+    var confidence: ImportMatchConfidence
+    var reason: String
+}
+
+enum QuickCaptureMatcher {
+    static func bestMatch(for draft: QuickCaptureDraft, in contacts: [Contact]) -> QuickCaptureMatch? {
+        guard !draft.isEmpty else { return nil }
+
+        let draftKeys = ContactMatchKey.keys(for: draft)
+        if let match = strongMatch(for: draftKeys, in: contacts) {
+            return match
+        }
+
+        return nameMatch(for: draft, in: contacts)
+    }
+
+    private static func strongMatch(
+        for draftKeys: Set<ContactMatchKey>,
+        in contacts: [Contact]
+    ) -> QuickCaptureMatch? {
+        guard !draftKeys.isEmpty else { return nil }
+
+        for contact in ContactQuery.sorted(contacts) {
+            let sharedKeys = DuplicateFinder.matchKeys(for: contact).intersection(draftKeys)
+            if sharedKeys.contains(where: \.isEmail) {
+                return QuickCaptureMatch(contact: contact, confidence: .likely, reason: "same email")
+            }
+            if sharedKeys.contains(where: \.isPhone) {
+                return QuickCaptureMatch(contact: contact, confidence: .likely, reason: "same phone")
+            }
+        }
+
+        return nil
+    }
+
+    private static func nameMatch(for draft: QuickCaptureDraft, in contacts: [Contact]) -> QuickCaptureMatch? {
+        let draftTokens = nameTokens(firstName: draft.firstName, lastName: draft.lastName)
+        guard !draftTokens.isEmpty else { return nil }
+
+        for contact in ContactQuery.sorted(contacts) {
+            let contactTokens = nameTokens(firstName: contact.firstName, lastName: contact.lastName)
+            if !contactTokens.isEmpty, draftTokens.isSubset(of: contactTokens) {
+                return QuickCaptureMatch(contact: contact, confidence: .possible, reason: "similar name")
+            }
+        }
+
+        return nil
+    }
+
+    private static func nameTokens(firstName: String, lastName: String) -> Set<String> {
+        let rawName = [firstName, lastName]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        return Set(
+            rawName
+                .split { !$0.isLetter && !$0.isNumber }
+                .map(String.init)
+                .filter { $0.count >= 3 }
+        )
+    }
+}
+
+extension ContactMatchKey {
+    static func keys(for draft: QuickCaptureDraft) -> Set<ContactMatchKey> {
+        keys(
+            firstName: draft.firstName,
+            lastName: draft.lastName,
+            emails: draft.emails.map(\.value),
+            phones: draft.phones.map(\.value)
+        )
+    }
+}

--- a/ContactManager/Views/QuickCaptureView.swift
+++ b/ContactManager/Views/QuickCaptureView.swift
@@ -13,12 +13,22 @@ struct QuickCaptureView: View {
     @Environment(\.modelContext) private var context
     @FocusState private var entryFocused: Bool
 
+    @Query private var contacts: [Contact]
+
     @State private var entry = ""
     @State private var errorMessage: String?
     @State private var createdMessage: String?
 
     private var draft: QuickCaptureDraft {
         QuickCaptureParser.parse(entry)
+    }
+
+    private var match: QuickCaptureMatch? {
+        QuickCaptureMatcher.bestMatch(for: draft, in: contacts)
+    }
+
+    private var canUpdateWithReturn: Bool {
+        match?.confidence == .likely || match?.confidence == .exact
     }
 
     private var store: ContactStore {
@@ -31,10 +41,13 @@ struct QuickCaptureView: View {
                 .textFieldStyle(.roundedBorder)
                 .focused($entryFocused)
                 .accessibilityIdentifier("quick-capture-entry-field")
-                .onSubmit(createContact)
+                .onSubmit(submitPrimaryAction)
 
             QuickCapturePreview(draft: draft)
             QuickCaptureWarnings(warnings: draft.parseWarnings)
+            if let match {
+                QuickCaptureMatchView(match: match)
+            }
 
             HStack {
                 if let createdMessage {
@@ -47,22 +60,40 @@ struct QuickCaptureView: View {
                     dismiss()
                 }
                 .accessibilityIdentifier("quick-capture-done-button")
-                Button("Create", action: createContact)
-                    .buttonStyle(.glassProminent)
-                    .disabled(draft.isEmpty)
-                    .accessibilityIdentifier("quick-capture-create-button")
+                if match != nil {
+                    Button("Create New", action: createContact)
+                        .disabled(draft.isEmpty)
+                        .accessibilityIdentifier("quick-capture-create-button")
+                    Button("Update Existing", action: updateExistingContact)
+                        .buttonStyle(.glassProminent)
+                        .disabled(draft.isEmpty)
+                        .accessibilityIdentifier("quick-capture-update-existing-button")
+                } else {
+                    Button("Create", action: createContact)
+                        .buttonStyle(.glassProminent)
+                        .disabled(draft.isEmpty)
+                        .accessibilityIdentifier("quick-capture-create-button")
+                }
             }
         }
         .padding(20)
-        .frame(minWidth: 420, idealWidth: 520, minHeight: 180)
+        .frame(minWidth: 420, idealWidth: 520, minHeight: 210)
         .onAppear { entryFocused = true }
-        .alert("Couldn't Create Contact", isPresented: Binding(
+        .alert("Couldn't Save Contact", isPresented: Binding(
             get: { errorMessage != nil },
             set: { if !$0 { errorMessage = nil } }
         )) {
             Button("OK", role: .cancel) {}
         } message: {
             Text(errorMessage ?? "")
+        }
+    }
+
+    private func submitPrimaryAction() {
+        if canUpdateWithReturn {
+            updateExistingContact()
+        } else {
+            createContact()
         }
     }
 
@@ -79,6 +110,26 @@ struct QuickCaptureView: View {
                 )
             }
             createdMessage = "Created \(contact.fullName)"
+            entry = ""
+            entryFocused = true
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func updateExistingContact() {
+        let parsed = draft
+        guard !parsed.isEmpty, let match else { return }
+        do {
+            try store.updateContact(match.contact, from: parsed)
+            if let encoded = match.contact.persistentModelID.storedString {
+                NotificationCenter.default.post(
+                    name: .openContactRequested,
+                    object: nil,
+                    userInfo: ["id": encoded]
+                )
+            }
+            createdMessage = "Updated \(match.contact.fullName)"
             entry = ""
             entryFocused = true
         } catch {
@@ -204,6 +255,36 @@ private struct QuickCapturePreviewRow: View {
         }
         .accessibilityLabel(item.title)
         .accessibilityIdentifier(item.accessibilityIdentifier)
+    }
+}
+
+private struct QuickCaptureMatchView: View {
+    var match: QuickCaptureMatch
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "person.crop.circle.badge.exclamationmark")
+                .foregroundStyle(.orange)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(match.confidence.title)
+                    .font(.caption.weight(.semibold))
+                    .accessibilityIdentifier("quick-capture-match-confidence")
+                Text(match.contact.fullName)
+                    .font(.subheadline)
+                    .lineLimit(1)
+                    .accessibilityIdentifier("quick-capture-match-name")
+                Text(match.reason)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("quick-capture-match-reason")
+            }
+        }
+        .padding(.vertical, 2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(match.confidence.title), \(match.contact.fullName), \(match.reason)")
+        .accessibilityIdentifier("quick-capture-match-row")
     }
 }
 

--- a/ContactManagerTests/QuickCaptureTests.swift
+++ b/ContactManagerTests/QuickCaptureTests.swift
@@ -119,6 +119,56 @@ struct QuickCaptureTests {
         ])
     }
 
+    @Test func duplicateMatchFindsExactEmail() {
+        let ada = Contact(firstName: "Ada", lastName: "Lovelace")
+        ada.fields = [
+            ContactField(kind: .email, label: .home, value: "ada@example.com"),
+        ]
+        let draft = QuickCaptureParser.parse("Ada Byron, ADA@example.com")
+
+        let match = QuickCaptureMatcher.bestMatch(for: draft, in: [ada])
+
+        #expect(match?.contact === ada)
+        #expect(match?.confidence == .likely)
+        #expect(match?.reason == "same email")
+    }
+
+    @Test func duplicateMatchFindsExactPhone() {
+        let ada = Contact(firstName: "Ada", lastName: "Lovelace")
+        ada.fields = [
+            ContactField(kind: .phone, label: .mobile, value: "(555) 010-1000"),
+        ]
+        let draft = QuickCaptureParser.parse("Ada Byron, phone 5550101000")
+
+        let match = QuickCaptureMatcher.bestMatch(for: draft, in: [ada])
+
+        #expect(match?.contact === ada)
+        #expect(match?.confidence == .likely)
+        #expect(match?.reason == "same phone")
+    }
+
+    @Test func duplicateMatchFindsPartialName() {
+        let ada = Contact(firstName: "Ada", lastName: "Lovelace")
+        let alan = Contact(firstName: "Alan", lastName: "Turing")
+        let draft = QuickCaptureParser.parse("Ada")
+
+        let match = QuickCaptureMatcher.bestMatch(for: draft, in: [alan, ada])
+
+        #expect(match?.contact === ada)
+        #expect(match?.confidence == .possible)
+        #expect(match?.reason == "similar name")
+    }
+
+    @Test func duplicateMatchIgnoresUnrelatedContacts() {
+        let alan = Contact(firstName: "Alan", lastName: "Turing")
+        alan.fields = [
+            ContactField(kind: .email, label: .home, value: "alan@example.com"),
+        ]
+        let draft = QuickCaptureParser.parse("Grace Hopper, grace@example.com")
+
+        #expect(QuickCaptureMatcher.bestMatch(for: draft, in: [alan]) == nil)
+    }
+
     @Test func parsesNumericBirthdayWithYear() throws {
         let draft = QuickCaptureParser.parse("Katherine Johnson, birthday 1918-08-26")
 
@@ -194,5 +244,26 @@ struct QuickCaptureTests {
         #expect(contact.tags.map(\.displayName) == ["VIP"])
         #expect(try context.fetchCount(FetchDescriptor<ContactGroup>()) == 1)
         #expect(try context.fetchCount(FetchDescriptor<ContactTag>()) == 1)
+    }
+
+    @Test func updateContactFromQuickCaptureDraftAddsMissingData() throws {
+        let contact = Contact(firstName: "Ada", lastName: "Lovelace")
+        contact.fields = [
+            ContactField(kind: .email, label: .home, value: "ada@example.com"),
+        ]
+        context.insert(contact)
+        try context.save()
+
+        let draft = QuickCaptureParser.parse(
+            "Ada Lovelace, ada@example.com, work ada@analytical.example, phone 555-0101, tag VIP"
+        )
+
+        try store.updateContact(contact, from: draft)
+
+        #expect(contact.emails.map(\.value) == ["ada@example.com", "ada@analytical.example"])
+        #expect(contact.phones.map(\.value) == ["555-0101"])
+        #expect(contact.tags.map(\.displayName) == ["VIP"])
+        #expect(try context.fetchCount(FetchDescriptor<Contact>()) == 1)
+        #expect(try context.fetchCount(FetchDescriptor<ContactField>()) == 3)
     }
 }

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -185,6 +185,38 @@ final class ContactManagerUITests: XCTestCase {
         )
     }
 
+    /// Verifies Quick Capture warns before creating an obvious duplicate and
+    /// can update the existing contact instead.
+    func test_quickCaptureShowsDuplicateMatchAndUpdatesExisting() {
+        let app = bootSeededApp()
+        app.typeKey("n", modifierFlags: [.command, .option])
+
+        let entry = app.textFields["quick-capture-entry-field"]
+        XCTAssertTrue(entry.waitForExistence(timeout: 3))
+        entry.click()
+        entry.typeText("Ada Lovelace, ada@analytical.engine, mobile 555-0200, tag VIP")
+
+        let matchRow = app.descendants(matching: .any)["quick-capture-match-row"]
+        XCTAssertTrue(
+            matchRow.waitForExistence(timeout: 3),
+            "Quick capture should show a duplicate match before saving"
+        )
+        let matchText = [matchRow.label, matchRow.value as? String ?? ""]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        XCTAssertTrue(matchText.contains("Ada Lovelace"), "Match row text was: \(matchText)")
+        XCTAssertTrue(matchText.contains("same email"), "Match row text was: \(matchText)")
+
+        let update = app.buttons["quick-capture-update-existing-button"]
+        XCTAssertTrue(update.waitForExistence(timeout: 3))
+        update.click()
+
+        XCTAssertTrue(
+            app.staticTexts["Updated Ada Lovelace"].waitForExistence(timeout: 3),
+            "Quick capture should confirm the existing contact was updated"
+        )
+    }
+
     /// Verifies the quick-capture preview renders all parsed detail kinds
     /// before saving, so users can trust what the one-line parser understood.
     func test_quickCapturePreviewShowsParsedDetails() {


### PR DESCRIPTION
## Summary
Adds duplicate awareness to Quick Capture so obvious matches are surfaced before saving and users can update an existing contact instead of creating a duplicate.

## Changes
- Added a QuickCaptureMatcher that reuses the normalized duplicate/import match keys.
- Added ContactStore.updateContact(from:) for Quick Capture updates through the durable mutate/save/rollback/notification pipeline.
- Updated QuickCaptureView to show match confidence/reason, offer Create New vs Update Existing, and only auto-update on Return for strong email/phone matches.
- Added an explicit accessibility label for the duplicate match card.
- Added unit coverage for email, phone, name-only, unrelated, and update-existing behavior.
- Added UI smoke coverage for the duplicate warning/update flow.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - make check
  - xcodebuild test -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO -only-testing:ContactManagerUITests/ContactManagerUITests/test_quickCaptureShowsDuplicateMatchAndUpdatesExisting
  - make test

## Screenshots (if applicable)
N/A

## Related Issues
Closes #