### PR TITLE
feat(ui): improve detail editor ergonomics

### DIFF
--- a/ContactManager.xcodeproj/project.pbxproj
+++ b/ContactManager.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		C2A11D686722C70868435ACE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303A7F66E428BF3662142C0 /* SidebarView.swift */; };
 		C2EA90DF3685BA76CCFA2C7E /* ContactTagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BEACB78914327E09F4DA17E /* ContactTagTests.swift */; };
 		C378A683EF56824504C580F9 /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D505A1E75ACB938A488465 /* CommandPaletteView.swift */; };
+		CA7CF4FB7522F0FDBDCE1185 /* ContactDetailView+Fields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56304352F8C447675D9558B4 /* ContactDetailView+Fields.swift */; };
 		CB3B48ECF52D91DC9B4789D7 /* ContactStore+Batch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C169D757A0DE2A58EEC0A32B /* ContactStore+Batch.swift */; };
 		CD70772ECD6A854C66159FFD /* OpenContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B27494A51645ACA6BED8EA8 /* OpenContactIntent.swift */; };
 		CE55AD882E6631A9541B6106 /* ContactsBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2489676BE6C77E41DDC56F60 /* ContactsBridge.swift */; };
@@ -190,6 +191,7 @@
 		54C373BD237429970D6A7C86 /* DuplicatesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DuplicatesView.swift; sourceTree = "<group>"; };
 		54F228309258FF5B6F85FA05 /* ContactStoreBatchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactStoreBatchTests.swift; sourceTree = "<group>"; };
 		5588D3AA3B4B31F1094D954F /* ImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageProcessingTests.swift; sourceTree = "<group>"; };
+		56304352F8C447675D9558B4 /* ContactDetailView+Fields.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Fields.swift"; sourceTree = "<group>"; };
 		570F825494F8D293928784C7 /* ContactDetailView+Birthday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContactDetailView+Birthday.swift"; sourceTree = "<group>"; };
 		58AFEE833481781C252FE8A5 /* ContactStore+SavedSmartLists.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ContactStore+SavedSmartLists.swift"; path = "Models/ContactStore+SavedSmartLists.swift"; sourceTree = "<group>"; };
 		5951D4D8D52B6CDB782FE37D /* QuickCaptureView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickCaptureView.swift; path = ContactManager/Views/QuickCaptureView.swift; sourceTree = "<group>"; };
@@ -411,6 +413,7 @@
 				40FA55EA1466B6711EE517B4 /* BackupPasswordPromptView.swift */,
 				CC0B4A31EACECB0C22183364 /* ContentView+Groups.swift */,
 				1E0C70519C31EA3869BCECA9 /* ContentView+Tags.swift */,
+				56304352F8C447675D9558B4 /* ContactDetailView+Fields.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -716,6 +719,7 @@
 				49951835ECDD188314B2D263 /* ContentView+Groups.swift in Sources */,
 				0DDC7707A54114378AB0E1E0 /* ContentView+Tags.swift in Sources */,
 				EBB44EB6D2563E1407989522 /* QuickCaptureMatcher.swift in Sources */,
