### PR TITLE
feat(ui): polish contact list and detail

### DIFF
--- a/ContactManager/Views/ContactDetailView+QuickInfo.swift
+++ b/ContactManager/Views/ContactDetailView+QuickInfo.swift
@@ -9,6 +9,82 @@ import AppKit
 import SwiftUI
 
 extension ContactDetailView {
+    var identityHeader: some View {
+        HStack(alignment: .center, spacing: 16) {
+            photoWell
+            VStack(alignment: .leading, spacing: 6) {
+                Text(contact.fullName)
+                    .font(.title2.weight(.semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                    .accessibilityAddTraits(.isHeader)
+                if let role = contact.roleLine {
+                    Text(role)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                if let primaryLine = contact.primaryReachabilityLine {
+                    Label(primaryLine, systemImage: "person.text.rectangle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 8)
+        .accessibilityIdentifier("contact-detail-identity-header")
+    }
+
+    var summaryChipRow: some View {
+        HStack(spacing: 8) {
+            ForEach(summaryChips, id: \.self) { chip in
+                Text(chip)
+                    .font(.caption.weight(.medium))
+                    .lineLimit(1)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 4)
+                    .background(.secondary.opacity(0.12), in: Capsule())
+            }
+            Spacer(minLength: 0)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(summaryChips.joined(separator: ", "))
+        .accessibilityIdentifier("contact-detail-summary-chips")
+    }
+
+    var primaryActionRow: some View {
+        HStack(spacing: 8) {
+            if let email = contact.primaryEmail, let url = ContactLink.mailto(email) {
+                Link(destination: url) {
+                    Label("Email", systemImage: "envelope")
+                }
+                .buttonStyle(.borderless)
+                .help("Send Email")
+            }
+            if let phone = contact.primaryPhone, let url = ContactLink.tel(phone) {
+                Link(destination: url) {
+                    Label("Call", systemImage: "phone")
+                }
+                .buttonStyle(.borderless)
+                .help("Call")
+            }
+            Button {
+                markContacted(contact)
+            } label: {
+                Label("Mark Contacted", systemImage: "checkmark.circle")
+            }
+            .buttonStyle(.borderless)
+            .help("Mark Contacted Today")
+        }
+        .labelStyle(.titleAndIcon)
+        .controlSize(.small)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("contact-detail-primary-actions")
+    }
+
     func quickRow(kind: FieldKind, value: String) -> some View {
         let label = kind == .email ? "Email" : "Phone"
         return HStack {
@@ -53,5 +129,36 @@ extension ContactDetailView {
     private func copyToPasteboard(_ value: String) {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(value, forType: .string)
+    }
+
+    var summaryChips: [String] {
+        var chips: [String] = []
+        let contact = contact
+        if !contact.emails.isEmpty {
+            chips.append("\(contact.emails.count) email\(contact.emails.count == 1 ? "" : "s")")
+        }
+        if !contact.phones.isEmpty {
+            chips.append("\(contact.phones.count) phone\(contact.phones.count == 1 ? "" : "s")")
+        }
+        if !contact.groups.isEmpty {
+            chips.append("\(contact.groups.count) group\(contact.groups.count == 1 ? "" : "s")")
+        }
+        if !contact.tags.isEmpty {
+            chips.append("\(contact.tags.count) tag\(contact.tags.count == 1 ? "" : "s")")
+        }
+        if contact.lastContactedAt == nil { chips.append("Needs follow-up") }
+        if contact.birthday != nil { chips.append("Birthday saved") }
+        return chips
+    }
+}
+
+extension Contact {
+    var primaryReachabilityLine: String? {
+        switch (primaryEmail, primaryPhone) {
+        case (.some(let email), .some(let phone)): "\(email) · \(phone)"
+        case (.some(let email), .none): email
+        case (.none, .some(let phone)): phone
+        case (.none, .none): nil
+        }
     }
 }

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -40,7 +40,13 @@ struct ContactDetailView: View {
 
     var body: some View {
         Form {
-            Section { identityHeader }
+            Section {
+                identityHeader
+                if !summaryChips.isEmpty {
+                    summaryChipRow
+                }
+                primaryActionRow
+            }
 
             quickInfoSection
 
@@ -194,26 +200,8 @@ struct ContactDetailView: View {
         }
     }
 
-    // MARK: - Identity header
-
-    private var identityHeader: some View {
-        HStack(spacing: 16) {
-            photoWell
-            VStack(alignment: .leading, spacing: 2) {
-                Text(contact.fullName)
-                    .font(.title2.weight(.semibold))
-                    .accessibilityAddTraits(.isHeader)
-                if let role = contact.roleLine {
-                    Text(role).foregroundStyle(.secondary)
-                }
-            }
-            Spacer()
-        }
-        .padding(.vertical, 4)
-    }
-
     /// Tappable avatar offering Choose / Remove Photo.
-    private var photoWell: some View {
+    var photoWell: some View {
         Menu {
             Button("Choose Photo…") { isImportingPhoto = true }
             if contact.photoData != nil {
@@ -384,5 +372,6 @@ struct ContactPlaceholderView: View {
             systemImage: "person.crop.circle",
             description: Text("Select a contact to view and edit their details.")
         )
+        .accessibilityIdentifier("contact-placeholder")
     }
 }

--- a/ContactManager/Views/ContactListView.swift
+++ b/ContactManager/Views/ContactListView.swift
@@ -210,7 +210,9 @@ struct ContactListView: View {
 
 private extension Contact {
     var accessibilityRowIdentifier: String {
-        "contact-row-\((persistentModelID.storedString ?? fullName).normalizedIdentifier)"
+        let name = fullName.normalizedIdentifier
+        let persistentToken = persistentModelID.storedString ?? String(describing: persistentModelID)
+        return "contact-row-\(name)-\(persistentToken.stableIdentifierHash)"
     }
 }
 
@@ -220,28 +222,67 @@ private extension String {
             .map { $0.isLetter || $0.isNumber ? String($0) : "-" }
             .joined()
     }
+
+    var stableIdentifierHash: String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 1_099_511_628_211
+        }
+        return String(hash, radix: 16)
+    }
 }
 
 struct ContactRow: View {
     let contact: Contact
 
     var body: some View {
-        HStack(spacing: 10) {
-            AvatarView(contact: contact, size: 30)
-            VStack(alignment: .leading, spacing: 1) {
+        HStack(alignment: .top, spacing: 10) {
+            AvatarView(contact: contact, size: 36)
+                .padding(.top, 1)
+            VStack(alignment: .leading, spacing: 3) {
                 Text(contact.fullName)
+                    .font(.body.weight(.medium))
                     .lineLimit(1)
-                if let subtitle = contact.subtitle {
-                    Text(subtitle)
+                    .accessibilityIdentifier("contact-row-title-\(displayIdentifier)")
+                if let role = contact.roleLine {
+                    Text(role)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                        .accessibilityIdentifier("contact-row-role-\(displayIdentifier)")
+                }
+                if let metaLine = contact.listMetaLine {
+                    Text(metaLine)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .accessibilityIdentifier("contact-row-meta-\(displayIdentifier)")
                 }
             }
+            Spacer(minLength: 0)
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, 4)
         // Read the row as a single VoiceOver element ("John Smith, name@example.com")
         // rather than three (avatar + name + subtitle).
         .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("contact-row-summary-\(displayIdentifier)")
+    }
+
+    private var displayIdentifier: String {
+        contact.fullName.normalizedIdentifier
+    }
+}
+
+private extension Contact {
+    var listMetaLine: String? {
+        let values = [primaryEmail, primaryPhone]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        if !values.isEmpty { return values.joined(separator: " · ") }
+
+        let trimmedCompany = company.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedCompany.isEmpty ? nil : trimmedCompany
     }
 }

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -54,8 +54,16 @@ final class ContactManagerUITests: XCTestCase {
             app.descendants(matching: .any)["sidebar-sync-status"].waitForExistence(timeout: 3),
             "Sidebar sync status should render"
         )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["contact-placeholder"].waitForExistence(timeout: 3),
+            "No-selection placeholder should render before a contact is selected"
+        )
         app.typeKey("n", modifierFlags: .command)
         XCTAssertTrue(app.textFields["contact-first-name-field"].waitForExistence(timeout: 3))
+        XCTAssertTrue(
+            app.descendants(matching: .any)["contact-detail-identity-header"].waitForExistence(timeout: 3),
+            "Detail identity header should render for a selected contact"
+        )
         XCTAssertTrue(
             app.menuButtons["batch-actions-menu"].waitForExistence(timeout: 3),
             "Batch actions menu should render"
@@ -129,6 +137,46 @@ final class ContactManagerUITests: XCTestCase {
         XCTAssertTrue(
             app.staticTexts["Test Person"].waitForExistence(timeout: 3),
             "Newly edited contact should be searchable in the list"
+        )
+    }
+
+    /// Verifies the polished list/detail anchors render against seeded data:
+    /// richer rows, a stronger no-selection placeholder, and the detail
+    /// identity/action cluster.
+    func test_contactListAndDetailPolishAnchorsRender() {
+        let app = bootSeededApp()
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["contact-placeholder"].waitForExistence(timeout: 3),
+            "No-selection placeholder should have a stable accessibility anchor"
+        )
+        let adaRow = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier BEGINSWITH %@", "contact-row-ada-lovelace-"))
+            .firstMatch
+        XCTAssertTrue(
+            adaRow.waitForExistence(timeout: 3),
+            "Ada row should render with a stable accessibility anchor"
+        )
+        let adaRowText = [adaRow.label, adaRow.value as? String ?? ""]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        XCTAssertTrue(adaRowText.contains("Ada Lovelace"), "Ada row text was: \(adaRowText)")
+        XCTAssertTrue(adaRowText.contains("Mathematician"), "Ada row text was: \(adaRowText)")
+        XCTAssertTrue(adaRowText.contains("ada@analytical.engine"), "Ada row text was: \(adaRowText)")
+
+        adaRow.click()
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["contact-detail-identity-header"].waitForExistence(timeout: 3),
+            "Selected contact should show the polished identity header"
+        )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["contact-detail-summary-chips"].waitForExistence(timeout: 3),
+            "Selected contact should show compact summary chips"
+        )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["contact-detail-primary-actions"].waitForExistence(timeout: 3),
+            "Selected contact should show primary action controls"
         )
     }
 


### PR DESCRIPTION
## Summary
Polishes the core contact browsing flow so the list and detail views show richer contact context before the user starts editing.

## Changes
- Add a stronger detail identity header with primary reachability, summary chips, and first-class Email, Call, and Mark Contacted actions.
- Enrich contact list rows with role and primary reachability metadata.
- Keep list row accessibility identifiers duplicate-safe by appending a deterministic persistent-id hash.
- Add stable UI anchors for the no-selection placeholder and polished detail sections.
- Extend UI smoke coverage for seeded contact list/detail rendering.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - make check
  - xcodebuild test -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO -only-testing:ContactManagerUITests/ContactManagerUITests/test_contactListAndDetailPolishAnchorsRender
  - xcodebuild test -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO -only-testing:ContactManagerUITests
  - code-review subagent returned No actionable findings.

## Screenshots (if applicable)
N/A

## Related Issues
Closes #