### PR TITLE
feat(command-palette): add contact actions

### DIFF
--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -20,7 +20,9 @@ struct ContactDetailView: View {
     /// Set for a just-created contact so the form opens with the cursor in
     /// First Name; the view clears it via `onNameFieldFocused` after focusing.
     var focusNameField = false
+    var focusFieldID: PersistentIdentifier?
     var onNameFieldFocused: () -> Void = {}
+    var onFieldFocused: () -> Void = {}
     var markContacted: (Contact) -> Void = { _ in }
     @Query(sort: \ContactGroup.name) private var allGroups: [ContactGroup]
     @Query(sort: \ContactTag.name) private var allTags: [ContactTag]
@@ -165,6 +167,7 @@ struct ContactDetailView: View {
         .onAppear {
             lastSavedFingerprint = editFingerprint
             if focusNameField { nameFieldFocused = true }
+            if let focusFieldID { focusedFieldID = focusFieldID }
         }
         .task(id: editFingerprint) {
             guard editFingerprint != lastSavedFingerprint else { return }
@@ -182,6 +185,15 @@ struct ContactDetailView: View {
         // so a missed/late focus application isn't dropped without a retry.
         .onChange(of: nameFieldFocused) { _, focused in
             if focused { onNameFieldFocused() }
+        }
+        .onChange(of: focusFieldID) { _, newValue in
+            guard let newValue else { return }
+            focusedFieldID = newValue
+        }
+        .onChange(of: focusedFieldID) { _, newValue in
+            if let newValue, newValue == focusFieldID {
+                onFieldFocused()
+            }
         }
         .toolbar {
             ToolbarItem {

--- a/ContactManager/Views/ContentView+CommandPalette.swift
+++ b/ContactManager/Views/ContentView+CommandPalette.swift
@@ -34,7 +34,7 @@ extension ContentView {
     }
 
     private var coreCommandPaletteEntries: [CommandPaletteAction] {
-        [
+        var entries = [
             command(
                 id: "new-contact",
                 title: "New Contact",
@@ -69,6 +69,14 @@ extension ContentView {
             ) {
                 NotificationCenter.default.post(name: .focusSearchRequested, object: nil)
             },
+            command(
+                id: "save-search",
+                title: "Save Search",
+                subtitle: "Save the current contact search",
+                keywords: ["smart list", "filter"],
+                systemImage: "line.3.horizontal.decrease.circle",
+                action: saveCurrentSearchAsSmartList
+            ),
             command(
                 id: "find-duplicates",
                 title: "Find Duplicates",
@@ -149,6 +157,12 @@ extension ContentView {
                 action: openSettings
             ),
         ]
+
+        if searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            entries.removeAll { $0.id == "save-search" }
+        }
+
+        return entries
     }
 
     private var navigationCommandPaletteEntries: [CommandPaletteAction] {
@@ -250,6 +264,56 @@ extension ContentView {
                 },
                 at: 0
             )
+            entries.insert(
+                command(
+                    id: "selected-add-phone",
+                    title: "Add Phone",
+                    subtitle: selectedContact.fullName,
+                    keywords: ["field", "number", "editor"],
+                    systemImage: "phone.badge.plus"
+                ) {
+                    addField(.phone, to: selectedContact)
+                },
+                at: 1
+            )
+            entries.insert(
+                command(
+                    id: "selected-add-email",
+                    title: "Add Email",
+                    subtitle: selectedContact.fullName,
+                    keywords: ["field", "mail", "editor"],
+                    systemImage: "envelope.badge"
+                ) {
+                    addField(.email, to: selectedContact)
+                },
+                at: 1
+            )
+            if let email = selectedContact.primaryEmail {
+                entries.append(
+                    command(
+                        id: "selected-copy-email",
+                        title: "Copy Email",
+                        subtitle: email,
+                        keywords: ["clipboard", "mail"],
+                        systemImage: "doc.on.doc"
+                    ) {
+                        copyToPasteboard(email)
+                    }
+                )
+            }
+            if let phone = selectedContact.primaryPhone {
+                entries.append(
+                    command(
+                        id: "selected-copy-phone",
+                        title: "Copy Phone",
+                        subtitle: phone,
+                        keywords: ["clipboard", "number"],
+                        systemImage: "doc.on.doc"
+                    ) {
+                        copyToPasteboard(phone)
+                    }
+                )
+            }
             entries.append(
                 command(
                     id: "selected-export-pdf",
@@ -300,5 +364,21 @@ extension ContentView {
 
     private func openSettings() {
         NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+    }
+
+    private func addField(_ kind: FieldKind, to contact: Contact) {
+        do {
+            let field = try store.addField(kind, to: contact)
+            selectedContact = contact
+            selectedContactIDs = [contact.persistentModelID]
+            contactPendingFieldFocus = field.persistentModelID
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func copyToPasteboard(_ value: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
     }
 }

--- a/ContactManager/Views/ContentView.swift
+++ b/ContactManager/Views/ContentView.swift
@@ -30,6 +30,7 @@ struct ContentView: View {
     @State var selectedContact: Contact?
     @State var selectedContactIDs: Set<PersistentIdentifier> = []
     @State private var contactPendingNameFocus: PersistentIdentifier?
+    @State var contactPendingFieldFocus: PersistentIdentifier?
     @State var errorMessage: String?
     @State var isConfirmingBatchDelete = false
     @State var isShowingCommandPalette = false
@@ -207,7 +208,9 @@ struct ContentView: View {
                     ContactDetailView(
                         contact: selectedContact,
                         focusNameField: selectedContact.persistentModelID == contactPendingNameFocus,
+                        focusFieldID: contactPendingFieldFocus,
                         onNameFieldFocused: { contactPendingNameFocus = nil },
+                        onFieldFocused: { contactPendingFieldFocus = nil },
                         markContacted: markContacted
                     )
                     .id(selectedContact.persistentModelID)

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -185,6 +185,58 @@ final class ContactManagerUITests: XCTestCase {
         )
     }
 
+    /// Verifies the command palette can perform contact-specific editor
+    /// actions, not just navigate to existing screens.
+    func test_commandPaletteAddsEmailToSelectedContact() {
+        let app = bootSeededApp()
+        app.typeKey("n", modifierFlags: .command)
+        XCTAssertTrue(app.textFields["contact-first-name-field"].waitForExistence(timeout: 3))
+
+        app.typeKey("k", modifierFlags: .command)
+        let paletteSearch = app.textFields["command-palette-search-field"]
+        XCTAssertTrue(paletteSearch.waitForExistence(timeout: 3))
+        paletteSearch.typeText("add email")
+
+        let addEmail = app.buttons["command-palette-row-selected-add-email"]
+        XCTAssertTrue(
+            addEmail.waitForExistence(timeout: 3),
+            "Selected-contact Add Email command should render in the palette"
+        )
+        addEmail.click()
+
+        XCTAssertTrue(
+            app.textFields["contact-email-value-field"].waitForExistence(timeout: 3),
+            "Palette Add Email should reveal an editable email value field"
+        )
+    }
+
+    /// Verifies a non-empty list search can be saved directly from the command
+    /// palette, matching the toolbar affordance.
+    func test_commandPaletteSavesCurrentSearch() {
+        let app = bootSeededApp()
+        app.typeKey("f", modifierFlags: .command)
+        let search = app.searchFields.firstMatch
+        XCTAssertTrue(search.waitForExistence(timeout: 3))
+        search.typeText("Ada")
+
+        app.typeKey("k", modifierFlags: .command)
+        let paletteSearch = app.textFields["command-palette-search-field"]
+        XCTAssertTrue(paletteSearch.waitForExistence(timeout: 3))
+        paletteSearch.typeText("save search")
+
+        let saveSearch = app.buttons["command-palette-row-save-search"]
+        XCTAssertTrue(
+            saveSearch.waitForExistence(timeout: 3),
+            "Save Search command should render when the current search is non-empty"
+        )
+        saveSearch.click()
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["sidebar-saved-smart-list-row-ada"].waitForExistence(timeout: 3),
+            "Palette Save Search should create and select a saved smart list"
+        )
+    }
+
     /// Verifies the polished list/detail anchors render against seeded data:
     /// richer rows, a stronger no-selection placeholder, and the detail
     /// identity/action cluster.


### PR DESCRIPTION
## Summary
Adds more keyboard-first contact actions to the command palette so users can keep working without leaving the palette.

## Changes
- Added a Save Search command that appears when the current contact search is non-empty.
- Added selected-contact Add Email and Add Phone commands that route through ContactStore and focus the newly-added field.
- Added selected-contact Copy Email and Copy Phone commands.
- Added UI smoke coverage for palette-driven Add Email and Save Search flows.
- Ran the repo-local code-review subagent before PR creation: No actionable findings.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps:
  - TDD failing UI run first for missing command-palette-row-selected-add-email.
  - make check
  - xcodebuild test -project ContactManager.xcodeproj -scheme ContactManager -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:ContactManagerUITests

## Screenshots (if applicable)
Not applicable.

## Related Issues
Closes #