+				CA7CF4FB7522F0FDBDCE1185 /* ContactDetailView+Fields.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContactManager/Views/ContactDetailView+Fields.swift
+++ b/ContactManager/Views/ContactDetailView+Fields.swift
@@ -1,0 +1,59 @@
+//
+//  ContactDetailView+Fields.swift
+//  ContactManager
+//
+//  Repeatable email/phone editor sections for ContactDetailView.
+//
+
+import SwiftUI
+
+extension ContactDetailView {
+    // MARK: - Repeatable field sections
+
+    func fieldSection(_ title: String, kind: FieldKind, fields: [ContactField]) -> some View {
+        Section(title) {
+            if fields.isEmpty {
+                emptyDetailHint(
+                    "No \(title.lowercased()) saved",
+                    systemImage: kind == .email ? "envelope" : "phone"
+                )
+                .accessibilityIdentifier("contact-empty-\(kind.rawValue)-hint")
+            }
+
+            ForEach(fields) { field in
+                ContactFieldRow(field: field, focusedFieldID: $focusedFieldID)
+            }
+            .onDelete { offsets in
+                delete(offsets, from: fields)
+            }
+
+            Button {
+                addField(kind: kind)
+            } label: {
+                Label("Add \(title)", systemImage: "plus.circle.fill")
+                    .foregroundStyle(.green)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("contact-add-\(kind.rawValue)-button")
+        }
+    }
+
+    // MARK: - Field actions
+
+    func addField(kind: FieldKind) {
+        do {
+            let field = try store.addField(kind, to: contact)
+            focusedFieldID = field.persistentModelID
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func delete(_ offsets: IndexSet, from fields: [ContactField]) {
+        do {
+            try store.delete(offsets.map { fields[$0] })
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -28,6 +28,7 @@ struct ContactDetailView: View {
     // Not private: the photo handlers in ContactDetailView+Photo.swift read them.
     @State var errorMessage: String?
     @FocusState private var nameFieldFocused: Bool
+    @FocusState var focusedFieldID: PersistentIdentifier?
     @State var lastSavedFingerprint = ""
     @State var interactionKind: ContactInteractionKind = .note
     @State var interactionSummary = ""
@@ -88,6 +89,10 @@ struct ContactDetailView: View {
             fieldSection("Phone", kind: .phone, fields: contact.phones)
 
             Section("Address") {
+                if contact.addressLines.isEmpty {
+                    emptyDetailHint("No address saved", systemImage: "mappin.and.ellipse")
+                        .accessibilityIdentifier("contact-address-empty-hint")
+                }
                 TextField("Street", text: $contact.street)
                     .accessibilityIdentifier("contact-street-field")
                 TextField("City", text: $contact.city)
@@ -144,6 +149,10 @@ struct ContactDetailView: View {
             }
 
             Section("Notes") {
+                if contact.notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    emptyDetailHint("No notes saved", systemImage: "note.text")
+                        .accessibilityIdentifier("contact-notes-empty-hint")
+                }
                 TextField("Notes", text: $contact.notes, axis: .vertical)
                     .lineLimit(3 ... 10)
                     .accessibilityIdentifier("contact-notes-field")
@@ -250,43 +259,11 @@ struct ContactDetailView: View {
         }
     }
 
-    // MARK: - Repeatable field sections
-
-    private func fieldSection(_ title: String, kind: FieldKind, fields: [ContactField]) -> some View {
-        Section(title) {
-            ForEach(fields) { field in
-                ContactFieldRow(field: field)
-            }
-            .onDelete { offsets in
-                delete(offsets, from: fields)
-            }
-
-            Button {
-                addField(kind: kind)
-            } label: {
-                Label("Add \(title)", systemImage: "plus.circle.fill")
-                    .foregroundStyle(.green)
-            }
-            .buttonStyle(.plain)
-        }
-    }
-
-    // MARK: - Field actions
-
-    private func addField(kind: FieldKind) {
-        do {
-            try store.addField(kind, to: contact)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    private func delete(_ offsets: IndexSet, from fields: [ContactField]) {
-        do {
-            try store.delete(offsets.map { fields[$0] })
-        } catch {
-            errorMessage = error.localizedDescription
-        }
+    func emptyDetailHint(_ text: String, systemImage: String) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .labelStyle(.titleAndIcon)
     }
 }
 

--- a/ContactManager/Views/ContactFieldRow.swift
+++ b/ContactManager/Views/ContactFieldRow.swift
@@ -5,20 +5,22 @@
 //  A single editable email/phone row.
 //
 
+import SwiftData
 import SwiftUI
 
 struct ContactFieldRow: View {
     @Bindable var field: ContactField
+    var focusedFieldID: FocusState<PersistentIdentifier?>.Binding
 
     var body: some View {
-        HStack {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
             Picker("", selection: $field.label) {
                 ForEach(FieldLabel.allCases) { label in
                     Text(label.title).tag(label)
                 }
             }
             .labelsHidden()
-            .fixedSize()
+            .frame(width: 92, alignment: .leading)
             .accessibilityLabel(field.kind == .email ? "Email label" : "Phone label")
             .accessibilityIdentifier(
                 field.kind == .email ? "contact-email-label-picker" : "contact-phone-label-picker"
@@ -26,6 +28,7 @@ struct ContactFieldRow: View {
 
             TextField(placeholder, text: $field.value)
                 .textContentType(field.kind == .email ? .emailAddress : .telephoneNumber)
+                .focused(focusedFieldID, equals: field.persistentModelID)
                 .accessibilityLabel(field.kind == .email ? "Email address" : "Phone number")
                 .accessibilityIdentifier(
                     field.kind == .email ? "contact-email-value-field" : "contact-phone-value-field"

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -140,6 +140,51 @@ final class ContactManagerUITests: XCTestCase {
         )
     }
 
+    /// Verifies a blank contact editor has clear empty states and direct add
+    /// affordances for the fields users commonly fill in first.
+    func test_blankContactEditorShowsErgonomicAddAffordances() {
+        let app = bootSeededApp()
+        app.typeKey("n", modifierFlags: .command)
+
+        XCTAssertTrue(app.textFields["contact-first-name-field"].waitForExistence(timeout: 3))
+        XCTAssertTrue(
+            app.descendants(matching: .any)["contact-empty-email-hint"].waitForExistence(timeout: 3),
+            "Blank contact should explain that no email is saved yet"
+        )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["contact-empty-phone-hint"].waitForExistence(timeout: 3),
+            "Blank contact should explain that no phone is saved yet"
+        )
+        XCTAssertTrue(
+            app.buttons["contact-add-email-button"].waitForExistence(timeout: 3),
+            "Blank contact should expose an anchored add-email action"
+        )
+        XCTAssertTrue(
+            app.buttons["contact-add-phone-button"].waitForExistence(timeout: 3),
+            "Blank contact should expose an anchored add-phone action"
+        )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["contact-address-empty-hint"].waitForExistence(timeout: 3),
+            "Blank contact should summarize the empty address section"
+        )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["contact-notes-empty-hint"].waitForExistence(timeout: 3),
+            "Blank contact should summarize the empty notes section"
+        )
+
+        app.buttons["contact-add-email-button"].click()
+        XCTAssertTrue(
+            app.textFields["contact-email-value-field"].waitForExistence(timeout: 3),
+            "Adding an email should reveal an editable email value field"
+        )
+        app.buttons["contact-add-email-button"].click()
+        XCTAssertGreaterThanOrEqual(
+            app.textFields.matching(identifier: "contact-email-value-field").count,
+            2,
+            "Adding a second email should create another editable email value field"
+        )
+    }
+
     /// Verifies the polished list/detail anchors render against seeded data:
     /// richer rows, a stronger no-selection placeholder, and the detail
     /// identity/action cluster.


### PR DESCRIPTION
## Summary
Improves the blank contact detail editor so new contacts feel ready to fill in instead of sparse.

## Changes
- Add empty-state hints for blank email, phone, address, and notes sections.
- Add stable add-email and add-phone accessibility anchors.
- Focus newly added email and phone value fields by concrete SwiftData field identity.
- Give repeatable field rows a steadier label/value layout.
- Split repeatable field section code into ContactDetailView+Fields.swift and register it with the app target.
- Add UI smoke coverage for blank-contact editor affordances and adding multiple email rows.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - TDD failing run first: test_blankContactEditorShowsErgonomicAddAffordances failed on missing contact-empty-email-hint before implementation
  - xcodebuild test -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO -only-testing:ContactManagerUITests/ContactManagerUITests/test_blankContactEditorShowsErgonomicAddAffordances
  - make check
  - xcodebuild test -project ContactManager.xcodeproj -scheme ContactManager -destination platform=macOS CODE_SIGNING_ALLOWED=NO -only-testing:ContactManagerUITests
  - code-review subagent returned No actionable findings.

## Screenshots (if applicable)
N/A

## Related Issues
Closes #