### PR TITLE
feat(ui): polish freeform editors

### DIFF
--- a/ContactManager/Views/ContactDetailView+History.swift
+++ b/ContactManager/Views/ContactDetailView+History.swift
@@ -10,26 +10,33 @@ import SwiftUI
 extension ContactDetailView {
     var historySection: some View {
         Section("History") {
-            Picker("Kind", selection: $interactionKind) {
-                ForEach(ContactInteractionKind.allCases) { kind in
-                    Label(kind.title, systemImage: kind.systemImage)
-                        .tag(kind)
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 10) {
+                    Picker("Kind", selection: $interactionKind) {
+                        ForEach(ContactInteractionKind.allCases) { kind in
+                            Label(kind.title, systemImage: kind.systemImage)
+                                .tag(kind)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .frame(width: 180, alignment: .leading)
+                    .accessibilityIdentifier("interaction-kind-picker")
+
+                    Button {
+                        addInteraction()
+                    } label: {
+                        Label("Add to History", systemImage: "plus.circle.fill")
+                    }
+                    .disabled(interactionSummary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .accessibilityIdentifier("add-interaction-button")
                 }
-            }
-            .pickerStyle(.menu)
-            .accessibilityIdentifier("interaction-kind-picker")
 
-            TextField("Add a note", text: $interactionSummary, axis: .vertical)
-                .lineLimit(2 ... 4)
-                .accessibilityIdentifier("interaction-summary-field")
-
-            Button {
-                addInteraction()
-            } label: {
-                Label("Add to History", systemImage: "plus.circle.fill")
+                freeformEditor(
+                    text: $interactionSummary,
+                    configuration: .historyNote(systemImage: interactionKind.systemImage)
+                )
             }
-            .disabled(interactionSummary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-            .accessibilityIdentifier("add-interaction-button")
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             ForEach(contact.sortedInteractions.prefix(5)) { interaction in
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -55,5 +62,74 @@ extension ContactDetailView {
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+
+    func freeformEditor(text: Binding<String>, configuration: FreeformEditorConfiguration) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Label(configuration.title, systemImage: configuration.systemImage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            ZStack(alignment: .topLeading) {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(.background)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(.quaternary, lineWidth: 1)
+                    )
+                    .accessibilityHidden(true)
+
+                TextEditor(text: text)
+                    .font(.body)
+                    .scrollContentBackground(.hidden)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 5)
+                    .frame(height: configuration.height)
+                    .accessibilityLabel(configuration.title)
+                    .accessibilityIdentifier(configuration.fieldIdentifier)
+
+                if text.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text(configuration.placeholder)
+                        .foregroundStyle(.tertiary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 12)
+                        .allowsHitTesting(false)
+                }
+            }
+            .frame(maxWidth: 460, minHeight: configuration.height, maxHeight: configuration.height)
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier(configuration.containerIdentifier)
+        }
+        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct FreeformEditorConfiguration {
+    var title: String
+    var systemImage: String
+    var placeholder: String
+    var height: CGFloat
+    var containerIdentifier: String
+    var fieldIdentifier: String
+
+    static let notes = FreeformEditorConfiguration(
+        title: "Notes",
+        systemImage: "note.text",
+        placeholder: "Add context, preferences, or anything worth remembering",
+        height: 92,
+        containerIdentifier: "contact-notes-editor",
+        fieldIdentifier: "contact-notes-field"
+    )
+
+    static func historyNote(systemImage: String) -> FreeformEditorConfiguration {
+        FreeformEditorConfiguration(
+            title: "History Note",
+            systemImage: systemImage,
+            placeholder: "Add a quick note about this interaction",
+            height: 74,
+            containerIdentifier: "interaction-summary-editor",
+            fieldIdentifier: "interaction-summary-field"
+        )
     }
 }

--- a/ContactManager/Views/ContactDetailView.swift
+++ b/ContactManager/Views/ContactDetailView.swift
@@ -155,9 +155,7 @@ struct ContactDetailView: View {
                     emptyDetailHint("No notes saved", systemImage: "note.text")
                         .accessibilityIdentifier("contact-notes-empty-hint")
                 }
-                TextField("Notes", text: $contact.notes, axis: .vertical)
-                    .lineLimit(3 ... 10)
-                    .accessibilityIdentifier("contact-notes-field")
+                freeformEditor(text: $contact.notes, configuration: .notes)
             }
         }
         .formStyle(.grouped)

--- a/ContactManagerUITests/ContactManagerUITests.swift
+++ b/ContactManagerUITests/ContactManagerUITests.swift
@@ -309,6 +309,28 @@ final class ContactManagerUITests: XCTestCase {
         )
     }
 
+    /// Verifies free-form editors render as contained surfaces instead of
+    /// oversized fields that can sprawl across or escape the detail content.
+    func test_freeformEditorsStayContainedInDetailPane() {
+        let app = bootSeededApp()
+        app.typeKey("n", modifierFlags: .command)
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 3))
+
+        let historyEditor = app.descendants(matching: .any)
+            .matching(identifier: "interaction-summary-editor")
+            .firstMatch
+        XCTAssertTrue(historyEditor.waitForExistence(timeout: 3))
+        assertContainedEditor(historyEditor, in: window)
+
+        let notesEditor = app.descendants(matching: .any)
+            .matching(identifier: "contact-notes-editor")
+            .firstMatch
+        XCTAssertTrue(notesEditor.waitForExistence(timeout: 3))
+        assertContainedEditor(notesEditor, in: window)
+    }
+
     /// Verifies the import-review sheet exposes the high-signal review
     /// affordances before writing anything: summary, batch actions, confidence,
     /// row action picker, and disabled/enabled import confirmation.
@@ -477,6 +499,35 @@ final class ContactManagerUITests: XCTestCase {
             "Main window didn't appear within 10s"
         )
         return app
+    }
+
+    private func assertContainedEditor(
+        _ editor: XCUIElement,
+        in window: XCUIElement,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertLessThanOrEqual(
+            editor.frame.width,
+            window.frame.width * 0.72,
+            "Free-form editor should stay visually contained",
+            file: file,
+            line: line
+        )
+        XCTAssertGreaterThanOrEqual(
+            editor.frame.height,
+            60,
+            "Free-form editor should remain large enough to type comfortably",
+            file: file,
+            line: line
+        )
+        XCTAssertLessThanOrEqual(
+            editor.frame.height,
+            120,
+            "Free-form editor should not grow tall enough to push form content around",
+            file: file,
+            line: line
+        )
     }
 
     private func openQuickCapture(


### PR DESCRIPTION
## Summary
Polishes the free-form text editing surfaces in the contact detail pane so notes and history entries feel contained instead of stretching across the whole form.

## Changes
- Replace the growing vertical Notes and History text fields with fixed-height contained TextEditor surfaces.
- Keep existing field accessibility identifiers and add container anchors for UI regression coverage.
- Label the editable TextEditor surfaces directly and hide the decorative editor chrome from accessibility.
- Add a UI smoke regression that asserts the free-form editors stay visually bounded.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps: Initial focused UI test failed before implementation; focused UI regression passed after implementation and accessibility fix; full UI suite passed: 17 tests, 0 failures; make check passed: 231 tests in 30 suites.
- [x] code-review subagent: No actionable findings.

## Screenshots (if applicable)
N/A

## Related Issues
Closes #