### PR TITLE
feat(import): polish review controls

### DIFF
--- a/ContactManager/Models/ImportReview.swift
+++ b/ContactManager/Models/ImportReview.swift
@@ -70,6 +70,46 @@ struct ImportReviewItem: Identifiable {
     }
 }
 
+struct ImportReviewPendingSummary {
+    var add = 0
+    var merge = 0
+    var updateExisting = 0
+    var skip = 0
+
+    init(items: [ImportReviewItem]) {
+        for item in items {
+            switch item.decision {
+            case .add: add += 1
+            case .merge: merge += 1
+            case .updateExisting: updateExisting += 1
+            case .skip: skip += 1
+            }
+        }
+    }
+
+    var totalToWrite: Int {
+        add + merge + updateExisting
+    }
+
+    var reviewText: String {
+        let parts = [
+            formatted("Add", count: add),
+            formatted("Merge", count: merge),
+            formatted("Update Existing", count: updateExisting),
+            formatted("Skip", count: skip),
+        ].compactMap { $0 }
+        return parts.isEmpty ? "No contacts to review" : parts.joined(separator: ", ")
+    }
+
+    var importButtonTitle: String {
+        totalToWrite == 1 ? "Import 1 Contact" : "Import \(totalToWrite) Contacts"
+    }
+
+    private func formatted(_ label: String, count: Int) -> String? {
+        count == 0 ? nil : "\(label) \(count)"
+    }
+}
+
 enum ImportReview {
     static func makeItems(for parsed: [ParsedContact], existing contacts: [Contact]) -> [ImportReviewItem] {
         parsed.map { parsedContact in
@@ -90,6 +130,12 @@ enum ImportReview {
                 confidence: confidence(for: decision, sharedKeys: match.sharedKeys),
                 matchReason: reason(for: match.sharedKeys)
             )
+        }
+    }
+
+    static func apply(_ decision: ImportDecision, to items: inout [ImportReviewItem]) {
+        for index in items.indices where items[index].availableDecisions.contains(decision) {
+            items[index].decision = decision
         }
     }
 

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -64,6 +64,7 @@ struct ContentView: View {
     @State var isReviewingImport = false
     @State var importSummary: ImportReviewResult?
     @State var restoreSummary: BackupRestoreResult?
+    @State private var didPresentUITestImportReview = false
 
     var store: ContactStore { ContactStore(context) }
 
@@ -149,6 +150,7 @@ struct ContentView: View {
             }
             .onAppear {
                 context.undoManager = undoManager
+                presentUITestImportReviewIfNeeded()
             }
             .onChange(of: undoManager) { _, new in
                 context.undoManager = new
@@ -284,6 +286,21 @@ struct ContentView: View {
 /// the SwiftUI type-checker (and the type-body length) happy. Same-file, so
 /// these still see ContentView's private state.
 private extension ContentView {
+    func presentUITestImportReviewIfNeeded() {
+        guard !didPresentUITestImportReview,
+              ProcessInfo.processInfo.environment["CONTACTMANAGER_UI_TEST_MODE"] != nil,
+              ProcessInfo.processInfo.environment["CONTACTMANAGER_UI_TEST_IMPORT_REVIEW"] != nil
+        else { return }
+
+        didPresentUITestImportReview = true
+        var ada = ParsedContact(firstName: "Ada", lastName: "Lovelace")
+        ada.emails = [(.work, "ada@analytical.engine")]
+        ada.phones = [(.mobile, "555-0200")]
+        let katherine = ParsedContact(firstName: "Katherine", lastName: "Johnson")
+        importReviewItems = ImportReview.makeItems(for: [ada, katherine], existing: contacts)
+        isReviewingImport = true
+    }
+
     /// Menu-command observers (New, imports/exports, Find Duplicates, Print/PDF,
     /// Spotlight open, and the incremental re-index on every mutation).
     func handlingMenuCommands(_ content: some View) -> some View {

--- a/ContactManager/Views/ImportReviewView.swift
+++ b/ContactManager/Views/ImportReviewView.swift
@@ -13,15 +13,21 @@ struct ImportReviewView: View {
     @Binding var items: [ImportReviewItem]
     var importAction: ([ImportReviewItem]) -> Void
 
-    private var importCount: Int {
-        items.filter { $0.decision != .skip }.count
+    private var summary: ImportReviewPendingSummary {
+        ImportReviewPendingSummary(items: items)
     }
 
     var body: some View {
         NavigationStack {
-            List {
-                ForEach($items) { $item in
-                    ImportReviewRow(item: $item)
+            VStack(spacing: 0) {
+                reviewSummary
+                    .padding(.horizontal)
+                    .padding(.vertical, 10)
+                Divider()
+                List {
+                    ForEach($items) { $item in
+                        ImportReviewRow(item: $item)
+                    }
                 }
             }
             .navigationTitle("Review Import")
@@ -35,7 +41,7 @@ struct ImportReviewView: View {
                         dismiss()
                         importAction(reviewed)
                     }
-                    .disabled(importCount == 0)
+                    .disabled(summary.totalToWrite == 0)
                     .accessibilityIdentifier("confirm-reviewed-import-button")
                 }
             }
@@ -43,8 +49,41 @@ struct ImportReviewView: View {
         .frame(minWidth: 560, minHeight: 420)
     }
 
+    private var reviewSummary: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(summary.reviewText)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .accessibilityLabel(summary.reviewText)
+                    .accessibilityIdentifier("import-review-summary")
+                Text(parsedContactCountText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("import-review-total-count")
+            }
+            Spacer()
+            Menu {
+                ForEach(ImportDecision.allCases) { decision in
+                    Button("Set All to \(decision.title)") {
+                        ImportReview.apply(decision, to: &items)
+                    }
+                    .disabled(!items.contains { $0.availableDecisions.contains(decision) })
+                    .accessibilityIdentifier("import-review-batch-\(decision.rawValue)")
+                }
+            } label: {
+                Label("Batch Actions", systemImage: "checklist")
+            }
+            .accessibilityIdentifier("import-review-batch-menu")
+        }
+    }
+
     private var importButtonTitle: String {
-        importCount == 1 ? "Import 1 Contact" : "Import \(importCount) Contacts"
+        summary.importButtonTitle
+    }
+
+    private var parsedContactCountText: String {
+        items.count == 1 ? "1 parsed contact" : "\(items.count) parsed contacts"
     }
 }
 
@@ -52,7 +91,7 @@ private struct ImportReviewRow: View {
     @Binding var item: ImportReviewItem
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             VStack(alignment: .leading, spacing: 3) {
                 Text(item.displayName)
                     .font(.headline)
@@ -73,18 +112,51 @@ private struct ImportReviewRow: View {
                 }
             }
             Spacer()
-            Picker("Import Action", selection: $item.decision) {
-                ForEach(item.availableDecisions) { decision in
-                    Text(decision.title).tag(decision)
+            VStack(alignment: .trailing, spacing: 6) {
+                matchBadge
+                Picker("Import Action", selection: $item.decision) {
+                    ForEach(item.availableDecisions) { decision in
+                        Text(decision.title).tag(decision)
+                    }
                 }
+                .labelsHidden()
+                .frame(width: 160)
+                .accessibilityIdentifier("import-review-action-picker")
             }
-            .labelsHidden()
-            .frame(width: 160)
-            .accessibilityIdentifier("import-review-action-picker")
         }
         .padding(.vertical, 4)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("import-review-row-\(item.displayName.normalizedIdentifier)")
+    }
+
+    private var matchBadge: some View {
+        Label(badgeTitle, systemImage: badgeImage)
+            .font(.caption.weight(.medium))
+            .foregroundStyle(badgeColor)
+            .lineLimit(1)
+            .accessibilityIdentifier("import-review-confidence-badge")
+    }
+
+    private var badgeTitle: String {
+        item.confidence?.title ?? "New"
+    }
+
+    private var badgeImage: String {
+        switch item.confidence {
+        case .exact: "checkmark.seal"
+        case .likely: "person.crop.circle.badge.checkmark"
+        case .possible: "questionmark.circle"
+        case nil: "plus.circle"
+        }
+    }
+
+    private var badgeColor: Color {
+        switch item.confidence {
+        case .exact: .green
+        case .likely: .blue
+        case .possible: .orange
+        case nil: .secondary
+        }
     }
 
     private func matchDescription(_ matched: Contact) -> String {

--- a/ContactManagerTests/ImportReviewTests.swift
+++ b/ContactManagerTests/ImportReviewTests.swift
@@ -153,4 +153,53 @@ struct ImportReviewTests {
         #expect(result.skipped == 4)
         #expect(result.totalWritten == 4)
     }
+
+    @Test func pendingSummaryCountsDecisionsAndFormatsThemForReview() throws {
+        let existing = try store.createContact()
+        existing.firstName = "Ada"
+        existing.lastName = "Lovelace"
+        try store.addField(.email, value: "ada@example.com", to: existing)
+        try context.save()
+
+        var matchedParsed = ParsedContact(firstName: "Ada", lastName: "Lovelace", company: "Analytical Engine Co.")
+        matchedParsed.emails = [(.home, "ada@example.com")]
+        let newParsed = ParsedContact(firstName: "Katherine", lastName: "Johnson")
+
+        var items = ImportReview.makeItems(for: [matchedParsed, newParsed], existing: [existing])
+        items[0].decision = .updateExisting
+        items[1].decision = .skip
+
+        let summary = ImportReviewPendingSummary(items: items)
+
+        #expect(summary.add == 0)
+        #expect(summary.updateExisting == 1)
+        #expect(summary.merge == 0)
+        #expect(summary.skip == 1)
+        #expect(summary.totalToWrite == 1)
+        #expect(summary.reviewText == "Update Existing 1, Skip 1")
+        #expect(summary.importButtonTitle == "Import 1 Contact")
+    }
+
+    @Test func applyingBatchDecisionOnlyChangesEligibleRows() throws {
+        let existing = try store.createContact()
+        existing.firstName = "Ada"
+        existing.lastName = "Lovelace"
+        try store.addField(.email, value: "ada@example.com", to: existing)
+        try context.save()
+
+        var matchedParsed = ParsedContact(firstName: "Ada", lastName: "Lovelace", company: "Analytical Engine Co.")
+        matchedParsed.emails = [(.home, "ada@example.com")]
+        let newParsed = ParsedContact(firstName: "Katherine", lastName: "Johnson")
+
+        var items = ImportReview.makeItems(for: [matchedParsed, newParsed], existing: [existing])
+
+        ImportReview.apply(.merge, to: &items)
+
+        #expect(items[0].decision == .merge)
+        #expect(items[1].decision == .add)
+
+        ImportReview.apply(.skip, to: &items)
+
+        #expect(items.map(\.decision) == [.skip, .skip])
+    }
 }

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -164,6 +164,41 @@ final class ContactManagerUITests: XCTestCase {
         )
     }
 
+    /// Verifies the import-review sheet exposes the high-signal review
+    /// affordances before writing anything: summary, batch actions, confidence,
+    /// row action picker, and disabled/enabled import confirmation.
+    func test_importReviewPolishControlsRender() {
+        app = XCUIApplication()
+        app.launchEnvironment["CONTACTMANAGER_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CONTACTMANAGER_UI_TEST_IMPORT_REVIEW"] = "1"
+        app.launchArguments = ["-ApplePersistenceIgnoreState", "YES"]
+        app.launch()
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        let summary = app.descendants(matching: .any)["import-review-summary"]
+        XCTAssertTrue(summary.waitForExistence(timeout: 3))
+        let summaryText = [
+            summary.label,
+            summary.value as? String ?? "",
+        ]
+        .filter { !$0.isEmpty }
+        .joined(separator: " ")
+        XCTAssertTrue(summaryText.contains("Add 1"), "Summary text was: \(summaryText)")
+        XCTAssertTrue(summaryText.contains("Update Existing 1"), "Summary text was: \(summaryText)")
+
+        XCTAssertTrue(app.menuButtons["import-review-batch-menu"].waitForExistence(timeout: 3))
+        XCTAssertTrue(
+            app.descendants(matching: .any)["import-review-confidence-badge"].waitForExistence(timeout: 3)
+        )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["import-review-row-ada-lovelace"].waitForExistence(timeout: 3)
+        )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["import-review-action-picker"].waitForExistence(timeout: 3)
+        )
+        XCTAssertTrue(app.buttons["confirm-reviewed-import-button"].isEnabled)
+    }
+
     /// Verifies the quick-capture command opens a focused capture window and
     /// creates a searchable contact from natural text.
     func test_quickCaptureCreatesSearchableContact() {


### PR DESCRIPTION
## Summary
Polishes the import review sheet so review-before-import feels more actionable and testable.

## Changes
- Added pending import summary counts and dynamic import button text.
- Added batch decision actions that only apply to eligible rows.
- Added confidence/new badges beside each reviewed contact.
- Added a gated UI-test launch hook for deterministic import-review smoke coverage.
- Added Swift Testing coverage for summary counts and batch decisions, plus an XCUITest smoke test for the review controls.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps: `make check`; `make test`
- [x] code-review subagent: No actionable findings.

## Screenshots (if applicable)
N/A

## Related Issues
Closes #