### PR TITLE
test(backup): stabilize encrypted backup assertion

### DIFF
--- a/ContactManagerTests/ContactBackupTests.swift
+++ b/ContactManagerTests/ContactBackupTests.swift
@@ -164,13 +164,23 @@ struct ContactBackupTests {
             exportedAt: Date(timeIntervalSinceReferenceDate: 42)
         )
 
+        let plaintext = try ContactBackupDocument.encode(backup)
         let data = try EncryptedContactBackupDocument.encode(backup, password: "correct horse battery staple")
+        let envelope = try JSONDecoder().decode(EncryptedBackupEnvelopeSnapshot.self, from: data)
         let decoded = try EncryptedContactBackupDocument.decode(data, password: "correct horse battery staple")
 
         #expect(EncryptedContactBackupDocument.isEncrypted(data))
-        #expect(!data.contains(Data("Ada".utf8)))
+        #expect(data != plaintext)
+        #expect(envelope.magic == "ContactManagerEncryptedBackup")
+        #expect(envelope.version == 1)
+        #expect(envelope.algorithm == "AES.GCM")
+        #expect(envelope.kdf == "PBKDF2-HMAC-SHA256")
+        #expect(envelope.iterations == 210_000)
+        #expect(envelope.salt.count == 16)
+        #expect(envelope.sealedData.count == plaintext.count + 28)
+        #expect(envelope.sealedData != plaintext)
         #expect(decoded == backup)
-        #expect(try ContactBackupDocument.decode(ContactBackupDocument.encode(backup)) == backup)
+        #expect(try ContactBackupDocument.decode(plaintext) == backup)
     }
 
     @Test func encryptedBackupDocumentRejectsWrongPassword() throws {
@@ -270,4 +280,14 @@ struct ContactBackupTests {
         )
         return contact
     }
+}
+
+private struct EncryptedBackupEnvelopeSnapshot: Decodable {
+    var magic: String
+    var version: Int
+    var algorithm: String
+    var kdf: String
+    var iterations: Int
+    var salt: Data
+    var sealedData: Data
 }


### PR DESCRIPTION
## Summary
Stabilizes encrypted backup test coverage by removing a probabilistic ciphertext substring assertion.

## Changes
- Replaced the random `"Ada"` byte search against the encrypted JSON document.
- Decode the encrypted backup envelope in the test and verify metadata, salt size, sealed payload shape, and plaintext/encrypted byte differences deterministically.
- Keep existing round-trip and plaintext backup decode checks.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps: `xcodebuild test -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:ContactManagerTests/ContactBackupTests`; `make check`; `xcodebuild test -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:ContactManagerUITests/ContactManagerUITests/test_quickCaptureCreatesSearchableContact`
- [x] Full `make test` ran: unit tests passed and 10/11 UI tests passed; `test_quickCaptureCreatesSearchableContact` hit the known app activation/shortcut timing flake, then passed on targeted rerun.
- [x] code-review subagent: No actionable findings.

## Screenshots (if applicable)
N/A

## Related Issues
Closes #